### PR TITLE
LAYOUT-1613 - Merge v4.6.1 fixes back into UXHelper

### DIFF
--- a/Sources/RoktUXHelper/UI/Components/Common/View+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/View+Extension.swift
@@ -43,7 +43,7 @@ extension View {
     }
     
     func readSize(weightProperties: WeightModifier.Properties? = nil,
-                  onChange: @escaping (CGSize, Alignment) -> Void) -> some View {
+                  onChange: @escaping (CGSizeWithMax, Alignment) -> Void) -> some View {
         background(
             GeometryReader { geometryProxy in
                 Color.clear
@@ -51,18 +51,18 @@ extension View {
             }
         )
         .onPreferenceChange(SizePreferenceKey.self) { value in
-            var newSize = CGSize(width: value.width, height: value.height)
+            var newSizeWithMax = CGSizeWithMax(size: CGSize(width: value.width, height: value.height))
             var alignment = Alignment.center // SwiftUI default frame alignment
             
             if let weightProperties {
                 let weight = WeightModifier(props: weightProperties)
-                newSize.height = weight.frameMaxHeight ?? newSize.height
-                newSize.width = weight.frameMaxWidth ?? newSize.width
+                newSizeWithMax.maxWidth = weight.frameMaxWidth
+                newSizeWithMax.maxHeight = weight.frameMaxHeight
                 alignment = weight.alignment
             }
             
             DispatchQueue.main.async {
-                onChange(newSize, alignment)
+                onChange(newSizeWithMax, alignment)
             }
         }
     }
@@ -124,4 +124,11 @@ extension View {
 private struct SizePreferenceKey: PreferenceKey {
     static var defaultValue: CGSize = .zero
     static func reduce(value: inout CGSize, nextValue: () -> CGSize) {}
+}
+
+@available(iOS 15, *)
+struct CGSizeWithMax {
+    let size: CGSize
+    var maxWidth: CGFloat?
+    var maxHeight: CGFloat?
 }

--- a/Sources/RoktUXHelper/UI/Components/ScrollableColumnComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/ScrollableColumnComponent.swift
@@ -24,7 +24,8 @@ struct ScrollableColumnComponent: View {
     @Binding var styleState: StyleState
     @State private var availableWidth: CGFloat?
     @State private var availableHeight: CGFloat?
-    @State private var contentSize: CGFloat = .zero
+    @State private var contentHeight: CGFloat? = nil
+    @State private var contentMaxHeight: CGFloat? = nil
     @State private var contentAlignment: Alignment = .center // SwiftUI default frame alignment
         
     var style: ColumnStyle? {
@@ -82,11 +83,16 @@ struct ScrollableColumnComponent: View {
                             parentHeight: $parentHeight,
                             styleState: $styleState,
                             parentOverride: parentOverride)
-            .readSize(weightProperties: weightProperties) { newSize, alignment in
-                contentSize = newSize.height
-                contentAlignment = alignment
+            .readSize(weightProperties: weightProperties) { newSizeWithMax, newAlignment in
+                if let newMaxHeight = newSizeWithMax.maxHeight {
+                    contentMaxHeight = newMaxHeight
+                } else {
+                    contentHeight = newSizeWithMax.size.height
+                }
+                contentAlignment = newAlignment
             }
         }
-        .frame(height: contentSize, alignment: contentAlignment)
+        .ifLet(contentMaxHeight) { $0.frame(maxHeight: $1, alignment: contentAlignment) }
+        .ifLet(contentHeight) { $0.frame(height: $1, alignment: contentAlignment) }
     }
 }

--- a/Sources/RoktUXHelper/UI/Components/ScrollableRowComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/ScrollableRowComponent.swift
@@ -24,7 +24,7 @@ struct ScrollableRowComponent: View {
     @Binding var styleState: StyleState
     @State private var availableWidth: CGFloat?
     @State private var availableHeight: CGFloat?
-    @State private var contentSize: CGFloat = .zero
+    @State private var contentMaxWidth: CGFloat = .zero
     @State private var contentAlignment: Alignment = .center // SwiftUI default frame alignment
         
     var style: RowStyle? {
@@ -82,12 +82,12 @@ struct ScrollableRowComponent: View {
                          parentHeight: $parentHeight,
                          styleState: $styleState,
                          parentOverride: parentOverride)
-            .readSize(weightProperties: weightProperties) { newSize, alignment in
-                contentSize = newSize.width
-                contentAlignment = alignment
+            .readSize(weightProperties: weightProperties) { newSizeWithMax, newAlignment  in
+                contentMaxWidth = newSizeWithMax.maxWidth ?? newSizeWithMax.size.width
+                contentAlignment = newAlignment
             }
         }
-        .frame(maxWidth: contentSize, alignment: contentAlignment)
+        .frame(maxWidth: contentMaxWidth, alignment: contentAlignment)
     }
     
 }


### PR DESCRIPTION
### Background ###

Merging back a fix we made in v4.6.1 to mitigate the "invalid frame dimension" error on ScrollableColumn into UXHelper. Setting frame `height` with value `.infinity` was triggering a "invalid frame dimension" error.

Fixes [LAYOUT=1613](https://rokt.atlassian.net/browse/LAYOUT-1613)

### What Has Changed: ###

ScrollableColumn conditionally sets either maxHeight or height.

### How Has This Been Tested? ###

Tested layout with ScrollableColumn with weight no longer shows invalid frame dimension error.

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.