### PR TITLE
LAYOUT-1763: Implement sent event caching on UXHelper module

### DIFF
--- a/Sources/RoktUXHelper/Data/Model/Event/ProcessedEvent.swift
+++ b/Sources/RoktUXHelper/Data/Model/Event/ProcessedEvent.swift
@@ -12,11 +12,11 @@
 import Foundation
 
 public struct ProcessedEvent: Hashable, Equatable {
-    public let sessionId: String
-    public let parentGuid: String
-    public let eventType: EventType
-    public let pageInstanceGuid: String
-    public let eventData: [RoktEventNameValue]
+    let sessionId: String
+    let parentGuid: String
+    let eventType: EventType
+    let pageInstanceGuid: String
+    let eventData: [RoktEventNameValue]
 }
 
 extension ProcessedEvent {

--- a/Sources/RoktUXHelper/Data/Model/Event/ProcessedEvent.swift
+++ b/Sources/RoktUXHelper/Data/Model/Event/ProcessedEvent.swift
@@ -11,16 +11,16 @@
 
 import Foundation
 
-struct ProcessedEvent: Hashable, Equatable {
-    let sessionId: String
-    let parentGuid: String
-    let eventType: EventType
-    let pageInstanceGuid: String
-    let eventData: [RoktEventNameValue]
+public struct ProcessedEvent: Hashable, Equatable {
+    public let sessionId: String
+    public let parentGuid: String
+    public let eventType: EventType
+    public let pageInstanceGuid: String
+    public let eventData: [RoktEventNameValue]
 }
 
 extension ProcessedEvent {
-    init(_ event: RoktEventRequest) {
+    public init(_ event: RoktEventRequest) {
         self = .init(
             sessionId: event.sessionId,
             parentGuid: event.parentGuid,
@@ -28,5 +28,27 @@ extension ProcessedEvent {
             pageInstanceGuid: event.pageInstanceGuid,
             eventData: event.eventData
         )
+    }
+    
+    private var attributesAsString: String {
+        let eventDataDict: [String: String] = eventData
+            .map { $0.getDictionary() }
+            .flatMap { $0 }
+            .reduce([String:String]()) { (dict, tuple) in
+                var nextDict = dict
+                nextDict.updateValue(tuple.1, forKey: tuple.0)
+                return nextDict
+            }
+        return eventDataDict
+            .sorted(by: { $0.0 < $1.0 })
+            .map { "\($0):\($1)" }
+            .joined(separator: "")
+    }
+    
+    @available(iOS 13.0, *)
+    public func getHashString() -> String {
+        return [sessionId, parentGuid, eventType.rawValue, pageInstanceGuid, attributesAsString]
+            .joined(separator: "")
+            .sha256()
     }
 }

--- a/Sources/RoktUXHelper/Data/Model/RoktPluginViewState.swift
+++ b/Sources/RoktUXHelper/Data/Model/RoktPluginViewState.swift
@@ -28,9 +28,9 @@ import Foundation
     }
 
     public init(pluginId: String,
-                offerIndex: Int?,
-                isPluginDismissed: Bool?,
-                customStateMap: CustomStateMap?) {
+                offerIndex: Int? = nil,
+                isPluginDismissed: Bool? = nil,
+                customStateMap: CustomStateMap? = nil) {
         self.pluginId = pluginId
         self.offerIndex = offerIndex
         self.isPluginDismissed = isPluginDismissed

--- a/Sources/RoktUXHelper/RoktUX.swift
+++ b/Sources/RoktUXHelper/RoktUX.swift
@@ -92,6 +92,7 @@ public class RoktUX: UXEventsDelegate {
        - startDate: The start date for the process. Default is current date.
        - experienceResponse: The response string containing the experience data.
        - layoutPluginViewStates: Plugin view states ([RoktPluginViewState]) to be restored.
+       - processedEventHashes: Set of hash strings representing processed events to be restored.
        - defaultLayoutLoader: Default loader for the layout.
        - layoutLoaders: A dictionary mapping layout element selectors to their loaders.
        - config: Configuration for the RoktUX.
@@ -106,6 +107,7 @@ public class RoktUX: UXEventsDelegate {
     public func loadLayout(
         startDate: Date = Date(),
         experienceResponse: String,
+        processedEventHashes: Set<String>? = nil,
         layoutPluginViewStates: [RoktPluginViewState]? = nil,
         defaultLayoutLoader: LayoutLoader? = nil,
         layoutLoaders: [String: LayoutLoader?]? = nil,
@@ -118,7 +120,9 @@ public class RoktUX: UXEventsDelegate {
         onPluginViewStateChange: @escaping (RoktPluginViewState) -> Void
     ) {
         let integrationType: HelperIntegrationType = .sdk
-        let processor = EventProcessor(integrationType: integrationType, onRoktPlatformEvent: onRoktPlatformEvent)
+        let processor = EventProcessor(integrationType: integrationType,
+                                       processedEventHashes: processedEventHashes,
+                                       onRoktPlatformEvent: onRoktPlatformEvent)
         do {
             let layoutPage = try initiatePageModel(integrationType: integrationType,
                                                    startDate: startDate,

--- a/Sources/RoktUXHelper/UI/Components/Common/String+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/String+Extension.swift
@@ -11,6 +11,7 @@
 
 import SwiftUI
 import DcuiSchema
+import CryptoKit
 
 @available(iOS 15, *)
 internal extension StringProtocol {
@@ -228,5 +229,13 @@ internal extension StringProtocol {
 
             originalStr.addAttribute(.font, value: updatedFont, range: fontRange)
         }
+    }
+}
+
+@available(iOS 13, *)
+internal extension StringProtocol {
+    func sha256() -> String {
+        guard let data = self.data(using: .utf8) else { return "" }
+        return CryptoKit.SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

Adds UXHelper module changes to support caching and restoring sent events.

Fixes https://rokt.atlassian.net/browse/LAYOUT-1763

### What Has Changed

- loadLayout method updated to receive (optional) restored processedEventHashes from SDK
- EventProcessor filters out duplicate events by hash
- Updates to ProcessedEvent and 

### How Has This Been Tested?

Caching events was tested on the SDK-side

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.
