### PR TITLE
NI-448 - add DebounceCollector

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,6 +8,11 @@ disabled_rules: # rule identifiers to exclude from running
   - cyclomatic_complexity
   - function_body_length
 
+nesting:
+  type_level:
+    warning: 3
+    error: 6
+
 line_length:
   warning: 130
   error: 160

--- a/Sources/RoktUXHelper/RoktUX.swift
+++ b/Sources/RoktUXHelper/RoktUX.swift
@@ -342,7 +342,7 @@ public class RoktUX: UXEventsDelegate {
             if let targetElement = layoutPlugin.targetElementSelector {
                 if let layoutLoader {
 
-                    var onSizeChange = { [weak layoutLoader] (size: CGFloat) in
+                    let onSizeChange = { [weak layoutLoader] (size: CGFloat) in
                         layoutLoader?.updateEmbeddedSize(size)
                         onEmbeddedSizeChange(targetElement, size)
                     }

--- a/Sources/RoktUXHelper/Services/Events/EventProcessor.swift
+++ b/Sources/RoktUXHelper/Services/Events/EventProcessor.swift
@@ -12,7 +12,8 @@
 import Foundation
 import Combine
 
-private let defaultEventBufferDuration: Double = 0.025
+@available(iOS 13.0, *)
+private let defaultEventBufferDuration: DispatchQueue.SchedulerTimeType.Stride = 0.025
 
 @available(iOS 13.0, *)
 protocol EventProcessing {
@@ -30,7 +31,7 @@ class EventProcessor: EventProcessing {
     private(set) var publisher: PassthroughSubject<(RoktEventRequest, EventProcessor?), Never> = .init()
 
     init(
-        delay: Double = defaultEventBufferDuration,
+        delay: DispatchQueue.SchedulerTimeType.Stride = defaultEventBufferDuration,
         queue: DispatchQueue = DispatchQueue.background,
         integrationType: HelperIntegrationType = .s2s,
         onRoktPlatformEvent: (([String: Any]) -> Void)?
@@ -48,7 +49,7 @@ class EventProcessor: EventProcessing {
             .filter { (event, processor) in
                 processor?.processedEvents.insert(.init(event)).inserted == true
             }
-            .collect(.byTime(queue, .seconds(delay)), options: nil)
+            .debounceCollect(for: delay, scheduler: queue)
             .map {
                 (EventsPayload.init(events: $0.map(\.0)), $0.first?.1)
             }

--- a/Sources/RoktUXHelper/UI/Components/Common/UIViewController+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/UIViewController+Extension.swift
@@ -45,7 +45,7 @@ extension UIViewController {
            let bottomSheetUIModel = bottomSheetUIModel {
             // Only for iOS 16+ dynamic bottomsheet
             var isOnLoadCalled = false
-            var onSizeChange = { [weak self, weak modal] size in
+            let onSizeChange = { [weak modal] size in
                 DispatchQueue.main.async {
                     if let sheet = modal?.sheetPresentationController {
                         sheet.animateChanges {
@@ -95,7 +95,7 @@ extension UIViewController {
         }
 
         modal.view.isOpaque = false
-        layoutState.actionCollection[.close] = { [weak self, weak modal, weak layoutState] _ in
+        layoutState.actionCollection[.close] = { [weak modal, weak layoutState] _ in
             modal?.dismiss(animated: true, completion: nil)
             layoutState?.capturePluginViewState(offerIndex: nil, dismiss: true)
         }

--- a/Sources/RoktUXHelper/Utils/DebounceCollector.swift
+++ b/Sources/RoktUXHelper/Utils/DebounceCollector.swift
@@ -1,0 +1,108 @@
+//
+//  DebounceCollector.swift
+//  RoktUXHelper
+//
+//  Copyright 2020 Rokt Pte Ltd
+//
+//  Licensed under the Rokt Software Development Kit (SDK) Terms of Use
+//  Version 2.0 (the "License");
+//
+//  You may not use this file except in compliance with the License.
+//
+//  You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
+
+import Combine
+
+@available(iOS 13.0, *)
+struct DebounceCollector<Upstream: Publisher, S: Scheduler>: Publisher {
+
+    typealias Output = [Upstream.Output]
+    typealias Failure = Upstream.Failure
+
+    let upstream: Upstream
+    let dueTime: S.SchedulerTimeType.Stride
+    let scheduler: S
+    let options: S.SchedulerOptions?
+
+    func receive<Sub>(subscriber: Sub) where Sub: Subscriber, Upstream.Failure == Sub.Failure, [Upstream.Output] == Sub.Input {
+        let debounceSubscriber = DebounceCollectorSubscriber(
+            downstream: subscriber,
+            dueTime: dueTime,
+            scheduler: scheduler,
+            options: options
+        )
+        upstream.subscribe(debounceSubscriber)
+    }
+}
+
+@available(iOS 13.0, *)
+extension DebounceCollector {
+    class DebounceCollectorSubscriber<Downstream: Subscriber, DownstreamScheduler: Scheduler>: Subscriber
+    where
+    Downstream.Input == [Upstream.Output],
+    Downstream.Failure == Failure {
+        typealias Input = Upstream.Output
+        typealias Failure = Downstream.Failure
+
+        private let downstream: Downstream
+        private let dueTime: DownstreamScheduler.SchedulerTimeType.Stride
+        private let scheduler: DownstreamScheduler
+        private let options: DownstreamScheduler.SchedulerOptions?
+        private var lastCancellable: Cancellable?
+        private var collectedValues: [Input] = []
+
+        init(
+            downstream: Downstream,
+            dueTime: DownstreamScheduler.SchedulerTimeType.Stride,
+            scheduler: DownstreamScheduler,
+            options: DownstreamScheduler.SchedulerOptions? = nil
+        ) {
+            self.downstream = downstream
+            self.dueTime = dueTime
+            self.scheduler = scheduler
+            self.options = options
+        }
+
+        func receive(subscription: Combine.Subscription) {
+            downstream.receive(subscription: subscription)
+        }
+
+        func receive(_ input: Input) -> Subscribers.Demand {
+            collectedValues.append(input)
+
+            lastCancellable?.cancel()
+            lastCancellable = scheduler.schedule(
+                after: scheduler.now.advanced(by: dueTime),
+                interval: .zero,
+                tolerance: .zero
+            ) { [weak self] in
+                guard let collectedValues = self?.collectedValues else { return }
+                _ = self?.downstream.receive(collectedValues)
+                self?.collectedValues = []
+                self?.lastCancellable?.cancel()
+            }
+
+            return .none
+        }
+
+        func receive(completion: Subscribers.Completion<Downstream.Failure>) {
+            downstream.receive(completion: completion)
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+extension Publisher {
+    func debounceCollect<S: Scheduler>(
+        for dueTime: S.SchedulerTimeType.Stride,
+        scheduler: S,
+        options: S.SchedulerOptions? = nil
+    ) -> DebounceCollector<Self, S> {
+        DebounceCollector(
+            upstream: self,
+            dueTime: dueTime,
+            scheduler: scheduler,
+            options: options
+        )
+    }
+}

--- a/Tests/RoktUXHelperTests/Services/Events/TestEventProcessor.swift
+++ b/Tests/RoktUXHelperTests/Services/Events/TestEventProcessor.swift
@@ -19,183 +19,183 @@ import XCTest
 @available(iOS 13.0, *)
 final class TestEventProcessor: XCTestCase {
     
-//    func testEvents() {
-//        let expectation = expectation(description: "test event types")
-//        let allEventTypes = EventType.allCases
-//        let date = Date()
-//        
-//        let sut = EventProcessor(integrationType: .sdk) { [weak self] payload in
-//            guard let self,
-//            let processedPayload: EventsPayload = deserialize(payload) else {
-//                XCTFail("fail unwrapping")
-//                return
-//            }
-//            
-//            XCTAssertEqual(processedPayload.integration.name, "UX Helper iOS")
-//            XCTAssertEqual(processedPayload.integration.framework, "Swift")
-//            XCTAssertEqual(processedPayload.integration.platform, "iOS")
-//            
-//            let processedRequests = processedPayload.events
-//            XCTAssertEqual(processedRequests.count, 11)
-//                
-//            allEventTypes.forEach { eventType in
-//                
-//                guard let request = try? XCTUnwrap(processedRequests.first(where: { $0.eventType == eventType })) else {
-//                    XCTFail("fail with unwrapping EventRequest")
-//                    return
-//                }
-//                XCTAssertEqual(request.eventData, [.init(name: "key", value: "value \(request.eventType.rawValue)")])
-//                let metaData = [
-//                    RoktEventNameValue(name: BE_CLIENT_TIME_STAMP,
-//                                       value: EventDateFormatter.getDateString(date)),
-//                    RoktEventNameValue(name: BE_CAPTURE_METHOD,
-//                                       value: kClientProvided),
-//                    RoktEventNameValue(name: "name",
-//                                       value: "meta \(request.eventType.rawValue)")
-//                ]
-//                XCTAssertEqual(request.metadata, metaData)
-//            }
-//            expectation.fulfill()
-//        }
-//        
-//        allEventTypes.forEach {
-//            sut.handle(
-//                event: mockEvent(
-//                    eventType: $0,
-//                    date: date,
-//                    extraMetadata: [.init(name: "name", value: "meta \($0.rawValue)")],
-//                    eventData: ["key": "value \($0.rawValue)"]
-//                )
-//            )
-//        }
-//        
-//        wait(for: [expectation], timeout: 1.0)
-//    }
-//    
-//    func testS2SEvents() {
-//        let expectation = expectation(description: "test s2s event types")
-//        let allEventTypes = EventType.allCases
-//        let date = Date()
-//        
-//        let sut = EventProcessor(integrationType: .s2s) { [weak self] payload in
-//            guard let self,
-//                  let processedPayload: EventsPayload = deserialize(payload) else {
-//                XCTFail("fail unwrapping")
-//                return
-//            }
-//            
-//            XCTAssertEqual(processedPayload.integration.name, "UX Helper iOS")
-//            XCTAssertEqual(processedPayload.integration.framework, "Swift")
-//            XCTAssertEqual(processedPayload.integration.platform, "iOS")
-//            
-//            let processedRequests = processedPayload.events
-//            XCTAssertEqual(processedRequests.count, 9)
-//            expectation.fulfill()
-//        }
-//        allEventTypes.forEach {
-//            sut.handle(
-//                event: mockEvent(
-//                    eventType: $0,
-//                    date: date,
-//                    extraMetadata: [.init(name: "name", value: "meta \($0.rawValue)")],
-//                    eventData: ["key": "value \($0.rawValue)"]
-//                )
-//            )
-//        }
-//        
-//        wait(for: [expectation], timeout: 1.0)
-//    }
-//    
-//    func testEventDelayProcessing() {
-//        var expectation = expectation(description: "wait")
-//        var receivedPayload: [RoktEventRequest]?
-//        let sut = EventProcessor(delay: 0.5) { [weak self] payload in
-//            guard let self else {
-//                XCTFail("Fail self")
-//                return
-//            }
-//            receivedPayload = deserialize(payload)?.events
-//            expectation.fulfill()
-//        }
-//        
-//        sut.handle(event: mockEvent(eventType: .SignalActivation, date: Date()))
-//        wait(for: [expectation], timeout: 1)
-//        XCTAssertEqual(receivedPayload?.count, 1)
-//        XCTAssertEqual(receivedPayload?.first?.eventType, .SignalActivation)
-//        
-//        expectation = XCTestExpectation(description: "wait again")
-//        sut.handle(event: mockEvent(eventType: .SignalViewed, date: Date()))
-//        microSleep(0.1)
-//        sut.handle(event: mockEvent(eventType: .SignalImpression, date: Date()))
-//        microSleep(0.1)
-//        sut.handle(event: mockEvent(eventType: .SignalResponse, date: Date()))
-//        wait(for: [expectation], timeout: 1)
-//        XCTAssertEqual(receivedPayload?.count, 3)
-//        XCTAssertEqual(receivedPayload?[0].eventType, .SignalViewed)
-//        XCTAssertEqual(receivedPayload?[1].eventType, .SignalImpression)
-//        XCTAssertEqual(receivedPayload?[2].eventType, .SignalResponse)
-//    }
-//
-//    func testEventRemoveDuplicates() {
-//        let expectation = expectation(description: "test duplicates")
-//        var receivedPayload: [RoktEventRequest]?
-//        let sut = EventProcessor() { [weak self] payload in
-//            guard let self else {
-//                XCTFail("Fail self")
-//                return
-//            }
-//            receivedPayload = deserialize(payload)?.events
-//            expectation.fulfill()
-//        }
-//        let date = Date()
-//        sut.handle(event: mockEvent(eventType: .SignalViewed, date: date))
-//        sut.handle(event: mockEvent(eventType: .SignalViewed, date: date))
-//        sut.handle(event: mockEvent(eventType: .SignalViewed, date: date + 10))
-//        
-//        sut.handle(event: mockEvent(eventType: .SignalActivation, date: date, eventData: ["key": "value"]))
-//        sut.handle(event: mockEvent(eventType: .SignalActivation, date: date, eventData: ["key": "value"]))
-//        sut.handle(event: mockEvent(eventType: .SignalActivation, date: date, eventData: ["key2": "value2"]))
-//        
-//        sut.handle(event: mockEvent(eventType: .SignalResponse, date: date, extraMetadata: [.init(name: "name", value: "value")]))
-//        sut.handle(event: mockEvent(
-//            eventType: .SignalResponse,
-//            date: date,
-//            extraMetadata: [.init(name: "name2", value: "value2")]
-//        ))
-//        
-//        wait(for: [expectation], timeout: 1)
-//        XCTAssertEqual(receivedPayload?.count, 4)
-//        XCTAssertEqual(receivedPayload?[0].eventType, .SignalViewed)
-//        XCTAssertEqual(receivedPayload?[1].eventType, .SignalActivation)
-//        XCTAssertEqual(receivedPayload?[2].eventType, .SignalActivation)
-//        XCTAssertEqual(receivedPayload?[2].eventData, [.init(name: "key2", value: "value2")])
-//        
-//        XCTAssertEqual(receivedPayload?[3].eventType, .SignalResponse)
-//    }
-//
-//    func testDelayProcessorDeallocation() {
-//        let expectation = expectation(description: "wait")
-//        var receivedPayload: [RoktEventRequest]?
-//        weak var weakSut: EventProcessor?
-//        var sut: EventProcessor? = EventProcessor(delay: 1) { [weak self] payload in
-//            guard let self else {
-//                XCTFail("Fail self")
-//                return
-//            }
-//            XCTAssertNotNil(weakSut)
-//            receivedPayload = deserialize(payload)?.events
-//            expectation.fulfill()
-//        }
-//        weakSut = sut
-//        sut?.handle(event: mockEvent(eventType: .SignalActivation, date: Date()))
-//        sut = nil
-//
-//        wait(for: [expectation], timeout: 3)
-//
-//        XCTAssertNil(weakSut)
-//        XCTAssertEqual(receivedPayload?.count, 1)
-//        XCTAssertEqual(receivedPayload?.first?.eventType, .SignalActivation)
-//    }
+    func testEvents() {
+        let expectation = expectation(description: "test event types")
+        let allEventTypes = EventType.allCases
+        let date = Date()
+        
+        let sut = EventProcessor(queue: .userInitiated, integrationType: .sdk) { [weak self] payload in
+            guard let self,
+            let processedPayload: EventsPayload = deserialize(payload) else {
+                XCTFail("fail unwrapping")
+                return
+            }
+            
+            XCTAssertEqual(processedPayload.integration.name, "UX Helper iOS")
+            XCTAssertEqual(processedPayload.integration.framework, "Swift")
+            XCTAssertEqual(processedPayload.integration.platform, "iOS")
+            
+            let processedRequests = processedPayload.events
+            XCTAssertEqual(processedRequests.count, 11)
+                
+            allEventTypes.forEach { eventType in
+                
+                guard let request = try? XCTUnwrap(processedRequests.first(where: { $0.eventType == eventType })) else {
+                    XCTFail("fail with unwrapping EventRequest")
+                    return
+                }
+                XCTAssertEqual(request.eventData, [.init(name: "key", value: "value \(request.eventType.rawValue)")])
+                let metaData = [
+                    RoktEventNameValue(name: BE_CLIENT_TIME_STAMP,
+                                       value: EventDateFormatter.getDateString(date)),
+                    RoktEventNameValue(name: BE_CAPTURE_METHOD,
+                                       value: kClientProvided),
+                    RoktEventNameValue(name: "name",
+                                       value: "meta \(request.eventType.rawValue)")
+                ]
+                XCTAssertEqual(request.metadata, metaData)
+            }
+            expectation.fulfill()
+        }
+        
+        allEventTypes.forEach {
+            sut.handle(
+                event: mockEvent(
+                    eventType: $0,
+                    date: date,
+                    extraMetadata: [.init(name: "name", value: "meta \($0.rawValue)")],
+                    eventData: ["key": "value \($0.rawValue)"]
+                )
+            )
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testS2SEvents() {
+        let expectation = expectation(description: "test s2s event types")
+        let allEventTypes = EventType.allCases
+        let date = Date()
+        
+        let sut = EventProcessor(queue: .userInitiated, integrationType: .s2s) { [weak self] payload in
+            guard let self,
+                  let processedPayload: EventsPayload = deserialize(payload) else {
+                XCTFail("fail unwrapping")
+                return
+            }
+            
+            XCTAssertEqual(processedPayload.integration.name, "UX Helper iOS")
+            XCTAssertEqual(processedPayload.integration.framework, "Swift")
+            XCTAssertEqual(processedPayload.integration.platform, "iOS")
+            
+            let processedRequests = processedPayload.events
+            XCTAssertEqual(processedRequests.count, 9)
+            expectation.fulfill()
+        }
+        allEventTypes.forEach {
+            sut.handle(
+                event: mockEvent(
+                    eventType: $0,
+                    date: date,
+                    extraMetadata: [.init(name: "name", value: "meta \($0.rawValue)")],
+                    eventData: ["key": "value \($0.rawValue)"]
+                )
+            )
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testEventDelayProcessing() {
+        var expectation = expectation(description: "wait")
+        var receivedPayload: [RoktEventRequest]?
+        let sut = EventProcessor(delay: 0.5, queue: .userInitiated) { [weak self] payload in
+            guard let self else {
+                XCTFail("Fail self")
+                return
+            }
+            receivedPayload = deserialize(payload)?.events
+            expectation.fulfill()
+        }
+        
+        sut.handle(event: mockEvent(eventType: .SignalActivation, date: Date()))
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(receivedPayload?.count, 1)
+        XCTAssertEqual(receivedPayload?.first?.eventType, .SignalActivation)
+        
+        expectation = XCTestExpectation(description: "wait again")
+        sut.handle(event: mockEvent(eventType: .SignalViewed, date: Date()))
+        microSleep(0.3)
+        sut.handle(event: mockEvent(eventType: .SignalImpression, date: Date()))
+        microSleep(0.3)
+        sut.handle(event: mockEvent(eventType: .SignalResponse, date: Date()))
+        wait(for: [expectation], timeout: 2)
+        XCTAssertEqual(receivedPayload?.count, 3)
+        XCTAssertEqual(receivedPayload?[0].eventType, .SignalViewed)
+        XCTAssertEqual(receivedPayload?[1].eventType, .SignalImpression)
+        XCTAssertEqual(receivedPayload?[2].eventType, .SignalResponse)
+    }
+
+    func testEventRemoveDuplicates() {
+        let expectation = expectation(description: "test duplicates")
+        var receivedPayload: [RoktEventRequest]?
+        let sut = EventProcessor(queue: .userInitiated) { [weak self] payload in
+            guard let self else {
+                XCTFail("Fail self")
+                return
+            }
+            receivedPayload = deserialize(payload)?.events
+            expectation.fulfill()
+        }
+        let date = Date()
+        sut.handle(event: mockEvent(eventType: .SignalViewed, date: date))
+        sut.handle(event: mockEvent(eventType: .SignalViewed, date: date))
+        sut.handle(event: mockEvent(eventType: .SignalViewed, date: date + 10))
+        
+        sut.handle(event: mockEvent(eventType: .SignalActivation, date: date, eventData: ["key": "value"]))
+        sut.handle(event: mockEvent(eventType: .SignalActivation, date: date, eventData: ["key": "value"]))
+        sut.handle(event: mockEvent(eventType: .SignalActivation, date: date, eventData: ["key2": "value2"]))
+        
+        sut.handle(event: mockEvent(eventType: .SignalResponse, date: date, extraMetadata: [.init(name: "name", value: "value")]))
+        sut.handle(event: mockEvent(
+            eventType: .SignalResponse,
+            date: date,
+            extraMetadata: [.init(name: "name2", value: "value2")]
+        ))
+        
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(receivedPayload?.count, 4)
+        XCTAssertEqual(receivedPayload?[0].eventType, .SignalViewed)
+        XCTAssertEqual(receivedPayload?[1].eventType, .SignalActivation)
+        XCTAssertEqual(receivedPayload?[2].eventType, .SignalActivation)
+        XCTAssertEqual(receivedPayload?[2].eventData, [.init(name: "key2", value: "value2")])
+        
+        XCTAssertEqual(receivedPayload?[3].eventType, .SignalResponse)
+    }
+
+    func testDelayProcessorDeallocation() {
+        let expectation = expectation(description: "wait")
+        var receivedPayload: [RoktEventRequest]?
+        weak var weakSut: EventProcessor?
+        var sut: EventProcessor? = EventProcessor(delay: 1, queue: .userInitiated) { [weak self] payload in
+            guard let self else {
+                XCTFail("Fail self")
+                return
+            }
+            XCTAssertNotNil(weakSut)
+            receivedPayload = deserialize(payload)?.events
+            expectation.fulfill()
+        }
+        weakSut = sut
+        sut?.handle(event: mockEvent(eventType: .SignalActivation, date: Date()))
+        sut = nil
+
+        wait(for: [expectation], timeout: 3)
+
+        XCTAssertNil(weakSut)
+        XCTAssertEqual(receivedPayload?.count, 1)
+        XCTAssertEqual(receivedPayload?.first?.eventType, .SignalActivation)
+    }
 
     private func microSleep(_ seconds: Double) {
         usleep(useconds_t(Int32(seconds * 1000000)))


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

- Improve EventProcessor to debounce whenever a new event is collected.
- run EventProcessor on main thread for testing (overcome slow CI)

| before | after |
|:------:|:-----:|
| <img width="724" alt="Screenshot 2025-01-20 at 4 35 34 PM" src="https://github.com/user-attachments/assets/13bc5ef6-4e4f-47b5-bf81-a9d1078ee7f6" /> | <img width="730" alt="Screenshot 2025-01-20 at 4 35 40 PM" src="https://github.com/user-attachments/assets/f327fbd6-b6a8-449f-96ca-349dc95cb6ce" /> |

Fixes [([issue](https://rokt.atlassian.net/browse/NI-448))]

### What Has Changed

List out what has changed as a result of this PR.

### How Has This Been Tested?

Describe the tests that you ran to verify your changes.

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
