### PR TITLE
NI-327 - layout constraint warnings

### DIFF
--- a/Example/Example/SampleViewController.swift
+++ b/Example/Example/SampleViewController.swift
@@ -64,10 +64,11 @@ class SampleViewController: UIViewController {
         roktView.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
-            roktView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 100),
+            roktView.topAnchor.constraint(greaterThanOrEqualTo: view.topAnchor),
             roktView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             roktView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            roktView.bottomAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor)
+            roktView.bottomAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor),
+            roktView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
         ])
     }
 }

--- a/Sources/RoktUXHelper/UI/RoktLayoutUIView.swift
+++ b/Sources/RoktUXHelper/UI/RoktLayoutUIView.swift
@@ -29,6 +29,13 @@ import SwiftUI
     private var onPlatformEvent: (([String: Any]) -> Void)?
     private var onEmbeddedSizeChange: ((CGFloat) -> Void)?
     private var hasLoadedLayout = false
+    private lazy var heightConstraint: NSLayoutConstraint = .init(item: self,
+                                                                  attribute: .height,
+                                                                  relatedBy: .equal,
+                                                                  toItem: nil,
+                                                                  attribute: .notAnAttribute,
+                                                                  multiplier: 1,
+                                                                  constant: 0)
 
     public override init(frame: CGRect) {
         super.init(frame: frame)
@@ -110,7 +117,8 @@ import SwiftUI
             embeddedView.topAnchor.constraint(equalTo: topAnchor),
             embeddedView.leadingAnchor.constraint(equalTo: leadingAnchor),
             embeddedView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            embeddedView.bottomAnchor.constraint(equalTo: bottomAnchor)
+            embeddedView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            heightConstraint
         ])
     }
 }
@@ -140,7 +148,7 @@ extension RoktLayoutUIView: LayoutLoader {
     /// - Parameter size: The new height for the embedded view.
     public func updateEmbeddedSize(_ size: CGFloat) {
         if roktEmbeddedSwiftUIView != nil {
-            layoutIfNeeded()
+            heightConstraint.constant = size
         }
     }
 

--- a/Sources/RoktUXHelper/UI/RoktLayoutUIView.swift
+++ b/Sources/RoktUXHelper/UI/RoktLayoutUIView.swift
@@ -20,14 +20,7 @@ import SwiftUI
 /// and optional configuration parameters such as RoktUXConfig, ImageLoader, and event handlers.
 @available(iOS 15, *)
 @objc public class RoktLayoutUIView: UIView {
-    var roktEmbeddedSwiftUIView: UIView?
-
-    var topConstaint: NSLayoutConstraint?
-    var leadingConstaint: NSLayoutConstraint?
-    var trailingConstaint: NSLayoutConstraint?
-    var heightConstaint: NSLayoutConstraint?
-    // The default is -1 as 0 is a valid state. -1 means embedded view is not loaded correctly
-    private var latestHeight: CGFloat = -1
+    private(set) var roktEmbeddedSwiftUIView: UIView?
     private var uxHelper: RoktUX?
     private var experienceResponse: String?
     private var location: String?
@@ -112,52 +105,13 @@ import SwiftUI
         )
     }
 
-    private func decideTranslatesAutoresizingMask() {
-        // translateAutoresizingMaskIntoConstraints only when view doesn't have any constraints.
-        if !self.constraints.isEmpty {
-            self.translatesAutoresizingMaskIntoConstraints = false
-        } else {
-            self.translatesAutoresizingMaskIntoConstraints = true
-        }
-    }
-
-    private func cleanupEmbeddedView() {
-        subviews.forEach({ $0.removeFromSuperview() })
-        removeEmbeddedLayoutConstraint(topConstaint)
-        removeEmbeddedLayoutConstraint(leadingConstaint)
-        removeEmbeddedLayoutConstraint(trailingConstaint)
-        removeEmbeddedLayoutConstraint(heightConstaint)
-    }
-
     private func addEmbeddedLayoutConstraints(embeddedView: UIView) {
-        topConstaint = NSLayoutConstraint(item: self, attribute: .top,
-                                          relatedBy: .equal, toItem: embeddedView,
-                                          attribute: .top, multiplier: 1, constant: 0)
-        leadingConstaint = NSLayoutConstraint(item: self, attribute: .leading,
-                                              relatedBy: .equal, toItem: embeddedView,
-                                              attribute: .leading, multiplier: 1, constant: 0)
-        trailingConstaint = NSLayoutConstraint(item: self, attribute: .trailing,
-                                               relatedBy: .equal, toItem: embeddedView,
-                                               attribute: .trailing, multiplier: 1, constant: 0)
-        heightConstaint = NSLayoutConstraint(item: self, attribute: .height,
-                                             relatedBy: .equal, toItem: nil,
-                                             attribute: .notAnAttribute, multiplier: 1, constant: 0)
-        addEmbeddedLayoutConstraint(topConstaint)
-        addEmbeddedLayoutConstraint(leadingConstaint)
-        addEmbeddedLayoutConstraint(trailingConstaint)
-        addEmbeddedLayoutConstraint(heightConstaint)
-    }
-
-    private func addEmbeddedLayoutConstraint(_ layoutConstraint: NSLayoutConstraint?) {
-        if let layoutConstraint {
-            self.addConstraint(layoutConstraint)
-        }
-    }
-
-    private func removeEmbeddedLayoutConstraint(_ layoutConstraint: NSLayoutConstraint?) {
-        if let layoutConstraint {
-            self.removeConstraint(layoutConstraint)
-        }
+        NSLayoutConstraint.activate([
+            embeddedView.topAnchor.constraint(equalTo: topAnchor),
+            embeddedView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            embeddedView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            embeddedView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
     }
 }
 
@@ -170,23 +124,15 @@ extension RoktLayoutUIView: LayoutLoader {
     ///   - injectedView: A closure returning the SwiftUI view to embed.
     public func load<Content>(onSizeChanged: @escaping ((CGFloat) -> Void),
                               injectedView: @escaping () -> Content) where Content: View {
-        cleanupEmbeddedView()
-
+        roktEmbeddedSwiftUIView?.removeFromSuperview()
         let vc = ResizableHostingController(rootView: AnyView(injectedView()))
-        let swiftuiView = vc.view!
-        self.roktEmbeddedSwiftUIView = swiftuiView
+        guard let swiftUIView = vc.view else { return }
 
+        self.roktEmbeddedSwiftUIView = swiftUIView
         parentViewControllers?.addChild(vc)
-        swiftuiView.translatesAutoresizingMaskIntoConstraints = false
-
-        decideTranslatesAutoresizingMask()
-
-        addSubview(swiftuiView)
-
-        self.frame = CGRect(x: self.frame.minX, y: self.frame.minY, width: self.frame.width, height: 0)
-
-        addEmbeddedLayoutConstraints(embeddedView: swiftuiView)
-
+        swiftUIView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(swiftUIView)
+        addEmbeddedLayoutConstraints(embeddedView: swiftUIView)
         vc.didMove(toParent: parentViewControllers)
     }
 
@@ -194,13 +140,7 @@ extension RoktLayoutUIView: LayoutLoader {
     /// - Parameter size: The new height for the embedded view.
     public func updateEmbeddedSize(_ size: CGFloat) {
         if roktEmbeddedSwiftUIView != nil {
-            for cons in self.constraints where cons.firstAttribute == NSLayoutConstraint.Attribute.height {
-                cons.constant = size
-                cons.isActive = true
-            }
-            self.frame = CGRect(x: self.frame.minX, y: self.frame.minY, width: self.frame.width, height: size)
-            roktEmbeddedSwiftUIView?.frame = CGRect(x: 0, y: 0, width: self.frame.width, height: size)
-            latestHeight = size
+            layoutIfNeeded()
         }
     }
 

--- a/Sources/RoktUXHelper/UI/RoktLayoutView/RoktLayoutView.swift
+++ b/Sources/RoktUXHelper/UI/RoktLayoutView/RoktLayoutView.swift
@@ -48,6 +48,8 @@ public struct RoktLayoutView: View {
             switch viewModel.state {
             case let .ready(view):
                 view
+                    .frame(height: viewModel.height)
+                    .frame(maxWidth: .infinity)
             case .empty:
                 EmptyView()
             }

--- a/Sources/RoktUXHelper/UI/RoktLayoutView/RoktLayoutViewModel.swift
+++ b/Sources/RoktUXHelper/UI/RoktLayoutView/RoktLayoutViewModel.swift
@@ -21,6 +21,7 @@ class RoktLayoutViewModel: ObservableObject, LayoutLoader {
         case empty
     }
     @Published var state: State = .empty
+    @Published var height: CGFloat = 0
     private let experienceResponse: String
     private let location: String
     private let config: RoktUXConfig?
@@ -68,5 +69,7 @@ extension RoktLayoutViewModel: LayoutLoader {
         state = .empty
     }
 
-    public func updateEmbeddedSize(_ size: CGFloat) {}
+    public func updateEmbeddedSize(_ size: CGFloat) {
+        height = size
+    }
 }


### PR DESCRIPTION
### Background ###

- RoktLayoutView would resize when loaded from max height to its appropriate size for a brief moment
- RoktLayoutUIView has a few layout constraint warnings
- additionally, RoktLayoutUIView had an issue with not laying out accordingly due to `decideTranslatesAutoresizingMask()` enabling `translatesAutoresizingMaskIntoConstraints` for RoktLayoutUIView which creates NSAutoresizingMaskLayoutConstraints that conflicts with the constraints we set.

| View | Before | After |
|:--------:|:-----------:|:----------:| 
| RoktLayoutView | https://github.com/user-attachments/assets/3ad5ba23-dd9f-42ad-8f5d-837a2ff0cc1b | https://github.com/user-attachments/assets/2c2060ef-4b4d-44f8-a93b-156bac913898 |
| RoktLayoutUIView | ![Screenshot 2024-11-08 at 3 32 45 PM](https://github.com/user-attachments/assets/f4cb357b-8944-483f-a92c-22693807ccae) |  |
|RoktLayoutUIView centerYAnchor Constraint | <img src="https://github.com/user-attachments/assets/8268b6a5-a1d0-432d-be03-f5965668dd8c" width=150 /> | <img src="https://github.com/user-attachments/assets/c02c28b8-d80b-4836-bc6b-7263ce7bbd6a" width=150 /> |

Further testing of RoktLayoutUIView, the red and blue rectangles have black borders that show how the RoktLayoutUIView is able to dynamically resize without affecting its neighbour.
https://github.com/user-attachments/assets/d45513dc-da23-47e8-a754-9f2d1e3c5b6c



Fixes [([issue](https://rokt.atlassian.net/browse/NI-327))]

### What Has Changed: ###

List out what has changed as a result of this PR.

### How Has This Been Tested? ###

Describe the tests that you ran to verify your changes. 

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.