### PR TITLE
NI-204 - add github composite actions for xcode 16

### DIFF
--- a/.github/composite_actions/run_xcodebuild_tests_swift_5/action.yml
+++ b/.github/composite_actions/run_xcodebuild_tests_swift_5/action.yml
@@ -1,0 +1,17 @@
+name: "Run unit tests"
+description: "Action runs `xcodebuild test` on xcode 15.4"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: "15.4"
+
+    - name: Run unit-tests
+      run: >
+        set -o pipefail &&
+        xcodebuild -skipPackagePluginValidation -scheme RoktUXHelper test -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.5'
+        | xcbeautify --renderer github-actions
+      shell: bash

--- a/.github/composite_actions/run_xcodebuild_tests_swift_6/action.yml
+++ b/.github/composite_actions/run_xcodebuild_tests_swift_6/action.yml
@@ -1,0 +1,17 @@
+name: "Run unit tests"
+description: "Action runs `xcodebuild test` on xcode 16.1"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: "16.1.0"
+
+    - name: Run unit-tests
+      run: >
+        set -o pipefail &&
+        xcodebuild -skipPackagePluginValidation -scheme RoktUXHelper test -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest'
+        | xcbeautify --renderer github-actions
+      shell: bash

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "15.4"
+      - name: Install xcbeautify
+        run: |
+          brew list xcbeautify || brew install xcbeautify
 
-      - name: Run tests
-        run: xcodebuild -skipPackagePluginValidation -scheme RoktUXHelper test -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.5'
+      - name: Run unit tests
+        uses: ./.github/composite_actions/run_xcodebuild_tests_swift_5
+#        uses: ./.github/composite_actions/run_xcodebuild_tests_swift_6 # use this to run on xcode 16.1


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

A simple way to configure github actions to run on xcode 15 or xcode 16, with warnings and errors from linting and unit tests now showing as annotations and in files changed 

Fixes [([issue](https://rokt.atlassian.net/browse/NI-300))]

### What Has Changed

List out what has changed as a result of this PR.

### How Has This Been Tested?

Describe the tests that you ran to verify your changes.

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
