### PR TITLE
Change escaping callback optional which is escaping by default

### DIFF
--- a/Sources/RoktUXHelper/Data/Model/Event/EventRequest.swift
+++ b/Sources/RoktUXHelper/Data/Model/Event/EventRequest.swift
@@ -1,5 +1,5 @@
 //
-//  EventRequest.swift
+//  RoktEventRequest.swift
 //  RoktUXHelper
 //
 //  Copyright 2020 Rokt Pte Ltd

--- a/Sources/RoktUXHelper/UI/Components/Common/View+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/View+Extension.swift
@@ -14,7 +14,7 @@ import DcuiSchema
 
 @available(iOS 15, *)
 extension View {
-    func readSize(spacing: SpacingStylingProperties? = nil, onChange: @escaping (CGSize) -> Void) -> some View {
+    func readSize(spacing: SpacingStylingProperties? = nil, onChange: ((CGSize) -> Void)?) -> some View {
         background(
             GeometryReader { geometryProxy in
                 Color.clear
@@ -37,14 +37,14 @@ extension View {
             }
 
             DispatchQueue.main.async {
-                onChange(newSize)
+                onChange?(newSize)
             }
         }
     }
 
     func readSize(
         weightProperties: WeightModifier.Properties? = nil,
-        onChange: @escaping (CGSizeWithMax, Alignment) -> Void
+        onChange: ((CGSizeWithMax, Alignment) -> Void)?
     ) -> some View {
         background(
             GeometryReader { geometryProxy in
@@ -64,7 +64,7 @@ extension View {
             }
 
             DispatchQueue.main.async {
-                onChange(newSizeWithMax, alignment)
+                onChange?(newSizeWithMax, alignment)
             }
         }
     }
@@ -73,7 +73,7 @@ extension View {
     // When timer is over and view is still inside this area, execute closure.
     func onBecomingViewed(
         currentOffer: Int? = nil,
-        execute: @escaping (() -> Void)
+        execute: (() -> Void)?
     ) -> some View {
         background(
             GeometryReader { geometryProxy in
@@ -84,7 +84,7 @@ extension View {
 
                             Timer.scheduledTimer(withTimeInterval: kSignalViewedTimeThreshold, repeats: false) { _ in
                                 if UIScreen.main.bounds.intersectPercent(geometryProxy) > kSignalViewedIntersectThreshold {
-                                    execute()
+                                    execute?()
                                 }
                             }
                         }
@@ -94,7 +94,7 @@ extension View {
 
                             Timer.scheduledTimer(withTimeInterval: kSignalViewedTimeThreshold, repeats: false) { _ in
                                 if UIScreen.main.bounds.intersectPercent(geometryProxy) > kSignalViewedIntersectThreshold {
-                                    execute()
+                                    execute?()
                                 }
                             }
                         }
@@ -104,7 +104,7 @@ extension View {
 
                             Timer.scheduledTimer(withTimeInterval: kSignalViewedTimeThreshold, repeats: false) { _ in
                                 if UIScreen.main.bounds.intersectPercent(geometryProxy) > kSignalViewedIntersectThreshold {
-                                    execute()
+                                    execute?()
                                 }
                             }
                         }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

Need to change the escaping callback to optional which is escaping by default and more feature prof

### How Has This Been Tested?

Tested locally

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
