### PR TITLE
NI-378 Change the ownership of eventService to RoktUX

### DIFF
--- a/Sources/RoktUXHelper/RoktUX.swift
+++ b/Sources/RoktUXHelper/RoktUX.swift
@@ -22,6 +22,7 @@ public class RoktUX: UXEventsDelegate {
     public static var integrationInfo: RoktIntegrationInfo { RoktIntegrationInfo.shared }
 
     private(set) var onRoktEvent: ((RoktUXEvent) -> Void)?
+    private var eventService: EventService?
 
     public init() {}
 
@@ -199,7 +200,7 @@ public class RoktUX: UXEventsDelegate {
 
         let layoutState = LayoutState(actionCollection: actionCollection, config: config)
 
-        let eventService = EventService(
+        eventService = EventService(
             pageId: page.pageId,
             pageInstanceGuid: page.pageInstanceGuid,
             sessionId: page.sessionId,
@@ -217,7 +218,7 @@ public class RoktUX: UXEventsDelegate {
         layoutState.items[LayoutState.breakPointsSharedKey] = layoutPlugin.breakpoints
         layoutState.items[LayoutState.layoutSettingsKey] = layoutPlugin.settings
 
-        eventService.sendSignalLoadStartEvent()
+        eventService?.sendSignalLoadStartEvent()
 
         layoutState.setLayoutType(.unknown)
 
@@ -283,15 +284,15 @@ public class RoktUX: UXEventsDelegate {
 
                 }
             }
-            eventService.sendEventsOnTransformerSuccess()
+            eventService?.sendEventsOnTransformerSuccess()
         } catch LayoutTransformerError.InvalidColor(color: let color) {
             // invalid color error
-            eventService.sendDiagnostics(message: kValidationErrorCode,
+            eventService?.sendDiagnostics(message: kValidationErrorCode,
                                          callStack: kColorInvalid + color)
             onRoktUXEvent(RoktUXEvent.LayoutFailure(layoutId: layoutPlugin.pluginId))
         } catch {
             // generic validation error
-            eventService.sendDiagnostics(message: kValidationErrorCode,
+            eventService?.sendDiagnostics(message: kValidationErrorCode,
                                          callStack: kLayoutInvalid)
             onRoktUXEvent(RoktUXEvent.LayoutFailure(layoutId: layoutPlugin.pluginId))
         }

--- a/Sources/RoktUXHelper/UI/Components/Common/UIViewController+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/UIViewController+Extension.swift
@@ -160,7 +160,7 @@ extension UIViewController {
 @available(iOS 15.0, *)
 public final class SwiftUIViewController: UIHostingController<AnyView> {
     let onUnload: (() -> Void)?
-    let eventService: EventService?
+    weak var eventService: EventService?
     let layoutState: LayoutState?
 
     required init?(coder: NSCoder) {
@@ -185,7 +185,8 @@ public final class SwiftUIViewController: UIHostingController<AnyView> {
         onUnload?()
     }
 
-    func closeModal() {
+    public func closeModal() {
+        
         if let eventService {
             eventService.dismissOption = .partnerTriggered
             eventService.sendDismissalEvent()

--- a/Sources/RoktUXHelper/UI/Components/EmbeddedComponent/EmbeddedComponentViewModel.swift
+++ b/Sources/RoktUXHelper/UI/Components/EmbeddedComponent/EmbeddedComponentViewModel.swift
@@ -15,7 +15,7 @@ import SwiftUI
 class EmbeddedComponentViewModel: ObservableObject {
     let layout: LayoutSchemaViewModel
     private let layoutState: LayoutState?
-    private let eventService: EventServicing?
+    private weak var eventService: EventServicing?
     private var onLoadCallback: (() -> Void)?
     private var onSizeChange: ((CGFloat) -> Void)?
     private var lastUpdatedHeight: CGFloat = 0


### PR DESCRIPTION
### Background ###

There was a bug in the SignalDismissal that was not populated when user dismiss the view.

Fixes [([issue](https://rokt.atlassian.net/browse/NI-378))]

### What Has Changed: ###

* Ownership of eventService changed to RoktUX
* made closeModal function public

### How Has This Been Tested? ###

Tested locally. Will add E2E test to capture this scenario as it is hard to be Unit tested at the moment.

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.