### PR TITLE
NI-558 - update size precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- limit view dimensions to 2 decimal places to resolve precision issues. 
+
 ## [0.3.0] - 2025-02-06
 
 ### Changed

--- a/Sources/RoktUXHelper/UI/Components/Common/CGFloat+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/CGFloat+Extension.swift
@@ -13,6 +13,6 @@ import Foundation
 
 extension CGFloat {
     func precised(_ value: Int = 2) -> CGFloat {
-        (self * pow(10.0, CGFloat(value))).rounded()/pow(10.0,CGFloat(value))
+        (self * pow(10.0, CGFloat(value))).rounded()/pow(10.0, CGFloat(value))
     }
 }

--- a/Sources/RoktUXHelper/UI/Components/Common/CGFloat+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/CGFloat+Extension.swift
@@ -1,0 +1,18 @@
+//
+//  CGFloat+extension.swift
+//  RoktUXHelper
+//
+//  Licensed under the Rokt Software Development Kit (SDK) Terms of Use
+//  Version 2.0 (the "License");
+//
+//  You may not use this file except in compliance with the License.
+//
+//  You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
+
+import Foundation
+
+extension CGFloat {
+    func precised(_ value: Int = 2) -> CGFloat {
+        (self * pow(10.0, CGFloat(value))).rounded()/pow(10.0,CGFloat(value))
+    }
+}

--- a/Sources/RoktUXHelper/UI/Components/Common/CGSize+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/CGSize+Extension.swift
@@ -1,0 +1,22 @@
+//
+//  CGSize+extension.swift
+//  RoktUXHelper
+//
+//  Licensed under the Rokt Software Development Kit (SDK) Terms of Use
+//  Version 2.0 (the "License");
+//
+//  You may not use this file except in compliance with the License.
+//
+//  You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
+
+import Foundation
+
+extension CGSize {
+
+    func precised(_ value: Int = 2) -> CGSize {
+        .init(
+            width: width.precised(value),
+            height: height.precised(value)
+        )
+    }
+}

--- a/Sources/RoktUXHelper/UI/Components/Common/View+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/View+Extension.swift
@@ -18,7 +18,7 @@ extension View {
         background(
             GeometryReader { geometryProxy in
                 Color.clear
-                    .preference(key: SizePreferenceKey.self, value: geometryProxy.size)
+                    .preference(key: SizePreferenceKey.self, value: geometryProxy.size.precised())
             }
         )
         .onPreferenceChange(SizePreferenceKey.self) { value in
@@ -49,7 +49,7 @@ extension View {
         background(
             GeometryReader { geometryProxy in
                 Color.clear
-                    .preference(key: SizePreferenceKey.self, value: geometryProxy.size)
+                    .preference(key: SizePreferenceKey.self, value: geometryProxy.size.precised())
             }
         )
         .onPreferenceChange(SizePreferenceKey.self) { value in

--- a/Tests/RoktUXHelperTests/UI/Components/Common/TestCGFloatExtension.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/Common/TestCGFloatExtension.swift
@@ -1,0 +1,31 @@
+//
+//  TestCGFloatExtension.swift
+//  RoktUXHelper
+//
+//  Copyright 2020 Rokt Pte Ltd
+//
+//  Licensed under the Rokt Software Development Kit (SDK) Terms of Use
+//  Version 2.0 (the "License");
+//
+//  You may not use this file except in compliance with the License.
+//
+//  You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
+
+
+import Foundation
+import XCTest
+@testable import RoktUXHelper
+
+class TestCGFloatExtension: XCTestCase {
+
+    func testPrecisionAddition() {
+        let a: CGFloat = 1.923, b: CGFloat = 59.240, c: CGFloat = 61.163
+        XCTAssertEqual((a+b).precised(), c.precised())
+    }
+
+    func testPrecised() {
+        XCTAssertEqual(CGFloat(1.12345).precised(2), 1.12)
+        XCTAssertEqual(CGFloat(1.12345).precised(3), 1.123)
+        XCTAssertEqual(CGFloat(1.12345).precised(4), 1.1235)
+    }
+}

--- a/Tests/RoktUXHelperTests/UI/Components/Common/TestCGSizeExtension.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/Common/TestCGSizeExtension.swift
@@ -1,0 +1,27 @@
+//
+//  TestCGSizeExtension.swift
+//  RoktUXHelper
+//
+//  Copyright 2020 Rokt Pte Ltd
+//
+//  Licensed under the Rokt Software Development Kit (SDK) Terms of Use
+//  Version 2.0 (the "License");
+//
+//  You may not use this file except in compliance with the License.
+//
+//  You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
+
+
+import Foundation
+import XCTest
+@testable import RoktUXHelper
+
+class TestCGSizeExtension: XCTestCase {
+
+    func testPrecised() {
+        let size = CGSize(width: CGFloat(1.12345), height: CGFloat(61.16352))
+        XCTAssertEqual(size.precised(2), .init(width: 1.12, height: 61.16))
+        XCTAssertEqual(size.precised(3), .init(width: 1.123, height: 61.164))
+        XCTAssertEqual(size.precised(4), .init(width: 1.1235, height: 61.1635))
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

We are currently passing around width and height dimensions with really high decimal places, this can lead to precision issues. Lately, we have noticed artefacts such as `onEmbeddedSizeChange` being called back repeatedly as the value bounces between minute changes.

![Screenshot 2025-02-14 at 11 12 37 AM](https://github.com/user-attachments/assets/aa84b6d2-897d-4a01-9a3f-683fc6411a18)

Since there's no benefit to having such high precision, we have decided to limit the view dimensions to 2 decimal places to resolve these precision issues.

| before | after |
|:-------:|:-----:|
| ![Screenshot 2025-02-14 at 10 43 46 AM](https://github.com/user-attachments/assets/c600ed02-cdf1-4fe9-af40-6e2ce1e2eba8) | ![Screenshot 2025-02-14 at 10 47 09 AM](https://github.com/user-attachments/assets/846b2bc6-e3f7-4e08-87cd-d7a3d1d1a947) |

Fixes [([issue](https://rokt.atlassian.net/browse/NI-558))]

### What Has Changed

- update `readSize` modifier to pass 2 decimal places only.

### How Has This Been Tested?


### Notes

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
