### PR TITLE
NI-394 - reduce redraw

### DIFF
--- a/Sources/RoktUXHelper/UI/Components/OuterLayerComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/OuterLayerComponent.swift
@@ -32,7 +32,7 @@ struct OuterLayerComponent: View {
     @Binding var parentHeight: CGFloat?
     @State private var availableWidth: CGFloat?
     @State private var availableHeight: CGFloat?
-
+    @State private var styleState: StyleState = .default
     @State var lastUpdatedHeight: CGFloat = 0
 
     var verticalAlignment: VerticalAlignmentProperty {
@@ -110,7 +110,7 @@ struct OuterLayerComponent: View {
                                       layout: child,
                                       parentWidth: $availableWidth,
                                       parentHeight: $availableHeight,
-                                      styleState: .constant(.default),
+                                      styleState: $styleState,
                                       parentOverride: ComponentParentOverride(parentVerticalAlignment: nil,
                                                                               parentHorizontalAlignment: nil,
                                                                               parentBackgroundStyle: backgroundStyle,
@@ -129,6 +129,6 @@ struct OuterLayerComponent: View {
 
 @available(iOS 15, *)
 class GlobalScreenSize: ObservableObject, Equatable {
-    @Published var width: CGFloat?
-    @Published var height: CGFloat?
+    @LazyPublished var width: CGFloat?
+    @LazyPublished var height: CGFloat?
 }

--- a/Sources/RoktUXHelper/UI/Components/ViewModel/BasicTextViewModel.swift
+++ b/Sources/RoktUXHelper/UI/Components/ViewModel/BasicTextViewModel.swift
@@ -30,10 +30,10 @@ class BasicTextViewModel: Hashable, Identifiable, ObservableObject, DataBindingI
     private(set) var dataBinding: DataBinding<String> = .value("")
 
     // extracted data from `dataBinding` that's published externally
-    @Published var boundValue = ""
+    @LazyPublished var boundValue = ""
 
-    @Published var styleState = StyleState.default
-    @Published var breakpointIndex = 0
+    @LazyPublished var styleState = StyleState.default
+    @LazyPublished var breakpointIndex = 0
     var currentStylingProperties: BasicTextStyle? {
         switch styleState {
         case .hovered:
@@ -60,16 +60,11 @@ class BasicTextViewModel: Hashable, Identifiable, ObservableObject, DataBindingI
         layoutState?.imageLoader
     }
 
-    var currentIndex: Binding<Int> {
-        layoutState?.items[LayoutState.currentProgressKey] as? Binding<Int> ?? .constant(0)
-    }
+    var currentIndex: Binding<Int> = .constant(0)
+    var viewableItems: Binding<Int> = .constant(1)
 
     var totalOffer: Int {
         layoutState?.items[LayoutState.totalItemsKey] as? Int ?? 1
-    }
-
-    var viewableItems: Binding<Int> {
-        layoutState?.items[LayoutState.viewableItemsKey] as? Binding<Int> ?? .constant(1)
     }
 
     init(
@@ -94,6 +89,8 @@ class BasicTextViewModel: Hashable, Identifiable, ObservableObject, DataBindingI
         self.stateDataExpansionClosure = stateDataExpansionClosure
         self.layoutState = layoutState
         self.diagnosticService = diagnosticService
+        self.viewableItems = layoutState?.items[LayoutState.viewableItemsKey] as? Binding<Int> ?? .constant(1)
+        self.currentIndex = layoutState?.items[LayoutState.currentProgressKey] as? Binding<Int> ?? .constant(0)
         performStyleStateBinding()
     }
 

--- a/Sources/RoktUXHelper/UI/Components/ViewModel/ProgressIndicatorViewModel.swift
+++ b/Sources/RoktUXHelper/UI/Components/ViewModel/ProgressIndicatorViewModel.swift
@@ -31,16 +31,11 @@ class ProgressIndicatorViewModel: Identifiable, Hashable {
         layoutState?.imageLoader
     }
 
-    var currentIndex: Binding<Int> {
-        layoutState?.items[LayoutState.currentProgressKey] as? Binding<Int> ?? .constant(0)
-    }
+    var currentIndex: Binding<Int>
+    var viewableItems: Binding<Int>
 
     var totalOffer: Int {
         layoutState?.items[LayoutState.totalItemsKey] as? Int ?? 1
-    }
-
-    var viewableItems: Binding<Int> {
-        layoutState?.items[LayoutState.viewableItemsKey] as? Binding<Int> ?? .constant(1)
     }
 
     init(
@@ -64,6 +59,8 @@ class ProgressIndicatorViewModel: Identifiable, Hashable {
         self.accessibilityHidden = accessibilityHidden
         self.layoutState = layoutState
         self.eventService = eventService
+        self.viewableItems = layoutState.items[LayoutState.viewableItemsKey] as? Binding<Int> ?? .constant(1)
+        self.currentIndex = layoutState.items[LayoutState.currentProgressKey] as? Binding<Int> ?? .constant(0)
     }
 
     func updateDataBinding(dataBinding: DataBinding<String>) {

--- a/Sources/RoktUXHelper/UI/Components/ViewModel/RichTextViewModel.swift
+++ b/Sources/RoktUXHelper/UI/Components/ViewModel/RichTextViewModel.swift
@@ -29,18 +29,18 @@ class RichTextViewModel: Hashable, Identifiable, ObservableObject, ScreenSizeAda
     weak var layoutState: (any LayoutStateRepresenting)?
 
     // extracted data from `dataBinding` that's published externally
-    @Published var boundValue = ""
-    @Published var breakpointIndex = 0
-    @Published var breakpointLinkIndex = 0
-    @Published var attributedString = NSAttributedString("")
+    @LazyPublished var boundValue = ""
+    @LazyPublished var breakpointIndex = 0
+    @LazyPublished var breakpointLinkIndex = 0
+    @LazyPublished var attributedString = NSAttributedString("")
 
     var imageLoader: ImageLoader? {
         layoutState?.imageLoader
     }
 
-    lazy var currentIndex: Binding<Int> = layoutState?.items[LayoutState.currentProgressKey] as? Binding<Int> ?? .constant(0)
+    var viewableItems: Binding<Int>
+    var currentIndex: Binding<Int>
     lazy var totalOffer: Int = layoutState?.items[LayoutState.totalItemsKey] as? Int ?? 1
-    lazy var viewableItems: Binding<Int> = layoutState?.items[LayoutState.viewableItemsKey] as? Binding<Int> ?? .constant(1)
 
     var totalPages: Int {
         return Int(ceil(Double(totalOffer)/Double(viewableItems.wrappedValue)))
@@ -79,6 +79,8 @@ class RichTextViewModel: Hashable, Identifiable, ObservableObject, ScreenSizeAda
         self.stateDataExpansionClosure = stateDataExpansionClosure
         self.layoutState = layoutState
         self.eventService = eventService
+        self.viewableItems = layoutState?.items[LayoutState.viewableItemsKey] as? Binding<Int> ?? .constant(1)
+        self.currentIndex = layoutState?.items[LayoutState.currentProgressKey] as? Binding<Int> ?? .constant(0)
         updateBoundValueWithStyling()
     }
 

--- a/Sources/RoktUXHelper/Utils/LazyPublished.swift
+++ b/Sources/RoktUXHelper/Utils/LazyPublished.swift
@@ -38,8 +38,8 @@ class LazyPublished<Value: Equatable>: ObservableObject {
          message: "@LazyPublished can only be applied to classes"
     )
     var wrappedValue: Value {
-        get { fatalError() }
-        set { fatalError() }
+        get { storage }
+        set { assertionFailure("Can only be applied to classes") }
     }
 
     var projectedValue: Published<Value>.Publisher {

--- a/Sources/RoktUXHelper/Utils/LazyPublished.swift
+++ b/Sources/RoktUXHelper/Utils/LazyPublished.swift
@@ -1,0 +1,55 @@
+//
+//  LazyPublished.swift
+//  RoktUXHelper
+//
+//  Licensed under the Rokt Software Development Kit (SDK) Terms of Use
+//  Version 2.0 (the "License");
+//
+//  You may not use this file except in compliance with the License.
+//
+//  You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
+
+import Foundation
+import Combine
+
+@available(iOS 14.0, *)
+@propertyWrapper
+class LazyPublished<Value: Equatable>: ObservableObject {
+
+    static subscript<T: ObservableObject>(
+        _enclosingInstance instance: T,
+        wrapped wrappedKeyPath: ReferenceWritableKeyPath<T, Value>,
+        storage storageKeyPath: ReferenceWritableKeyPath<T, LazyPublished>
+    ) -> Value {
+        get {
+            instance[keyPath: storageKeyPath].storage
+        }
+        set {
+            let oldValue = instance[keyPath: storageKeyPath].storage
+            if oldValue != newValue {
+                (instance.objectWillChange as? ObservableObjectPublisher)?.send()
+            }
+            instance[keyPath: storageKeyPath].storage = newValue
+        }
+    }
+
+    @available(
+        *, unavailable,
+         message: "@LazyPublished can only be applied to classes"
+    )
+    var wrappedValue: Value {
+        get { fatalError() }
+        set { fatalError() }
+    }
+
+    var projectedValue: Published<Value>.Publisher {
+        get { $storage }
+        set { $storage = newValue }
+    }
+
+    @Published private var storage: Value
+
+    init(wrappedValue: Value) {
+        storage = wrappedValue
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

our swiftUI views are being redrawn too many times resulting in really slow loading times for more complex views.
here's a couple things i've identified that works and has cut down rendering time by half (rendering the bottomsheet shown as benchmark)
- reducing the use of constants when initializing bindings, can't find any literature on it, but this can trigger a redraw when we initialize a view that has a binding with a constant.
- @Published property triggers the view to redraw indiscriminately even if the value is same, introducing a new property wrapper @LazyPublished that only triggers redraw when the wrapped value is different (thanks to [swift evolution 0258](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0258-property-wrappers.md#referencing-the-enclosing-self-in-a-wrapper-type)).

| | Before | After |
|:------:|:------:|:------:|
| time to display | 500ms  | 200ms |

[bottomsheet layout gist](https://gist.github.com/WeiYewT/02139f9a05161916745265413e4949c9)

further investigation needed if we can decouple BasicTextComponent with the progress state indicator, as that has alot of state management that is not needed most of the time.

Fixes [([issue](https://rokt.atlassian.net/browse/NI-394))]

### What Has Changed

List out what has changed as a result of this PR.

### How Has This Been Tested?

Describe the tests that you ran to verify your changes.

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
