### PR TITLE
Ni 369 i os send cart item platform events

### DIFF
--- a/Sources/RoktUXHelper/Data/Model/Event/EventType.swift
+++ b/Sources/RoktUXHelper/Data/Model/Event/EventType.swift
@@ -34,6 +34,8 @@ public enum EventType: String, Codable, CaseIterable {
     case SignalActivation
     /// Triggered when the content displays to user.
     case SignalViewed
+    /// Triggered when the user clicks catalog response button.
+    case SignalCartItemInstantPurchaseInitiated
     /// Not applicable
     case CaptureAttributes
 }

--- a/Sources/RoktUXHelper/Services/Events/EventService.swift
+++ b/Sources/RoktUXHelper/Services/Events/EventService.swift
@@ -170,6 +170,9 @@ class EventService: Hashable, EventDiagnosticServicing {
     }
     
     func cartItemInstantPurchase(catalogItem: CatalogItem) {
+        sendEvent(.SignalCartItemInstantPurchaseInitiated,
+                  parentGuid: catalogItem.instanceGuid ?? "",
+                  jwtToken: catalogItem.token ?? "")
         uxEventDelegate?.onCartItemInstantPurchase(pluginId, catalogItem: catalogItem)
     }
 

--- a/Tests/RoktUXHelperTests/UI/Components/TestCatalogResponseButtonComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestCatalogResponseButtonComponent.swift
@@ -43,11 +43,14 @@ final class TestCatalogResponseButtonComponent: XCTestCase {
 
     func test_send_ux_event() throws {
         var closeEventCalled = false
+        var signalCartItemInitiatedCalled = false
         let eventDelegate = MockUXHelper()
         let view = try TestPlaceHolder.make(
             eventHandler: { event in
                 if event.eventType == .SignalDismissal {
                     closeEventCalled = true
+                } else if event.eventType == .SignalCartItemInstantPurchaseInitiated {
+                    signalCartItemInitiatedCalled = true
                 }
             },
             eventDelegate: eventDelegate,
@@ -66,6 +69,7 @@ final class TestCatalogResponseButtonComponent: XCTestCase {
 
         XCTAssertTrue(eventDelegate.roktEvents.contains(.CartItemInstantPurchase))
         XCTAssertTrue(eventDelegate.roktEvents.contains(.PlacementClosed))
+        XCTAssertTrue(signalCartItemInitiatedCalled)
         XCTAssertTrue(closeEventCalled)
         XCTAssertNotNil(sut.layoutState)
     }


### PR DESCRIPTION
### Background ###

Need to send the `SignalCartItemInstantPurchaseInitiated` when catalog response button is pressed

Fixes [([issue](https://rokt.atlassian.net/browse/NI-369))]

### What Has Changed: ###

* SignalCartItemInstantPurchaseInitiated is supported

### How Has This Been Tested? ###

Unit test added

### Checklist: ###

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.