### PR TITLE
Ni-503 i os failed downloaded image will not remove the margin and padding from view

### DIFF
--- a/Sources/RoktUXHelper/UI/Components/Common/Image/AsyncImageView.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/Image/AsyncImageView.swift
@@ -86,6 +86,8 @@ struct AsyncImageView: View {
     }
 
     func setImageAsInvalid() {
-        isImageValid = false
+        DispatchQueue.background.async {
+            isImageValid = false
+        }
     }
 }

--- a/Tests/RoktUXHelperTests/UI/Components/TestDataImageComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestDataImageComponent.swift
@@ -84,6 +84,20 @@ final class TestDataImageComponent: XCTestCase {
         // test the effect of custom modifier
         let padding = try image.padding()
         XCTAssertEqual(padding, EdgeInsets(top: 18.0, leading: 24.0, bottom: 0.0, trailing: 24.0))
+    }    
+    
+    func test_data_image_failed() throws {
+        let view = TestPlaceHolder(layout: LayoutSchemaViewModel.dataImage(try get_model(isValid: false)))
+        
+        let image = try view.inspect().view(TestPlaceHolder.self)
+            .view(EmbeddedComponent.self)
+            .vStack()[0]
+            .view(LayoutSchemaComponent.self)
+            .view(DataImageViewComponent.self)
+            .actualView()
+            .inspect()
+        // Invalid Image should be removed from view
+        XCTAssertNil(try? image.find(AsyncImageView.self))
     }
     
     func test_dataImage_computedProperties_usesModelProperties() throws {
@@ -114,19 +128,24 @@ final class TestDataImageComponent: XCTestCase {
     }
 #endif
     
-    func get_model() throws -> DataImageViewModel {
-        let transformer = LayoutTransformer(layoutPlugin: get_mock_layout_plugin(slots: [get_slot()]))
-        return try transformer.getDataImage(ModelTestData.DataImageData.dataImage(), slot: get_slot().toSlotOfferModel())
+    func get_model(isValid: Bool = true) throws -> DataImageViewModel {
+        let validImage = "https://docs.rokt.com/assets/images/embedded-placement-1-5ab04a718fe7dda94ac24aa7b89aac92.png"
+        let invalidImage = ""
+        let transformer = LayoutTransformer(layoutPlugin: 
+                                                get_mock_layout_plugin(slots:
+                                                                        [get_slot(image: isValid ? validImage : invalidImage)]))
+        return try transformer.getDataImage(ModelTestData.DataImageData.dataImage(), 
+                                            slot: get_slot(image: isValid ? validImage : invalidImage).toSlotOfferModel())
     }
     
-    func get_slot() -> SlotModel {
+    func get_slot(image: String) -> SlotModel {
         return SlotModel(instanceGuid: "",
                          offer: OfferModel(campaignId: "", creative:
                                             CreativeModel(referralCreativeId: "",
                                                           instanceGuid: "",
                                                           copy: [:],
                                                           images: [
-                                                              "creativeImage": CreativeImage(light: "https://docs.rokt.com/assets/images/embedded-placement-1-5ab04a718fe7dda94ac24aa7b89aac92.png",
+                                                              "creativeImage": CreativeImage(light: image,
                                                                                                    dark: nil, alt: "",
                                                                                                    title: nil)
                                                           ],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

There is a bug that padding or margin of the image remains in the layout if the image failed to download

Fixes [([issue](https://rokt.atlassian.net/browse/NI-503))]

### What Has Changed

* Changed the thread where the image is marked as invalid

### How Has This Been Tested?

The test added.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
