### PR TITLE
NI-504 - fix color mode update

### DIFF
--- a/Sources/RoktUXHelper/UI/Components/ViewModel/RoktEmbeddedViewModel.swift
+++ b/Sources/RoktUXHelper/UI/Components/ViewModel/RoktEmbeddedViewModel.swift
@@ -43,12 +43,12 @@ class RoktEmbeddedViewModel {
     }
 
     func updateAttributedStrings(_ newColor: ColorScheme) {
-        DispatchQueue.main.async { [weak self] in
-            if let layouts = self?.layouts {
+        DispatchQueue.main.async { [config, layouts] in
+            if let layouts = layouts {
                 layouts.forEach { layout in
                     AttributedStringTransformer.convertRichTextHTMLIfExists(
                         uiModel: layout,
-                        config: self?.config,
+                        config: config,
                         colorScheme: newColor
                     )
                 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

Because the `RoktEmbeddedViewModel` doesn't get retained in `OuterLayerComponent` on every redraw the view model gets deallocated with its contents.
When the asynchronous code in `updateAttributedStrings` runs the view model would have been deallocated and it's variables would be `nil`, thus the fix is to capture the layouts array so that it can be accessed when the code block runs.


Fixes [([issue](https://rokt.atlassian.net/browse/NI-504))]

### What Has Changed

List out what has changed as a result of this PR.

### How Has This Been Tested?

Describe the tests that you ran to verify your changes.

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
