### PR TITLE
NO-JIRA: extract sent event handling out of uxhelper

### DIFF
--- a/Sources/RoktUXHelper/Data/Model/Event/ProcessedEvent.swift
+++ b/Sources/RoktUXHelper/Data/Model/Event/ProcessedEvent.swift
@@ -12,11 +12,11 @@
 import Foundation
 
 public struct ProcessedEvent: Hashable, Equatable {
-    public let sessionId: String
-    public let parentGuid: String
-    public let eventType: EventType
-    public let pageInstanceGuid: String
-    public let eventData: [RoktEventNameValue]
+    let sessionId: String
+    let parentGuid: String
+    let eventType: EventType
+    let pageInstanceGuid: String
+    let eventData: [RoktEventNameValue]
 }
 
 extension ProcessedEvent {

--- a/Sources/RoktUXHelper/Data/Model/Event/ProcessedEvent.swift
+++ b/Sources/RoktUXHelper/Data/Model/Event/ProcessedEvent.swift
@@ -11,7 +11,7 @@
 
 import Foundation
 
-public struct ProcessedEvent: Hashable, Equatable {
+struct ProcessedEvent: Hashable, Equatable {
     let sessionId: String
     let parentGuid: String
     let eventType: EventType
@@ -20,7 +20,7 @@ public struct ProcessedEvent: Hashable, Equatable {
 }
 
 extension ProcessedEvent {
-    public init(_ event: RoktEventRequest) {
+    init(_ event: RoktEventRequest) {
         self = .init(
             sessionId: event.sessionId,
             parentGuid: event.parentGuid,
@@ -28,27 +28,5 @@ extension ProcessedEvent {
             pageInstanceGuid: event.pageInstanceGuid,
             eventData: event.eventData
         )
-    }
-    
-    private var attributesAsString: String {
-        let eventDataDict: [String: String] = eventData
-            .map { $0.getDictionary() }
-            .flatMap { $0 }
-            .reduce([String:String]()) { (dict, tuple) in
-                var nextDict = dict
-                nextDict.updateValue(tuple.1, forKey: tuple.0)
-                return nextDict
-            }
-        return eventDataDict
-            .sorted(by: { $0.0 < $1.0 })
-            .map { "\($0):\($1)" }
-            .joined(separator: "")
-    }
-    
-    @available(iOS 13.0, *)
-    public func getHashString() -> String {
-        return [sessionId, parentGuid, eventType.rawValue, pageInstanceGuid, attributesAsString]
-            .joined(separator: "")
-            .sha256()
     }
 }

--- a/Sources/RoktUXHelper/Data/Model/Event/ProcessedEvent.swift
+++ b/Sources/RoktUXHelper/Data/Model/Event/ProcessedEvent.swift
@@ -11,16 +11,16 @@
 
 import Foundation
 
-struct ProcessedEvent: Hashable, Equatable {
-    let sessionId: String
-    let parentGuid: String
-    let eventType: EventType
-    let pageInstanceGuid: String
-    let eventData: [RoktEventNameValue]
+public struct ProcessedEvent: Hashable, Equatable {
+    public let sessionId: String
+    public let parentGuid: String
+    public let eventType: EventType
+    public let pageInstanceGuid: String
+    public let eventData: [RoktEventNameValue]
 }
 
 extension ProcessedEvent {
-    init(_ event: RoktEventRequest) {
+    public init(_ event: RoktEventRequest) {
         self = .init(
             sessionId: event.sessionId,
             parentGuid: event.parentGuid,
@@ -28,5 +28,27 @@ extension ProcessedEvent {
             pageInstanceGuid: event.pageInstanceGuid,
             eventData: event.eventData
         )
+    }
+    
+    private var attributesAsString: String {
+        let eventDataDict: [String: String] = eventData
+            .map { $0.getDictionary() }
+            .flatMap { $0 }
+            .reduce([String:String]()) { (dict, tuple) in
+                var nextDict = dict
+                nextDict.updateValue(tuple.1, forKey: tuple.0)
+                return nextDict
+            }
+        return eventDataDict
+            .sorted(by: { $0.0 < $1.0 })
+            .map { "\($0):\($1)" }
+            .joined(separator: "")
+    }
+    
+    @available(iOS 13.0, *)
+    public func getHashString() -> String {
+        return [sessionId, parentGuid, eventType.rawValue, pageInstanceGuid, attributesAsString]
+            .joined(separator: "")
+            .sha256()
     }
 }

--- a/Sources/RoktUXHelper/Data/Model/RoktPluginViewState.swift
+++ b/Sources/RoktUXHelper/Data/Model/RoktPluginViewState.swift
@@ -28,9 +28,9 @@ import Foundation
     }
 
     public init(pluginId: String,
-                offerIndex: Int?,
-                isPluginDismissed: Bool?,
-                customStateMap: CustomStateMap?) {
+                offerIndex: Int? = nil,
+                isPluginDismissed: Bool? = nil,
+                customStateMap: CustomStateMap? = nil) {
         self.pluginId = pluginId
         self.offerIndex = offerIndex
         self.isPluginDismissed = isPluginDismissed

--- a/Sources/RoktUXHelper/RoktUX.swift
+++ b/Sources/RoktUXHelper/RoktUX.swift
@@ -92,7 +92,6 @@ public class RoktUX: UXEventsDelegate {
        - startDate: The start date for the process. Default is current date.
        - experienceResponse: The response string containing the experience data.
        - layoutPluginViewStates: Plugin view states ([RoktPluginViewState]) to be restored.
-       - processedEventHashes: Set of hash strings representing processed events to be restored.
        - defaultLayoutLoader: Default loader for the layout.
        - layoutLoaders: A dictionary mapping layout element selectors to their loaders.
        - config: Configuration for the RoktUX.
@@ -107,7 +106,6 @@ public class RoktUX: UXEventsDelegate {
     public func loadLayout(
         startDate: Date = Date(),
         experienceResponse: String,
-        processedEventHashes: Set<String>? = nil,
         layoutPluginViewStates: [RoktPluginViewState]? = nil,
         defaultLayoutLoader: LayoutLoader? = nil,
         layoutLoaders: [String: LayoutLoader?]? = nil,
@@ -120,9 +118,7 @@ public class RoktUX: UXEventsDelegate {
         onPluginViewStateChange: @escaping (RoktPluginViewState) -> Void
     ) {
         let integrationType: HelperIntegrationType = .sdk
-        let processor = EventProcessor(integrationType: integrationType,
-                                       processedEventHashes: processedEventHashes,
-                                       onRoktPlatformEvent: onRoktPlatformEvent)
+        let processor = EventProcessor(integrationType: integrationType, onRoktPlatformEvent: onRoktPlatformEvent)
         do {
             let layoutPage = try initiatePageModel(integrationType: integrationType,
                                                    startDate: startDate,

--- a/Sources/RoktUXHelper/RoktUX.swift
+++ b/Sources/RoktUXHelper/RoktUX.swift
@@ -92,6 +92,7 @@ public class RoktUX: UXEventsDelegate {
        - startDate: The start date for the process. Default is current date.
        - experienceResponse: The response string containing the experience data.
        - layoutPluginViewStates: Plugin view states ([RoktPluginViewState]) to be restored.
+       - processedEventHashes: Set of hash strings representing processed events to be restored.
        - defaultLayoutLoader: Default loader for the layout.
        - layoutLoaders: A dictionary mapping layout element selectors to their loaders.
        - config: Configuration for the RoktUX.
@@ -106,6 +107,7 @@ public class RoktUX: UXEventsDelegate {
     public func loadLayout(
         startDate: Date = Date(),
         experienceResponse: String,
+        processedEventHashes: Set<String>? = nil,
         layoutPluginViewStates: [RoktPluginViewState]? = nil,
         defaultLayoutLoader: LayoutLoader? = nil,
         layoutLoaders: [String: LayoutLoader?]? = nil,
@@ -118,7 +120,9 @@ public class RoktUX: UXEventsDelegate {
         onPluginViewStateChange: @escaping (RoktPluginViewState) -> Void
     ) {
         let integrationType: HelperIntegrationType = .sdk
-        let processor = EventProcessor(integrationType: integrationType, onRoktPlatformEvent: onRoktPlatformEvent)
+        let processor = EventProcessor(integrationType: integrationType,
+                                       processedEventHashes: processedEventHashes,
+                                       onRoktPlatformEvent: onRoktPlatformEvent)
         do {
             let layoutPage = try initiatePageModel(integrationType: integrationType,
                                                    startDate: startDate,

--- a/Sources/RoktUXHelper/RoktUX.swift
+++ b/Sources/RoktUXHelper/RoktUX.swift
@@ -92,7 +92,6 @@ public class RoktUX: UXEventsDelegate {
        - startDate: The start date for the process. Default is current date.
        - experienceResponse: The response string containing the experience data.
        - layoutPluginViewStates: Plugin view states ([RoktPluginViewState]) to be restored.
-       - processedEventHashes: Set of hash strings representing processed events to be restored.
        - defaultLayoutLoader: Default loader for the layout.
        - layoutLoaders: A dictionary mapping layout element selectors to their loaders.
        - config: Configuration for the RoktUX.
@@ -107,7 +106,6 @@ public class RoktUX: UXEventsDelegate {
     public func loadLayout(
         startDate: Date = Date(),
         experienceResponse: String,
-        processedEventHashes: Set<String>? = nil,
         layoutPluginViewStates: [RoktPluginViewState]? = nil,
         defaultLayoutLoader: LayoutLoader? = nil,
         layoutLoaders: [String: LayoutLoader?]? = nil,
@@ -121,7 +119,6 @@ public class RoktUX: UXEventsDelegate {
     ) {
         let integrationType: HelperIntegrationType = .sdk
         let processor = EventProcessor(integrationType: integrationType,
-                                       processedEventHashes: processedEventHashes,
                                        onRoktPlatformEvent: onRoktPlatformEvent)
         do {
             let layoutPage = try initiatePageModel(integrationType: integrationType,

--- a/Sources/RoktUXHelper/Services/Events/EventProcessor.swift
+++ b/Sources/RoktUXHelper/Services/Events/EventProcessor.swift
@@ -24,7 +24,7 @@ protocol EventProcessing {
 @available(iOS 13.0, *)
 class EventProcessor: EventProcessing {
     private var cancellables: Set<AnyCancellable> = .init()
-    private var processedEventHashes: Set<String>
+    private var processedEvents: Set<ProcessedEvent> = .init()
     private var onRoktPlatformEvent: (([String: Any]) -> Void)?
     private(set) var publisher: PassthroughSubject<RoktEventRequest, Never> = .init()
 
@@ -32,10 +32,8 @@ class EventProcessor: EventProcessing {
         delay: Double = defaultEventBufferDuration,
         queue: DispatchQueue = DispatchQueue.background,
         integrationType: HelperIntegrationType = .s2s,
-        processedEventHashes: Set<String>? = nil,
         onRoktPlatformEvent: (([String: Any]) -> Void)?
     ) {
-        self.processedEventHashes = processedEventHashes ?? .init()
         self.onRoktPlatformEvent = onRoktPlatformEvent
         publisher
             .filter {
@@ -47,9 +45,7 @@ class EventProcessor: EventProcessing {
                 return true
             }
             .filter { [weak self] in
-                let processedEvent: ProcessedEvent = .init($0)
-                return self?.processedEventHashes.insert(
-                    processedEvent.getHashString()).inserted == true
+                self?.processedEvents.insert(.init($0)).inserted == true
             }
             .collect(.byTime(queue, .seconds(delay)), options: nil)
             .map(EventsPayload.init(events:))

--- a/Sources/RoktUXHelper/UI/Components/Common/String+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/String+Extension.swift
@@ -11,7 +11,6 @@
 
 import SwiftUI
 import DcuiSchema
-import CryptoKit
 
 @available(iOS 15, *)
 internal extension StringProtocol {
@@ -229,13 +228,5 @@ internal extension StringProtocol {
 
             originalStr.addAttribute(.font, value: updatedFont, range: fontRange)
         }
-    }
-}
-
-@available(iOS 13, *)
-internal extension StringProtocol {
-    func sha256() -> String {
-        guard let data = self.data(using: .utf8) else { return "" }
-        return CryptoKit.SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Sources/RoktUXHelper/UI/Components/Common/String+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/String+Extension.swift
@@ -231,11 +231,3 @@ internal extension StringProtocol {
         }
     }
 }
-
-@available(iOS 13, *)
-internal extension StringProtocol {
-    func sha256() -> String {
-        guard let data = self.data(using: .utf8) else { return "" }
-        return CryptoKit.SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
-    }
-}

--- a/Sources/RoktUXHelper/UI/Components/Common/String+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/String+Extension.swift
@@ -11,6 +11,7 @@
 
 import SwiftUI
 import DcuiSchema
+import CryptoKit
 
 @available(iOS 15, *)
 internal extension StringProtocol {
@@ -228,5 +229,13 @@ internal extension StringProtocol {
 
             originalStr.addAttribute(.font, value: updatedFont, range: fontRange)
         }
+    }
+}
+
+@available(iOS 13, *)
+internal extension StringProtocol {
+    func sha256() -> String {
+        guard let data = self.data(using: .utf8) else { return "" }
+        return CryptoKit.SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

Extracting sent event handling out of uxhelper as this is not required. Sent event filtering will be moved off to SDK

Fixes NO-JIRA

### What Has Changed

Extracting sent event handling out of uxhelper. (Reverting changes related to sent event filtering from this PR https://github.com/ROKT/rokt-ux-helper-ios/pull/26

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.
