### PR TITLE
NI-411 - fix fetching image twice

### DIFF
--- a/Sources/RoktUXHelper/UI/Components/WhenComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/WhenComponent.swift
@@ -73,11 +73,7 @@ struct WhenComponent: View {
 
     var body: some View {
         Group {
-            if let visible {
-                if visible {
-                    buildComponent()
-                }
-            } else if shouldApply {
+            if visible == true || shouldApply {
                 buildComponent()
             }
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

we were noticing that the image was being fetched twice in the app, this is due to the conditional building of components in the when node. When the condition is true there are 2 conditional branches the when component takes to build the component, when it is waiting for the animation to load and when the animation is finished. these 2 branches represent 2 identities for the underlying swiftUI view, which tells the rendering engine that it's 2 separate views, thus replacing any states the view might have such as the fetched image.

fix is to reduce the conditional branches to just 1.

| before | sanity testing with expand card |
|:-------:|:-------------:|
| <img width="975" alt="Screenshot 2024-12-12 at 10 31 47 AM" src="https://github.com/user-attachments/assets/73481e29-08b4-41f1-97f8-ce9b64b132c7" /> |  https://github.com/user-attachments/assets/a8833e03-cccd-46ef-9762-322075d2bc58 |



Fixes [(issue)]

### What Has Changed

List out what has changed as a result of this PR.

### How Has This Been Tested?

Describe the tests that you ran to verify your changes.

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
