### PR TITLE
NI-392 - retain event processor

### DIFF
--- a/Sources/RoktUXHelper/Services/Events/EventProcessor.swift
+++ b/Sources/RoktUXHelper/Services/Events/EventProcessor.swift
@@ -45,21 +45,21 @@ class EventProcessor: EventProcessing {
                 }
                 return true
             }
-            .filter { [weak self] (event, _) in
-                self?.processedEvents.insert(.init(event)).inserted == true
+            .filter { (event, processor) in
+                processor?.processedEvents.insert(.init(event)).inserted == true
             }
             .collect(.byTime(queue, .seconds(delay)), options: nil)
             .map {
                 (EventsPayload.init(events: $0.map(\.0)), $0.first?.1)
             }
-            .compactMap { [weak self] (events, processor) in
-                guard let payload = self?.serializeData(payload: events) else { return nil }
+            .compactMap { (events, processor) in
+                guard let payload = processor?.serializeData(payload: events) else { return nil }
                 return (payload, processor)
             }
             .sink(
                 receiveCompletion: {_ in },
-                receiveValue: { [weak self] (event: [String: Any], processor: EventProcessor?) in
-                    self?.onRoktPlatformEvent?(event)
+                receiveValue: { (event: [String: Any], processor: EventProcessor?) in
+                    processor?.onRoktPlatformEvent?(event)
                 }
             )
             .store(in: &cancellables)

--- a/Sources/RoktUXHelper/Services/Events/EventProcessor.swift
+++ b/Sources/RoktUXHelper/Services/Events/EventProcessor.swift
@@ -16,7 +16,7 @@ private let defaultEventBufferDuration: Double = 0.025
 
 @available(iOS 13.0, *)
 protocol EventProcessing {
-    var publisher: PassthroughSubject<RoktEventRequest, Never> { get }
+    var publisher: PassthroughSubject<(RoktEventRequest, EventProcessor?), Never> { get }
 
     func handle(event: RoktEventRequest)
 }
@@ -26,7 +26,13 @@ class EventProcessor: EventProcessing {
     private var cancellables: Set<AnyCancellable> = .init()
     private var processedEvents: Set<ProcessedEvent> = .init()
     private var onRoktPlatformEvent: (([String: Any]) -> Void)?
-    private(set) var publisher: PassthroughSubject<RoktEventRequest, Never> = .init()
+    // EventProcessor is being passed in so that the publisher will always finish publishing before the Processor class gets deallocated.
+    private(set) var publisher: PassthroughSubject<(RoktEventRequest, EventProcessor?), Never> = .init()
+
+    struct Payload {
+        let processor: EventProcessor
+        let event: RoktEventRequest
+    }
 
     init(
         delay: Double = defaultEventBufferDuration,
@@ -36,30 +42,40 @@ class EventProcessor: EventProcessing {
     ) {
         self.onRoktPlatformEvent = onRoktPlatformEvent
         publisher
-            .filter {
+            .filter { (event, processor) in
                 if integrationType == .s2s &&
-                    ($0.eventType == .SignalLoadStart ||
-                     $0.eventType == .SignalLoadComplete) {
+                    (event.eventType == .SignalLoadStart ||
+                     event.eventType == .SignalLoadComplete) {
                     return false
                 }
                 return true
             }
-            .filter { [weak self] in
-                self?.processedEvents.insert(.init($0)).inserted == true
+            .filter { [weak self] (event, processor) in
+                self?.processedEvents.insert(.init(event)).inserted == true
             }
             .collect(.byTime(queue, .seconds(delay)), options: nil)
-            .map(EventsPayload.init(events:))
-            .encode(encoder: JSONEncoder())
             .map {
-                (try? JSONSerialization.jsonObject(with: $0)) as? [String: Any] ?? [:]
+                (EventsPayload.init(events: $0.map(\.0)), $0.first?.1)
             }
-            .sink(receiveCompletion: {_ in }, receiveValue: { [weak self] in
-                self?.onRoktPlatformEvent?($0)
-            })
+            .compactMap { [weak self] in
+                guard let payload = self?.serializeData(payload: $0) else { return nil }
+                return (payload, $1)
+            }
+            .sink(
+                receiveCompletion: {_ in },
+                receiveValue: { [weak self] (event: [String: Any], processor: EventProcessor?) in
+                    self?.onRoktPlatformEvent?(event)
+                }
+            )
             .store(in: &cancellables)
     }
 
     func handle(event: RoktEventRequest) {
-        publisher.send(event)
+        publisher.send((event, self))
+    }
+
+    private func serializeData(payload: EventsPayload) -> [String: Any]? {
+        guard let data = try? JSONEncoder().encode(payload) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] ?? [:]
     }
 }

--- a/Tests/RoktUXHelperTests/Services/Mock/MockEventProcessor.swift
+++ b/Tests/RoktUXHelperTests/Services/Mock/MockEventProcessor.swift
@@ -15,7 +15,7 @@ import Combine
 
 @available(iOS 13.0, *)
 class MockEventProcessor: EventProcessing {
-    var publisher: PassthroughSubject<RoktEventRequest, Never> = .init()
+    var publisher: PassthroughSubject<(RoktEventRequest, EventProcessor?), Never> = .init()
     var handler: ((RoktEventRequest) -> Void)?
     
     init(handler: ((RoktEventRequest) -> Void)? = nil) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

Currently if RoktUX is deallocated and there are partner events in queue waiting to be published to the user, the pending events will be lost.
this is to fix the EventProcessor to finish publishing all events before deallocating itself.

Fixes [([issue](https://rokt.atlassian.net/browse/NI-392))]

### What Has Changed

List out what has changed as a result of this PR.

### How Has This Been Tested?

Describe the tests that you ran to verify your changes.

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
