### PR TITLE
NO-JIRA - CustomStateMap public to use in cache viewstate

### DIFF
--- a/Sources/RoktUXHelper/Data/Model/CustomStateMap.swift
+++ b/Sources/RoktUXHelper/Data/Model/CustomStateMap.swift
@@ -11,8 +11,6 @@
 
 import Foundation
 
-typealias CustomStateMap = [CustomStateIdentifiable: Int]
-
 extension CustomStateMap {
     mutating func toggleValueFor(_ customStateId: Any?) -> CustomStateMap {
         guard let customStateId = customStateId as? CustomStateIdentifiable else {
@@ -24,7 +22,9 @@ extension CustomStateMap {
     }
 }
 
-struct CustomStateIdentifiable: Hashable {
+public typealias CustomStateMap = [CustomStateIdentifiable: Int]
+
+public struct CustomStateIdentifiable: Hashable {
     let position: Int?
     let key: String
 }


### PR DESCRIPTION
### Background ###

Need to expose CustomStateMap as public so it can be re-used in the Rokt SDK view state (for caching).

Fixes NO-JIRA

### What Has Changed: ###

Expose CustomStateMap as public

### How Has This Been Tested? ###

Integrated in Rokt SDK view state

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.