### PR TITLE
NI-385 - send catalog events

### DIFF
--- a/Sources/RoktUXHelper/Data/Model/Event/EventType.swift
+++ b/Sources/RoktUXHelper/Data/Model/Event/EventType.swift
@@ -36,6 +36,10 @@ public enum EventType: String, Codable, CaseIterable {
     case SignalViewed
     /// Triggered when the user clicks catalog response button.
     case SignalCartItemInstantPurchaseInitiated
+    /// Triggered when instant purchase succeeds
+    case SignalCartItemInstantPurchase
+    /// Triggered when instant purchase fails
+    case SignalCartItemInstantPurchaseFailure
     /// Not applicable
     case CaptureAttributes
 }

--- a/Sources/RoktUXHelper/RoktUX.swift
+++ b/Sources/RoktUXHelper/RoktUX.swift
@@ -216,7 +216,7 @@ public class RoktUX: UXEventsDelegate {
         let catalogItems = layoutPlugin.slots
             .compactMap(\.offer)
             .map(\.catalogItems)
-            .flatMap { $0 }
+            .compactMap { $0 }
             .flatMap { $0 }
 
         let eventService = EventService(
@@ -334,7 +334,7 @@ public class RoktUX: UXEventsDelegate {
             if let targetElement = layoutPlugin.targetElementSelector {
                 if let layoutLoader {
 
-                    var onSizeChange = { [weak layoutLoader] (size: CGFloat) in
+                    let onSizeChange = { [weak layoutLoader] (size: CGFloat) in
                         layoutLoader?.updateEmbeddedSize(size)
                         onEmbeddedSizeChange(targetElement, size)
                     }

--- a/Sources/RoktUXHelper/Services/Events/EventService.swift
+++ b/Sources/RoktUXHelper/Services/Events/EventService.swift
@@ -174,6 +174,7 @@ class EventService: Hashable, EventDiagnosticServicing {
 
     func cartItemInstantPurchase(catalogItem: CatalogItem) {
         sendCartItemEvent(eventType: .SignalCartItemInstantPurchaseInitiated, catalogItem: catalogItem)
+        uxEventDelegate?.onCartItemInstantPurchase(pluginId, catalogItem: catalogItem)
     }
 
     func cartItemInstantPurchaseSuccess(itemId: String) {
@@ -202,7 +203,6 @@ class EventService: Hashable, EventDiagnosticServicing {
                 ],
             jwtToken: catalogItem.token ?? ""
         )
-        uxEventDelegate?.onCartItemInstantPurchase(pluginId, catalogItem: catalogItem)
     }
 
     private func canOpenUrl(_ url: URL) {

--- a/Sources/RoktUXHelper/Services/Events/EventService.swift
+++ b/Sources/RoktUXHelper/Services/Events/EventService.swift
@@ -31,6 +31,7 @@ class EventService: Hashable, EventDiagnosticServicing {
     let pluginConfigJWTToken: String
     let useDiagnosticEvents: Bool
     let processor: EventProcessing
+    let catalogItems: [CatalogItem]
 
     weak var uxEventDelegate: UXEventsDelegate?
     var responseReceivedDate: Date
@@ -44,6 +45,7 @@ class EventService: Hashable, EventDiagnosticServicing {
          pluginId: String?,
          pluginName: String?,
          startDate: Date,
+         catalogItems: [CatalogItem] = [],
          uxEventDelegate: UXEventsDelegate,
          processor: EventProcessing,
          responseReceivedDate: Date,
@@ -65,6 +67,7 @@ class EventService: Hashable, EventDiagnosticServicing {
         self.dismissOption = dismissOption
         self.useDiagnosticEvents = useDiagnosticEvents
         self.processor = processor
+        self.catalogItems = catalogItems
     }
 
     func sendSignalLoadStartEvent() {
@@ -168,10 +171,24 @@ class EventService: Hashable, EventDiagnosticServicing {
             }
         })
     }
-    
+
     func cartItemInstantPurchase(catalogItem: CatalogItem) {
+        sendCartItemEvent(eventType: .SignalCartItemInstantPurchaseInitiated, catalogItem: catalogItem)
+    }
+
+    func cartItemInstantPurchaseSuccess(itemId: String) {
+        guard let catalogItem = catalogItems.first(where: { $0.catalogItemId == itemId }) else { return }
+        sendCartItemEvent(eventType: .SignalCartItemInstantPurchase, catalogItem: catalogItem)
+    }
+
+    func cartItemInstantPurchaseFailure(itemId: String) {
+        guard let catalogItem = catalogItems.first(where: { $0.catalogItemId == itemId }) else { return }
+        sendCartItemEvent(eventType: .SignalCartItemInstantPurchaseFailure, catalogItem: catalogItem)
+    }
+
+    private func sendCartItemEvent(eventType: EventType, catalogItem: CatalogItem) {
         sendEvent(
-            .SignalCartItemInstantPurchaseInitiated,
+            eventType,
             parentGuid: catalogItem.instanceGuid ?? "",
             eventData: [
                 kCartItemId: catalogItem.cartItemId ?? "",

--- a/Sources/RoktUXHelper/Services/Events/EventServicing.swift
+++ b/Sources/RoktUXHelper/Services/Events/EventServicing.swift
@@ -24,4 +24,6 @@ protocol EventServicing: AnyObject {
     func sendDismissalEvent()
     func openURL(url: URL, type: OpenURLType, completionHandler: @escaping () -> Void)
     func cartItemInstantPurchase(catalogItem: CatalogItem)
+    func cartItemInstantPurchaseSuccess(itemId: String)
+    func cartItemInstantPurchaseFailure(itemId: String)
 }

--- a/Sources/RoktUXHelper/UI/Components/Common/UIViewController+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/UIViewController+Extension.swift
@@ -186,7 +186,7 @@ public final class SwiftUIViewController: UIHostingController<AnyView> {
     }
 
     public func closeModal() {
-        
+
         if let eventService {
             eventService.dismissOption = .partnerTriggered
             eventService.sendDismissalEvent()

--- a/Tests/RoktUXHelperTests/Services/Events/TestEventProcessor.swift
+++ b/Tests/RoktUXHelperTests/Services/Events/TestEventProcessor.swift
@@ -36,8 +36,8 @@ final class TestEventProcessor: XCTestCase {
             XCTAssertEqual(processedPayload.integration.platform, "iOS")
             
             let processedRequests = processedPayload.events
-            XCTAssertEqual(processedRequests.count, 12)
-                
+            XCTAssertEqual(processedRequests.count, 14)
+
             allEventTypes.forEach { eventType in
                 
                 guard let request = try? XCTUnwrap(processedRequests.first(where: { $0.eventType == eventType })) else {
@@ -89,7 +89,7 @@ final class TestEventProcessor: XCTestCase {
             XCTAssertEqual(processedPayload.integration.platform, "iOS")
             
             let processedRequests = processedPayload.events
-            XCTAssertEqual(processedRequests.count, 10)
+            XCTAssertEqual(processedRequests.count, 12)
             expectation.fulfill()
         }
         allEventTypes.forEach {

--- a/Tests/RoktUXHelperTests/Services/Events/TestEventService.swift
+++ b/Tests/RoktUXHelperTests/Services/Events/TestEventService.swift
@@ -268,6 +268,137 @@ final class TestEventService: XCTestCase {
         let result = XCTWaiter().wait(for: [expectation], timeout: 2)
         XCTAssertEqual(result, .timedOut, "The test should time out since the expectation was not fulfilled.")
     }
+
+    func test_send_instant_purchase_initiated() {
+        // Arrange
+        let eventService = get_mock_event_processor(startDate: startDate,
+                                                    uxEventDelegate: stubUXHelper,
+                                                    eventHandler: { event in
+            self.events.append(event)
+        })
+
+        // Act
+        eventService.cartItemInstantPurchase(catalogItem: .mock())
+
+        // Assert
+        let event = events.first
+        XCTAssertEqual(event?.eventType, .SignalCartItemInstantPurchaseInitiated)
+        XCTAssertEqual(event?.pageInstanceGuid, mockPageInstanceGuid)
+        let cartItemId = event?.eventData.first{$0.name == kCartItemId}
+        XCTAssertEqual(cartItemId?.value, "v1:d5bc61ab-1b92-45ed-a52c-63d4dd2661d2:staples-retail")
+        let catalogItemId = event?.eventData.first{$0.name == kCatalogItemId}
+        XCTAssertEqual(catalogItemId?.value, "staples.861425")
+        let currency = event?.eventData.first{$0.name == kCurrency}
+        XCTAssertEqual(currency?.value, "USD")
+        let description = event?.eventData.first{$0.name == kDescription}
+        XCTAssertEqual(description?.value, "Catalog Description")
+        let linkedProductId = event?.eventData.first{$0.name == kLinkedProductId}
+        XCTAssertEqual(linkedProductId?.value, "linked")
+        let totalPrice = event?.eventData.first{$0.name == kTotalPrice}
+        XCTAssertEqual(totalPrice?.value, "14.99")
+        let quantity = event?.eventData.first{$0.name == kQuantity}
+        XCTAssertEqual(quantity?.value, "1")
+        let unitPrice = event?.eventData.first{$0.name == kUnitPrice}
+        XCTAssertEqual(unitPrice?.value, "14.99")
+
+        // Rokt callbacks
+        XCTAssertEqual(stubUXHelper.roktEvents.count, 1)
+        XCTAssertTrue(stubUXHelper.roktEvents.contains(.CartItemInstantPurchase))
+    }
+
+    func test_send_instant_purchase_succeeded() {
+        // Arrange
+        let eventService = get_mock_event_processor(startDate: startDate,
+                                                    catalogItems: [.mock(catalogItemId: "staples.861425")],
+                                                    uxEventDelegate: stubUXHelper,
+                                                    eventHandler: { event in
+            self.events.append(event)
+        })
+
+        // Act
+        eventService.cartItemInstantPurchaseSuccess(itemId: "staples.861425")
+
+        // Assert
+        let event = events.first
+        XCTAssertEqual(event?.eventType, .SignalCartItemInstantPurchase)
+        XCTAssertEqual(event?.pageInstanceGuid, mockPageInstanceGuid)
+        let cartItemId = event?.eventData.first{$0.name == kCartItemId}
+        XCTAssertEqual(cartItemId?.value, "v1:d5bc61ab-1b92-45ed-a52c-63d4dd2661d2:staples-retail")
+        let catalogItemId = event?.eventData.first{$0.name == kCatalogItemId}
+        XCTAssertEqual(catalogItemId?.value, "staples.861425")
+        let currency = event?.eventData.first{$0.name == kCurrency}
+        XCTAssertEqual(currency?.value, "USD")
+        let description = event?.eventData.first{$0.name == kDescription}
+        XCTAssertEqual(description?.value, "Catalog Description")
+        let linkedProductId = event?.eventData.first{$0.name == kLinkedProductId}
+        XCTAssertEqual(linkedProductId?.value, "linked")
+        let totalPrice = event?.eventData.first{$0.name == kTotalPrice}
+        XCTAssertEqual(totalPrice?.value, "14.99")
+        let quantity = event?.eventData.first{$0.name == kQuantity}
+        XCTAssertEqual(quantity?.value, "1")
+        let unitPrice = event?.eventData.first{$0.name == kUnitPrice}
+        XCTAssertEqual(unitPrice?.value, "14.99")
+
+        // Rokt callbacks
+        XCTAssertEqual(stubUXHelper.roktEvents.count, 0)
+    }
+
+    func test_send_instant_purchase_failed() {
+        // Arrange
+        let eventService = get_mock_event_processor(startDate: startDate,
+                                                    catalogItems: [.mock(catalogItemId: "xyz"), .mock(catalogItemId: "staples.861425")],
+                                                    uxEventDelegate: stubUXHelper,
+                                                    eventHandler: { event in
+            self.events.append(event)
+        })
+
+        // Act
+        eventService.cartItemInstantPurchaseFailure(itemId: "staples.861425")
+
+        // Assert
+        let event = events.first
+        XCTAssertEqual(event?.eventType, .SignalCartItemInstantPurchaseFailure)
+        XCTAssertEqual(event?.pageInstanceGuid, mockPageInstanceGuid)
+        let cartItemId = event?.eventData.first{$0.name == kCartItemId}
+        XCTAssertEqual(cartItemId?.value, "v1:d5bc61ab-1b92-45ed-a52c-63d4dd2661d2:staples-retail")
+        let catalogItemId = event?.eventData.first{$0.name == kCatalogItemId}
+        XCTAssertEqual(catalogItemId?.value, "staples.861425")
+        let currency = event?.eventData.first{$0.name == kCurrency}
+        XCTAssertEqual(currency?.value, "USD")
+        let description = event?.eventData.first{$0.name == kDescription}
+        XCTAssertEqual(description?.value, "Catalog Description")
+        let linkedProductId = event?.eventData.first{$0.name == kLinkedProductId}
+        XCTAssertEqual(linkedProductId?.value, "linked")
+        let totalPrice = event?.eventData.first{$0.name == kTotalPrice}
+        XCTAssertEqual(totalPrice?.value, "14.99")
+        let quantity = event?.eventData.first{$0.name == kQuantity}
+        XCTAssertEqual(quantity?.value, "1")
+        let unitPrice = event?.eventData.first{$0.name == kUnitPrice}
+        XCTAssertEqual(unitPrice?.value, "14.99")
+
+        // Rokt callbacks
+        XCTAssertEqual(stubUXHelper.roktEvents.count, 0)
+    }
+
+    func test_given_no_catalogItems_then_send_nothing() {
+        // Arrange
+        let eventService = get_mock_event_processor(startDate: startDate,
+                                                    catalogItems: [],
+                                                    uxEventDelegate: stubUXHelper,
+                                                    eventHandler: { event in
+            self.events.append(event)
+        })
+
+        // Act
+        eventService.cartItemInstantPurchaseSuccess(itemId: "staples.861425")
+        eventService.cartItemInstantPurchaseFailure(itemId: "staples.861425")
+
+        // Assert
+        XCTAssertEqual(events.count, 0)
+
+        // Rokt callbacks
+        XCTAssertEqual(stubUXHelper.roktEvents.count, 0)
+    }
 }
 
 class MockUXHelper: UXEventsDelegate {

--- a/Tests/RoktUXHelperTests/Services/Mock/MockEventProcessor.swift
+++ b/Tests/RoktUXHelperTests/Services/Mock/MockEventProcessor.swift
@@ -15,7 +15,7 @@ import Combine
 
 @available(iOS 13.0, *)
 class MockEventProcessor: EventProcessing {
-    var publisher: PassthroughSubject<RoktEventRequest, Never> = .init()
+    var publisher: PassthroughSubject<(RoktEventRequest, EventProcessor?), Never> = .init()
     var handler: ((RoktEventRequest) -> Void)?
     
     init(handler: ((RoktEventRequest) -> Void)? = nil) {

--- a/Tests/RoktUXHelperTests/UI/Utils/MockModels.swift
+++ b/Tests/RoktUXHelperTests/UI/Utils/MockModels.swift
@@ -56,6 +56,7 @@ func get_mock_uistate(currentProgress: Int = 0,
 
 @available(iOS 13.0, *)
 func get_mock_event_processor(startDate: Date = Date(),
+                              catalogItems: [CatalogItem] = [],
                               responseReceivedDate: Date = Date(),
                               uxEventDelegate: UXEventsDelegate = MockUXHelper(),
                               useDiagnosticEvents: Bool = false,
@@ -67,6 +68,7 @@ func get_mock_event_processor(startDate: Date = Date(),
                         pluginId: mockPluginId, 
                         pluginName: mockPluginName,
                         startDate: startDate,
+                        catalogItems: catalogItems,
                         uxEventDelegate: uxEventDelegate,
                         processor: MockEventProcessor(handler: eventHandler),
                         responseReceivedDate: responseReceivedDate,
@@ -96,5 +98,34 @@ extension OfferModel {
                 jwtToken: token
             ),
             catalogItems: nil)
+    }
+}
+
+extension CatalogItem {
+    static func mock(catalogItemId: String = "staples.861425") -> Self {
+        .init(
+            images: [
+                "catalogItemImage0": CreativeImage(
+                    light:  "https://apps.rokt.com/userfiles/3066947111576076810.png",
+                    dark: nil,
+                    alt: nil,
+                    title: nil
+                )
+            ],
+            catalogItemId: catalogItemId,
+            cartItemId: "v1:d5bc61ab-1b92-45ed-a52c-63d4dd2661d2:staples-retail",
+            instanceGuid: "catalogInstanceGuid",
+            title: "Catalog Title",
+            description: "Catalog Description",
+            price: 14.99,
+            originalPrice: 14.99,
+            originalPriceFormatted: "$14.99",
+            currency: "USD",
+            linkedProductId: "linked",
+            positiveResponseText: "Add to order",
+            negativeResponseText: "Dismiss",
+            providerData: "861425",
+            token: "catalog1Token"
+        )
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

RoktUX to provide a way to send partner events when instant purchase succeeds or fails.
- also cherry-picked the event processor retention change from main

Fixes [([issue](https://rokt.atlassian.net/browse/NI-392))]

### What Has Changed

List out what has changed as a result of this PR.

### How Has This Been Tested?

Describe the tests that you ran to verify your changes.

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
