### PR TITLE
LAYOUT-1829 - Fix partner event on cached experience with isPluginDismissed

### DIFF
--- a/Sources/RoktUXHelper/RoktUX.swift
+++ b/Sources/RoktUXHelper/RoktUX.swift
@@ -214,7 +214,7 @@ public class RoktUX: UXEventsDelegate {
         
         if let isPluginDismissed = layoutPluginViewState?.isPluginDismissed,
            isPluginDismissed {
-            onPlacementClosed(layoutPlugin.pluginId)
+            onPlacementCompleted(layoutPlugin.pluginId)
             onUnload()
             return
         }

--- a/Sources/RoktUXHelper/RoktUX.swift
+++ b/Sources/RoktUXHelper/RoktUX.swift
@@ -211,6 +211,14 @@ public class RoktUX: UXEventsDelegate {
         processor: EventProcessing
     ) {
         onRoktEvent = onRoktUXEvent
+        
+        if let isPluginDismissed = layoutPluginViewState?.isPluginDismissed,
+           isPluginDismissed {
+            onPlacementClosed(layoutPlugin.pluginId)
+            onUnload()
+            return
+        }
+
         let actionCollection = ActionCollection()
 
         let layoutState = LayoutState(actionCollection: actionCollection,
@@ -337,13 +345,6 @@ public class RoktUX: UXEventsDelegate {
                     var onSizeChange = { [weak layoutLoader] (size: CGFloat) in
                         layoutLoader?.updateEmbeddedSize(size)
                         onEmbeddedSizeChange(targetElement, size)
-                    }
-                    
-                    if let isPluginDismissed = layoutState.initialPluginViewState?.isPluginDismissed,
-                       isPluginDismissed {
-                        layoutLoader.closeEmbedded()
-                        onUnload()
-                        return
                     }
 
                     layoutLoader.load(onSizeChanged: onSizeChange,

--- a/Sources/RoktUXHelper/UI/Components/Common/UIViewController+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/UIViewController+Extension.swift
@@ -39,13 +39,6 @@ extension UIViewController {
                                           eventService: eventService,
                                           layoutState: layoutState,
                                           onUnload: onUnLoad)
-        
-        if let isPluginDismissed = layoutState.initialPluginViewState?.isPluginDismissed,
-           isPluginDismissed {
-            modal.dismiss(animated: true, completion: nil)
-            return
-        }
-
         if #available(iOS 16.0, *),
            let type = placementType,
            type == .BottomSheet(.dynamic),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

This PR is to align the partner event sent when a cached experience with isPluginDismissed is retrieved with Android SDK. Previously we sent PlacementReady however this case should be sending PlacementCompleted.

Fixes https://rokt.atlassian.net/browse/LAYOUT-1829

### What Has Changed

- Move isPluginDismissed check to the top of the method to ensure it is checked before any other logic is executed
- Send PlacementClosed event if isPluginDismissed

### How Has This Been Tested?

Tested locally

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation. (docs.rokt.com partner events definition will be updated)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
