### PR TITLE
LAYOUT-1720 - caching view states part 1 (UXHelper)

### DIFF
--- a/Sources/RoktUXHelper/Data/Model/CustomStateMap.swift
+++ b/Sources/RoktUXHelper/Data/Model/CustomStateMap.swift
@@ -24,7 +24,7 @@ extension CustomStateMap {
 
 public typealias CustomStateMap = [CustomStateIdentifiable: Int]
 
-public struct CustomStateIdentifiable: Hashable {
+public struct CustomStateIdentifiable: Hashable, Encodable, Decodable {
     let position: Int?
     let key: String
 }

--- a/Sources/RoktUXHelper/Data/Model/CustomStateMap.swift
+++ b/Sources/RoktUXHelper/Data/Model/CustomStateMap.swift
@@ -24,7 +24,7 @@ extension CustomStateMap {
 
 public typealias CustomStateMap = [CustomStateIdentifiable: Int]
 
-public struct CustomStateIdentifiable: Hashable, Encodable, Decodable {
+public struct CustomStateIdentifiable: Hashable, Codable {
     let position: Int?
     let key: String
 }

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/PageModel.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/PageModel.swift
@@ -16,14 +16,14 @@ public struct PageModel {
     public let pageId: String?
     public let sessionId: String
     public let pageInstanceGuid: String
-    let layoutPlugins: [LayoutPlugin]?
+    public let layoutPlugins: [LayoutPlugin]?
     var startDate: Date = Date()
     var responseReceivedDate: Date = Date()
     let token: String
     let options: [SDKOption]?
 }
 
-struct LayoutPlugin {
+public struct LayoutPlugin {
     let pluginInstanceGuid: String
     let breakpoints: BreakPoint?
     let settings: LayoutSettings?
@@ -31,7 +31,7 @@ struct LayoutPlugin {
     let slots: [SlotModel]
     let targetElementSelector: String?
     let pluginConfigJWTToken: String
-    let pluginId: String?
+    public let pluginId: String?
     let pluginName: String?
 }
 

--- a/Sources/RoktUXHelper/Data/Model/RoktPluginViewState.swift
+++ b/Sources/RoktUXHelper/Data/Model/RoktPluginViewState.swift
@@ -1,0 +1,56 @@
+//
+//  RoktPluginViewState.swift
+//  Pods
+//
+//  Copyright 2020 Rokt Pte Ltd
+//
+//  Licensed under the Rokt Software Development Kit (SDK) Terms of Use
+//  Version 2.0 (the "License");
+//
+//  You may not use this file except in compliance with the License.
+//
+//  You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
+
+import Foundation
+
+@objc public class RoktPluginViewState: NSObject {
+    public let pluginId: String
+    public var offerIndex: Int
+    public var isPluginDismissed: Bool
+    public var customStateMap: CustomStateMap?
+    
+    /// Shortcut initialiser that, given a pluginId, defaults to standard, initial plugin view states
+    public convenience init(pluginId: String) {
+        self.init(pluginId: pluginId,
+                  offerIndex: 0,
+                  isPluginDismissed: false,
+                  customStateMap: nil)
+    }
+
+    public init(pluginId: String,
+                offerIndex: Int,
+                isPluginDismissed: Bool,
+                customStateMap: CustomStateMap?) {
+        self.pluginId = pluginId
+        self.offerIndex = offerIndex
+        self.isPluginDismissed = isPluginDismissed
+        self.customStateMap = customStateMap
+    }
+}
+
+@objc public class RoktPluginViewStateUpdates: NSObject {
+    public let pluginId: String
+    public let offerIndex: Int?
+    public let isPluginDismissed: Bool?
+    public let customStateMap: CustomStateMap?
+    
+    public init(pluginId: String,
+                offerIndex: Int? = nil,
+                isPluginDismissed: Bool? = nil,
+                customStateMap: CustomStateMap? = nil) {
+        self.pluginId = pluginId
+        self.offerIndex = offerIndex
+        self.isPluginDismissed = isPluginDismissed
+        self.customStateMap = customStateMap
+    }
+}

--- a/Sources/RoktUXHelper/Data/Model/RoktPluginViewState.swift
+++ b/Sources/RoktUXHelper/Data/Model/RoktPluginViewState.swift
@@ -36,6 +36,14 @@ import Foundation
         self.isPluginDismissed = isPluginDismissed
         self.customStateMap = customStateMap
     }
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let rhs = object as? RoktPluginViewState else { return false }
+
+        return (self.pluginId == rhs.pluginId &&
+                self.offerIndex == rhs.offerIndex &&
+                self.isPluginDismissed == rhs.isPluginDismissed &&
+                self.customStateMap == rhs.customStateMap)
+    }
 }
 
 @objc public class RoktPluginViewStateUpdates: NSObject {

--- a/Sources/RoktUXHelper/RoktUX.swift
+++ b/Sources/RoktUXHelper/RoktUX.swift
@@ -91,6 +91,7 @@ public class RoktUX: UXEventsDelegate {
      - Parameters:
        - startDate: The start date for the process. Default is current date.
        - experienceResponse: The response string containing the experience data.
+       - layoutPluginViewStates: Plugin view states ([RoktPluginViewState]) to be restored.
        - defaultLayoutLoader: Default loader for the layout.
        - layoutLoaders: A dictionary mapping layout element selectors to their loaders.
        - config: Configuration for the RoktUX.

--- a/Sources/RoktUXHelper/RoktUX.swift
+++ b/Sources/RoktUXHelper/RoktUX.swift
@@ -100,10 +100,12 @@ public class RoktUX: UXEventsDelegate {
        - onRoktUXEvent: Closure to handle RoktUX events.
        - onRoktPlatformEvent: Closure to handle platform events. Platform events are an essential part of integration and it has to be sent to Rokt via your backend.
             For ease of use, platformEvent is defined as [String: Any]
+       - onPluginViewStateChange: Closure to handle changes to the RoktPluginViewState.
      */
     public func loadLayout(
         startDate: Date = Date(),
         experienceResponse: String,
+        layoutPluginViewStates: [RoktPluginViewState]? = nil,
         defaultLayoutLoader: LayoutLoader? = nil,
         layoutLoaders: [String: LayoutLoader?]? = nil,
         config: RoktUXConfig? = nil,
@@ -111,7 +113,8 @@ public class RoktUX: UXEventsDelegate {
         onUnload: @escaping (() -> Void),
         onEmbeddedSizeChange: @escaping (String, CGFloat) -> Void,
         onRoktUXEvent: @escaping (RoktUXEvent) -> Void,
-        onRoktPlatformEvent: @escaping ([String: Any]) -> Void
+        onRoktPlatformEvent: @escaping ([String: Any]) -> Void,
+        onPluginViewStateChange: @escaping (RoktPluginViewStateUpdates) -> Void
     ) {
         let integrationType: HelperIntegrationType = .sdk
         let processor = EventProcessor(integrationType: integrationType, onRoktPlatformEvent: onRoktPlatformEvent)
@@ -126,9 +129,12 @@ public class RoktUX: UXEventsDelegate {
                     let layoutLoader = defaultLayoutLoader ?? layoutLoaders?
                         .first { $0.key == layoutPlugin.targetElementSelector }?
                         .value
+                    let layoutPluginViewState = try? layoutPluginViewStates?
+                        .first { viewState in viewState.pluginId == layoutPlugin.pluginId }
                     displayLayout(
                         page: layoutPage,
                         layoutPlugin: layoutPlugin,
+                        layoutPluginViewState: layoutPluginViewState,
                         startDate: startDate,
                         responseReceivedDate: layoutPage.responseReceivedDate,
                         layoutLoader: layoutLoader,
@@ -137,6 +143,7 @@ public class RoktUX: UXEventsDelegate {
                         onUnload: onUnload,
                         onEmbeddedSizeChange: onEmbeddedSizeChange,
                         onRoktUXEvent: onRoktUXEvent,
+                        onPluginViewStateChange: onPluginViewStateChange,
                         processor: processor
                     )
                 }
@@ -184,6 +191,7 @@ public class RoktUX: UXEventsDelegate {
     private func displayLayout(
         page: PageModel,
         layoutPlugin: LayoutPlugin,
+        layoutPluginViewState: RoktPluginViewState? = nil,
         startDate: Date,
         responseReceivedDate: Date,
         layoutLoader: LayoutLoader?,
@@ -192,12 +200,17 @@ public class RoktUX: UXEventsDelegate {
         onUnload: @escaping (() -> Void),
         onEmbeddedSizeChange: @escaping (String, CGFloat) -> Void,
         onRoktUXEvent: @escaping (RoktUXEvent) -> Void,
+        onPluginViewStateChange: ((RoktPluginViewStateUpdates) -> Void)? = nil,
         processor: EventProcessing
     ) {
         onRoktEvent = onRoktUXEvent
         let actionCollection = ActionCollection()
 
-        let layoutState = LayoutState(actionCollection: actionCollection, config: config)
+        let layoutState = LayoutState(actionCollection: actionCollection,
+                                      config: config,
+                                      pluginId: layoutPlugin.pluginId,
+                                      initialPluginViewState: layoutPluginViewState,
+                                      onPluginViewStateChange: onPluginViewStateChange)
 
         let eventService = EventService(
             pageId: page.pageId,
@@ -316,6 +329,13 @@ public class RoktUX: UXEventsDelegate {
                         layoutLoader?.updateEmbeddedSize(size)
                         onEmbeddedSizeChange(targetElement, size)
                     }
+                    
+                    if let isPluginDismissed = layoutState.initialPluginViewState?.isPluginDismissed,
+                       isPluginDismissed {
+                        layoutLoader.closeEmbedded()
+                        onUnload()
+                        return
+                    }
 
                     layoutLoader.load(onSizeChanged: onSizeChange,
                                       injectedView: {
@@ -331,6 +351,7 @@ public class RoktUX: UXEventsDelegate {
                     layoutState.actionCollection[.close] = { [weak layoutLoader] _ in
                         layoutLoader?.closeEmbedded()
                         onUnload()
+                        layoutState.capturePluginViewState(offerIndex: nil, dismiss: true)
                     }
                 } else {
                     eventService?.sendDiagnostics(message: kAPIExecuteErrorCode,

--- a/Sources/RoktUXHelper/RoktUX.swift
+++ b/Sources/RoktUXHelper/RoktUX.swift
@@ -130,7 +130,7 @@ public class RoktUX: UXEventsDelegate {
                     let layoutLoader = defaultLayoutLoader ?? layoutLoaders?
                         .first { $0.key == layoutPlugin.targetElementSelector }?
                         .value
-                    let layoutPluginViewState = try? layoutPluginViewStates?
+                    let layoutPluginViewState = layoutPluginViewStates?
                         .first { viewState in viewState.pluginId == layoutPlugin.pluginId }
                     displayLayout(
                         page: layoutPage,

--- a/Sources/RoktUXHelper/Services/LayoutState.swift
+++ b/Sources/RoktUXHelper/Services/LayoutState.swift
@@ -53,9 +53,30 @@ class LayoutState: LayoutStateRepresenting {
         config?.imageLoader
     }
 
-    init(actionCollection: ActionCollecting = ActionCollection(), config: RoktUXConfig? = nil) {
+    public let initialPluginViewState: RoktPluginViewState?
+    private let pluginId: String?
+    private let onPluginViewStateChange: ((RoktPluginViewStateUpdates) -> Void)?
+
+    init(actionCollection: ActionCollecting = ActionCollection(),
+         config: RoktUXConfig? = nil,
+         pluginId: String? = nil,
+         initialPluginViewState: RoktPluginViewState? = nil,
+         onPluginViewStateChange: ((RoktPluginViewStateUpdates) -> Void)? = nil) {
         self.actionCollection = actionCollection
         self.config = config
+        self.pluginId = pluginId
+        self.initialPluginViewState = initialPluginViewState
+        self.onPluginViewStateChange = onPluginViewStateChange
+    }
+    
+    func capturePluginViewState(offerIndex: Int?, dismiss: Bool?) {
+        guard let pluginId else { return }
+        let currentProgress: Binding<Int>? = items[LayoutState.currentProgressKey] as? Binding<Int>
+        let customStateMap: Binding<CustomStateMap?>? = items[LayoutState.customStateMap] as? Binding<CustomStateMap?>
+        onPluginViewStateChange?(RoktPluginViewStateUpdates(pluginId: pluginId,
+                                                            offerIndex: offerIndex ?? currentProgress?.wrappedValue,
+                                                            isPluginDismissed: dismiss,
+                                                            customStateMap: customStateMap?.wrappedValue))
     }
 
     func setLayoutType(_ type: PlacementLayoutCode) {

--- a/Sources/RoktUXHelper/Services/LayoutStateRepresenting.swift
+++ b/Sources/RoktUXHelper/Services/LayoutStateRepresenting.swift
@@ -19,9 +19,11 @@ protocol LayoutStateRepresenting: Hashable, Equatable, AnyObject {
     var imageLoader: ImageLoader? { get }
     var colorMode: RoktUXConfig.ColorMode? { get }
     var config: RoktUXConfig? { get }
+    var initialPluginViewState: RoktPluginViewState? { get }
 
     func setLayoutType(_ type: PlacementLayoutCode)
     func layoutType() -> PlacementLayoutCode
     func closeOnComplete() -> Bool
     func getGlobalBreakpointIndex(_ width: CGFloat?) -> Int
+    func capturePluginViewState(offerIndex: Int?, dismiss: Bool?)
 }

--- a/Sources/RoktUXHelper/UI/Components/CarouselComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/CarouselComponent.swift
@@ -42,7 +42,7 @@ struct CarouselComponent: View {
 
     // states to track paging when we have multiple viewable items
     @State private var currentPage = 0
-    @State private var currentLeadingOffer = 0
+    @State private var currentLeadingOffer: Int
     @State private var indexWithinPage = 0
 
     @State private var carouselHeightMap: [Int: CGFloat] = [:]
@@ -87,6 +87,9 @@ struct CarouselComponent: View {
 
         self.parentOverride = parentOverride
         self.model = model
+        _currentLeadingOffer = State(wrappedValue: model.initialCurrentIndex ?? 0)
+        _customStateMap = State(wrappedValue: model.initialCustomStateMap)
+        setRecalculatedCurrentPage()
     }
 
     var verticalAlignment: VerticalAlignmentProperty {
@@ -188,11 +191,15 @@ struct CarouselComponent: View {
                 shouldFocusAccessibility = true
             }
             .onChange(of: currentLeadingOffer) { newValue in
+                model.layoutState?.capturePluginViewState(offerIndex: newValue, dismiss: false)
                 model.sendViewableImpressionEvents(viewableItems: viewableItems,
                                                    currentLeadingOffer: newValue)
                 shouldFocusAccessibility = true
                 UIAccessibility.post(notification: .announcement,
                                      argument: accessibilityAnnouncement)
+            }
+            .onChange(of: customStateMap) { _ in
+                model.layoutState?.capturePluginViewState(offerIndex: nil, dismiss: false)
             }
             .onChange(of: globalScreenSize.width) { newSize in
                 DispatchQueue.main.async {

--- a/Sources/RoktUXHelper/UI/Components/Common/UIViewController+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/UIViewController+Extension.swift
@@ -39,6 +39,12 @@ extension UIViewController {
                                           eventService: eventService,
                                           layoutState: layoutState,
                                           onUnload: onUnLoad)
+        
+        if let isPluginDismissed = layoutState.initialPluginViewState?.isPluginDismissed,
+           isPluginDismissed {
+            modal.dismiss(animated: true, completion: nil)
+            return
+        }
 
         if #available(iOS 16.0, *),
            let type = placementType,
@@ -98,6 +104,7 @@ extension UIViewController {
         modal.view.isOpaque = false
         layoutState.actionCollection[.close] = { [weak self, weak modal] _ in
             modal?.dismiss(animated: true, completion: nil)
+            layoutState.capturePluginViewState(offerIndex: nil, dismiss: true)
         }
     }
 

--- a/Sources/RoktUXHelper/UI/Components/Common/UIViewController+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/UIViewController+Extension.swift
@@ -102,9 +102,9 @@ extension UIViewController {
         }
 
         modal.view.isOpaque = false
-        layoutState.actionCollection[.close] = { [weak self, weak modal] _ in
+        layoutState.actionCollection[.close] = { [weak self, weak modal, weak layoutState] _ in
             modal?.dismiss(animated: true, completion: nil)
-            layoutState.capturePluginViewState(offerIndex: nil, dismiss: true)
+            layoutState?.capturePluginViewState(offerIndex: nil, dismiss: true)
         }
     }
 

--- a/Sources/RoktUXHelper/UI/Components/GroupedDistributionComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/GroupedDistributionComponent.swift
@@ -364,12 +364,8 @@ struct GroupedDistributionComponent: View {
     }
     
     func setRecalculatedCurrentGroup() {
-        if currentLeadingOffer + viewableItems > totalOffers - 1 {
-            // if projected to go above totalOffers, update to last page
-            currentGroup = totalPages - 1
-        } else if currentLeadingOffer >= 0,
-                  currentGroup <= totalPages - 1 {
-            currentGroup = Int(floor(Double(currentLeadingOffer/viewableItems)))
+        if currentLeadingOffer >= 0 {
+            self.currentGroup = Int(floor(Double(currentLeadingOffer+1/viewableItems)))
         }
     }
 }

--- a/Sources/RoktUXHelper/UI/Components/GroupedDistributionComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/GroupedDistributionComponent.swift
@@ -42,7 +42,7 @@ struct GroupedDistributionComponent: View {
 
     @State var currentGroup = 0
     @State private var toggleTransition = false
-    @State private var currentLeadingOffer = 0
+    @State private var currentLeadingOffer: Int
 
     @State var customStateMap: CustomStateMap?
 
@@ -74,6 +74,9 @@ struct GroupedDistributionComponent: View {
 
         self.parentOverride = parentOverride
         self.model = model
+        _currentLeadingOffer = State(wrappedValue: model.initialCurrentIndex ?? 0)
+        _customStateMap = State(wrappedValue: model.initialCustomStateMap)
+        setRecalculatedCurrentGroup()
     }
 
     var verticalAlignment: VerticalAlignmentProperty {
@@ -161,11 +164,15 @@ struct GroupedDistributionComponent: View {
                 .accessibilityFocused($shouldFocusAccessibility)
                 .accessibilityLabel(accessibilityAnnouncement)
                 .onChange(of: currentLeadingOffer) { newValue in
+                    model.layoutState?.capturePluginViewState(offerIndex: newValue, dismiss: false)
                     model.sendViewableImpressionEvents(viewableItems: viewableItems,
                                                        currentLeadingOffer: newValue)
                     shouldFocusAccessibility = true
                     UIAccessibility.post(notification: .announcement,
                                          argument: accessibilityAnnouncement)
+                }
+                .onChange(of: customStateMap) { _ in
+                    model.layoutState?.capturePluginViewState(offerIndex: nil, dismiss: false)
                 }
                 .onChange(of: globalScreenSize.width) { newSize in
                     // run it in background thread for smooth transition
@@ -353,6 +360,16 @@ struct GroupedDistributionComponent: View {
                 }
                 newPageIndex += 1
             }
+        }
+    }
+    
+    func setRecalculatedCurrentGroup() {
+        if currentLeadingOffer + viewableItems > totalOffers - 1 {
+            // if projected to go above totalOffers, update to last page
+            currentGroup = totalPages - 1
+        } else if currentLeadingOffer >= 0,
+                  currentGroup <= totalPages - 1 {
+            currentGroup = Int(floor(Double(currentLeadingOffer/viewableItems)))
         }
     }
 }

--- a/Sources/RoktUXHelper/UI/Components/OneByOneComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/OneByOneComponent.swift
@@ -40,7 +40,7 @@ struct OneByOneComponent: View {
     @Binding var parentHeight: CGFloat?
     @Binding var styleState: StyleState
 
-    @State var currentOffer = 0
+    @State var currentOffer: Int
     @State private var toggleTransition = false
     @State var customStateMap: CustomStateMap?
 
@@ -72,6 +72,8 @@ struct OneByOneComponent: View {
 
         self.parentOverride = parentOverride
         self.model = model
+        _currentOffer = State(wrappedValue: model.initialCurrentIndex ?? 0)
+        _customStateMap = State(wrappedValue: model.initialCustomStateMap)
     }
 
     var verticalAlignment: VerticalAlignmentProperty {
@@ -127,11 +129,15 @@ struct OneByOneComponent: View {
                     shouldFocusAccessibility = true
                 }
                 .onChange(of: currentOffer) { newValue in
+                    model.layoutState?.capturePluginViewState(offerIndex: newValue, dismiss: false)
                     transitionIn()
                     model.sendImpressionEvents(currentOffer: newValue)
                     shouldFocusAccessibility = true
                     UIAccessibility.post(notification: .announcement,
                                          argument: accessibilityAnnouncement)
+                }
+                .onChange(of: customStateMap) { _ in
+                    model.layoutState?.capturePluginViewState(offerIndex: nil, dismiss: false)
                 }
                 .onChange(of: globalScreenSize.width) { newSize in
                     // run it in background thread for smooth transition
@@ -153,7 +159,6 @@ struct OneByOneComponent: View {
     func registerActions() {
         model.layoutState?.actionCollection[.nextOffer] = goToNextOffer
         model.layoutState?.actionCollection[.toggleCustomState] = toggleCustomState
-
         model.setupBindings(
             currentProgess: $currentOffer,
             customStateMap: $customStateMap,

--- a/Sources/RoktUXHelper/UI/Components/ViewModel/DistributionViewModel.swift
+++ b/Sources/RoktUXHelper/UI/Components/ViewModel/DistributionViewModel.swift
@@ -19,6 +19,12 @@ class DistributionViewModel: Hashable {
     var config: RoktUXConfig? {
         layoutState?.config
     }
+    var initialCurrentIndex: Int? {
+        layoutState?.initialPluginViewState?.offerIndex
+    }
+    var initialCustomStateMap: CustomStateMap? {
+        layoutState?.initialPluginViewState?.customStateMap
+    }
 
     init(
         eventService: EventServicing?,


### PR DESCRIPTION
### Background ###

This PR lays the UXHelper foundations for part 1 of caching view states, to be used on the SDK side view states caching PR.

Fixes https://rokt.atlassian.net/browse/LAYOUT-1720

### What Has Changed: ###

- Move RoktPluginViewState to UXHelper
- Restore view states from RoktPluginViewStates passed into loadLayout from SDK
- Introduce onPluginViewStateChange callback to capture view states updates
- LayoutState stores pluginId, initialPluginViewStates and the onPluginViewStateChange callback
- DistributionViewModels and components updated to restore from initialPluginViewStates and to capture view states on change

### How Has This Been Tested? ###

Tested locally (recordings in SDK-side PR)

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.