### PR TITLE
Ni 570 i os consume data image carousel dcui alpha version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- DataImageCarousel node supported
+
 ### Changed
 
 - Refactored BNF mapping logic to simplify logic
 
 ### Fixed
 
-- limit view dimensions to 2 decimal places to resolve precision issues. 
+- limit view dimensions to 2 decimal places to resolve precision issues.
 
 ## [0.3.0] - 2025-02-06
 
@@ -36,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Replaced *attribute* with *eventData* in the RoktEventRequest
+- Replaced _attribute_ with _eventData_ in the RoktEventRequest
 
 ### Fixed
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ROKT/dcui-swift-schema.git",
       "state" : {
-        "revision" : "9f3d65f75034ad4739e4850653d11df587037f21",
-        "version" : "2.1.0"
+        "revision" : "34b7fba97a03da2b6940a2f2dcda21125e9aba3e",
+        "version" : "2.2.0-alpha2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/ROKT/dcui-swift-schema.git", exact: "2.1.0"),
+        .package(url: "https://github.com/ROKT/dcui-swift-schema.git", exact: "2.2.0-alpha2"),
         .package(url: "https://github.com/nalexn/ViewInspector.git", exact: "0.10.0")
     ],
     targets: [

--- a/Sources/RoktUXHelper/Services/LayoutTransformer/LayoutTransformer.swift
+++ b/Sources/RoktUXHelper/Services/LayoutTransformer/LayoutTransformer.swift
@@ -538,7 +538,7 @@ where CreativeSyntaxMapper.Context == CreativeContext {
         responseKey: String,
         openLinks: LinkOpenTarget?,
         styles: LayoutStyle<CreativeResponseElements,
-        ConditionalStyleTransition<CreativeResponseTransitions, WhenPredicate>>?,
+                            ConditionalStyleTransition<CreativeResponseTransitions, WhenPredicate>>?,
         children: [LayoutSchemaViewModel]?,
         offer: OfferModel
     ) throws -> CreativeResponseViewModel {
@@ -622,6 +622,39 @@ where CreativeSyntaxMapper.Context == CreativeContext {
                                      hoveredStyle: updateStyles.compactMap {$0.hovered},
                                      disabledStyle: updateStyles.compactMap {$0.disabled},
                                      layoutState: layoutState)
+    }
+
+    func getDataImageCarousel(_ imageModel: DataImageCarouselModel<WhenPredicate>,
+                              context: Context) throws -> DataImageCarouselViewModel {
+        var carouselImages: [CreativeImage]?
+        switch context {
+        case .inner(.generic(let offer?)),
+                .inner(.negative(let offer)),
+                .inner(.positive(let offer)):
+            carouselImages = offer.creative.images?.filter { $0.key.contains(imageModel.imageKey) }.compactMap { $0.value }
+        default:
+            throw LayoutTransformerError.InvalidMapping()
+        }
+        let ownStyle = try StyleTransformer.updatedStyles(imageModel.styles?.elements?.own)
+        let indicatorStyle = try StyleTransformer.updatedStyles(imageModel.styles?.elements?.indicator)
+        let seenIndicatorStyle = try StyleTransformer.updatedCarouselIndicatorStyles(
+            indicatorStyle,
+            newStyles: imageModel.styles?.elements?.seenIndicator
+        )
+        // active falls back to seen (which then falls back to indicator)
+        let activeIndicatorStyle = try StyleTransformer.updatedCarouselIndicatorStyles(
+            seenIndicatorStyle,
+            newStyles: imageModel.styles?.elements?.activeIndicator
+        )
+        let progressIndicatorStyle = try StyleTransformer
+            .updatedStyles(imageModel.styles?.elements?.progressIndicatorContainer)
+        return DataImageCarouselViewModel(images: carouselImages,
+                                          ownStyle: ownStyle,
+                                          indicatorStyle: indicatorStyle,
+                                          seenIndicatorStyle: seenIndicatorStyle,
+                                          activeIndicatorStyle: activeIndicatorStyle,
+                                          progressIndicatorContainer: progressIndicatorStyle,
+                                          layoutState: layoutState)
     }
 }
 

--- a/Sources/RoktUXHelper/Services/LayoutTransformer/LayoutTransformer.swift
+++ b/Sources/RoktUXHelper/Services/LayoutTransformer/LayoutTransformer.swift
@@ -195,6 +195,8 @@ where CreativeSyntaxMapper.Context == CreativeContext {
                                                     context: context)
                     )
                 )
+        case .dataImageCarousel(let dataImageCarouselModel):
+                .dataImageCarousel(try getDataImageCarousel(dataImageCarouselModel, context: context))
         }
     }
 
@@ -624,31 +626,33 @@ where CreativeSyntaxMapper.Context == CreativeContext {
                                      layoutState: layoutState)
     }
 
-    func getDataImageCarousel(_ imageModel: DataImageCarouselModel<WhenPredicate>,
+    func getDataImageCarousel(_ dataImageCarouselModel: DataImageCarouselModel<WhenPredicate>,
                               context: Context) throws -> DataImageCarouselViewModel {
         var carouselImages: [CreativeImage]?
         switch context {
         case .inner(.generic(let offer?)),
                 .inner(.negative(let offer)),
                 .inner(.positive(let offer)):
-            carouselImages = offer.creative.images?.filter { $0.key.contains(imageModel.imageKey) }.compactMap { $0.value }
+            carouselImages = offer.creative.images?.filter { $0.key.contains(dataImageCarouselModel.imageKey) }
+                .compactMap { $0.value }
         default:
             throw LayoutTransformerError.InvalidMapping()
         }
-        let ownStyle = try StyleTransformer.updatedStyles(imageModel.styles?.elements?.own)
-        let indicatorStyle = try StyleTransformer.updatedStyles(imageModel.styles?.elements?.indicator)
+        let ownStyle = try StyleTransformer.updatedStyles(dataImageCarouselModel.styles?.elements?.own)
+        let indicatorStyle = try StyleTransformer.updatedStyles(dataImageCarouselModel.styles?.elements?.indicator)
         let seenIndicatorStyle = try StyleTransformer.updatedCarouselIndicatorStyles(
             indicatorStyle,
-            newStyles: imageModel.styles?.elements?.seenIndicator
+            newStyles: dataImageCarouselModel.styles?.elements?.seenIndicator
         )
         // active falls back to seen (which then falls back to indicator)
         let activeIndicatorStyle = try StyleTransformer.updatedCarouselIndicatorStyles(
             seenIndicatorStyle,
-            newStyles: imageModel.styles?.elements?.activeIndicator
+            newStyles: dataImageCarouselModel.styles?.elements?.activeIndicator
         )
         let progressIndicatorStyle = try StyleTransformer
-            .updatedStyles(imageModel.styles?.elements?.progressIndicatorContainer)
+            .updatedStyles(dataImageCarouselModel.styles?.elements?.progressIndicatorContainer)
         return DataImageCarouselViewModel(images: carouselImages,
+                                          duration: dataImageCarouselModel.duration,
                                           ownStyle: ownStyle,
                                           indicatorStyle: indicatorStyle,
                                           seenIndicatorStyle: seenIndicatorStyle,

--- a/Sources/RoktUXHelper/Services/LayoutTransformer/StyleTransformer.swift
+++ b/Sources/RoktUXHelper/Services/LayoutTransformer/StyleTransformer.swift
@@ -155,6 +155,79 @@ struct StyleTransformer {
         return resultStyles
     }
 
+    static func updatedCarouselIndicatorStyles(
+        _ styles: [BasicStateStylingBlock<DataImageCarouselIndicatorStyles>]?,
+        newStyles: [BasicStateStylingBlock<DataImageCarouselIndicatorStyles>]?
+    ) throws -> [BasicStateStylingBlock<DataImageCarouselIndicatorStyles>] {
+        var resultStyles: [BasicStateStylingBlock<DataImageCarouselIndicatorStyles>] = []
+
+        let prefilledStyle = try updatedStyles(styles)
+        let prefilledNewStyle = try updatedStyles(newStyles)
+
+        var styleIndex = 0
+        var newStyleIndex = 0
+
+        var lastDefaultIndicator: BasicStateStylingBlock<DataImageCarouselIndicatorStyles>?
+        var lastNewIndicator: BasicStateStylingBlock<DataImageCarouselIndicatorStyles>?
+
+        var lastDefault: DataImageCarouselIndicatorStyles?
+        var lastPressed: DataImageCarouselIndicatorStyles?
+        var lastHovered: DataImageCarouselIndicatorStyles?
+        var lastDisabled: DataImageCarouselIndicatorStyles?
+
+        while styleIndex < prefilledStyle.count || newStyleIndex < prefilledNewStyle.count {
+
+            if prefilledStyle.count > styleIndex {
+                lastDefaultIndicator = prefilledStyle[styleIndex]
+            }
+
+            if prefilledNewStyle.count > newStyleIndex {
+                lastNewIndicator = prefilledNewStyle[newStyleIndex]
+            }
+
+            if let lastDefaultValue = lastDefault {
+                lastDefault = try updatedStyle(lastDefaultValue, newStyle: lastDefaultIndicator?.default)
+            } else {
+                lastDefault = lastDefaultIndicator?.default
+            }
+            lastDefault = try updatedStyle(lastDefault, newStyle: lastNewIndicator?.default)
+
+            if let lastPressedValue = lastPressed, let pressedStyle = lastDefaultIndicator?.pressed {
+                lastPressed = try updatedStyle(lastPressedValue, newStyle: pressedStyle)
+            } else {
+                lastPressed = lastDefaultIndicator?.pressed
+            }
+            lastPressed = try updatedStyle(lastPressed, newStyle: lastNewIndicator?.pressed)
+
+            if let lastHoveredValue = lastHovered, let hoveredStyle = lastDefaultIndicator?.hovered {
+                lastHovered = try updatedStyle(lastHoveredValue, newStyle: hoveredStyle)
+            } else {
+                lastHovered = lastDefaultIndicator?.hovered
+            }
+            lastHovered = try updatedStyle(lastHovered, newStyle: lastNewIndicator?.hovered)
+
+            if let lastDisabledValue = lastDisabled, let disabledStyle = lastDefaultIndicator?.disabled {
+                lastDisabled = try updatedStyle(lastDisabledValue, newStyle: disabledStyle)
+            } else {
+                lastDisabled = lastDefaultIndicator?.disabled
+            }
+            lastDisabled = try updatedStyle(lastDisabled, newStyle: lastNewIndicator?.disabled)
+
+            guard let lastDefault else { break }
+            resultStyles.append(
+                BasicStateStylingBlock(default: lastDefault,
+                                       pressed: try updatedStyle(lastDefault, newStyle: lastPressed),
+                                       hovered: try updatedStyle(lastDefault, newStyle: lastHovered),
+                                       disabled: try updatedStyle(lastDefault, newStyle: lastDisabled)))
+
+            styleIndex += 1
+            newStyleIndex += 1
+
+        }
+
+        return resultStyles
+    }
+
     static func updatedStyle<T: Codable>(_ defaultStyle: T?,
                                          newStyle: T?) throws -> T? {
         if let defaultStyle = defaultStyle as? StylingPropertiesModel {
@@ -216,6 +289,12 @@ struct StyleTransformer {
             return try getUpdatedStyle(defaultStyle, newStyle: newStyle) as? T
         } else if let defaultStyle = defaultStyle as? ToggleButtonStateTriggerStyle {
             let newStyle = newStyle as? ToggleButtonStateTriggerStyle
+            return try getUpdatedStyle(defaultStyle, newStyle: newStyle) as? T
+        } else if let defaultStyle = defaultStyle as? DataImageCarouselStyles {
+            let newStyle = newStyle as? DataImageCarouselStyles
+            return try getUpdatedStyle(defaultStyle, newStyle: newStyle) as? T
+        } else if let defaultStyle = defaultStyle as? DataImageCarouselIndicatorStyles {
+            let newStyle = newStyle as? DataImageCarouselIndicatorStyles
             return try getUpdatedStyle(defaultStyle, newStyle: newStyle) as? T
         }
         return nil
@@ -536,6 +615,38 @@ struct StyleTransformer {
                                                                          newStyle: newStyle?.flexChild),
                                              spacing: updatedSpacing(defaultStyle?.spacing,
                                                                      newStyle: newStyle?.spacing))
+    }
+
+    static func getUpdatedStyle(_ defaultStyle: DataImageCarouselStyles?,
+                                newStyle: DataImageCarouselStyles?) throws -> DataImageCarouselStyles {
+        return DataImageCarouselStyles(container: try updatedContainer(defaultStyle?.container,
+                                                                       newStyle: newStyle?.container),
+                                       background: try updatedBackground(defaultStyle?.background,
+                                                                         newStyle: newStyle?.background),
+                                       border: try updatedBorder(defaultStyle?.border,
+                                                                 newStyle: newStyle?.border),
+                                       dimension: updatedDimension(defaultStyle?.dimension,
+                                                                   newStyle: newStyle?.dimension),
+                                       flexChild: updatedFlexChild(defaultStyle?.flexChild,
+                                                                   newStyle: newStyle?.flexChild),
+                                       spacing: updatedSpacing(defaultStyle?.spacing,
+                                                               newStyle: newStyle?.spacing))
+    }
+
+    static func getUpdatedStyle(_ defaultStyle: DataImageCarouselIndicatorStyles?,
+                                newStyle: DataImageCarouselIndicatorStyles?) throws -> DataImageCarouselIndicatorStyles {
+        return DataImageCarouselIndicatorStyles(container: try updatedContainer(defaultStyle?.container,
+                                                                                newStyle: newStyle?.container),
+                                                background: try updatedBackground(defaultStyle?.background,
+                                                                                  newStyle: newStyle?.background),
+                                                border: try updatedBorder(defaultStyle?.border,
+                                                                          newStyle: newStyle?.border),
+                                                dimension: updatedDimension(defaultStyle?.dimension,
+                                                                            newStyle: newStyle?.dimension),
+                                                flexChild: updatedFlexChild(defaultStyle?.flexChild,
+                                                                            newStyle: newStyle?.flexChild),
+                                                spacing: updatedSpacing(defaultStyle?.spacing,
+                                                                        newStyle: newStyle?.spacing))
     }
 
     // MARK: Styling properties

--- a/Sources/RoktUXHelper/UI/Components/DataImageCarouselComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/DataImageCarouselComponent.swift
@@ -1,0 +1,32 @@
+//
+//  DataImageCarouselComponent.swift
+//  RoktUXHelper
+//
+//  Copyright 2020 Rokt Pte Ltd
+//
+//  Licensed under the Rokt Software Development Kit (SDK) Terms of Use
+//  Version 2.0 (the "License");
+//
+//  You may not use this file except in compliance with the License.
+//
+//  You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
+
+import SwiftUI
+import Combine
+import DcuiSchema
+
+@available(iOS 15, *)
+struct DataImageCarouselComponent: View {
+    let config: ComponentConfig
+    let model: DataImageCarouselViewModel
+
+    @Binding var parentWidth: CGFloat?
+    @Binding var parentHeight: CGFloat?
+    @Binding var styleState: StyleState
+
+    let parentOverride: ComponentParentOverride?
+
+    var body: some View {
+        EmptyView()
+    }
+}

--- a/Sources/RoktUXHelper/UI/Components/LayoutSchemaComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/LayoutSchemaComponent.swift
@@ -174,6 +174,13 @@ struct LayoutSchemaComponent: View {
                                   parentWidth: $parentWidth,
                                   parentHeight: $parentHeight,
                                   parentOverride: parentOverride)
+        case .dataImageCarousel(let dataImageCarouselModel):
+            DataImageCarouselComponent(config: config,
+                                       model: dataImageCarouselModel,
+                                       parentWidth: $parentWidth,
+                                       parentHeight: $parentHeight,
+                                       styleState: $styleState,
+                                       parentOverride: parentOverride)
         default:
             EmptyView()
         }

--- a/Sources/RoktUXHelper/UI/Components/ViewModel/DataImageCarouselViewModel.swift
+++ b/Sources/RoktUXHelper/UI/Components/ViewModel/DataImageCarouselViewModel.swift
@@ -1,0 +1,55 @@
+//
+//  DataImageCarouselViewModel.swift
+//  RoktUXHelper
+//
+//  Copyright 2020 Rokt Pte Ltd
+//
+//  Licensed under the Rokt Software Development Kit (SDK) Terms of Use
+//  Version 2.0 (the "License");
+//
+//  You may not use this file except in compliance with the License.
+//
+//  You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
+
+import Foundation
+import DcuiSchema
+
+@available(iOS 15, *)
+class DataImageCarouselViewModel: Hashable, Identifiable, ObservableObject, ScreenSizeAdaptive {
+    let id: UUID = UUID()
+
+    let images: [CreativeImage]?
+    let defaultStyle: [DataImageCarouselStyles]?
+    let pressedStyle: [DataImageCarouselStyles]?
+    let hoveredStyle: [DataImageCarouselStyles]?
+    let disabledStyle: [DataImageCarouselStyles]?
+
+    let indicatorStyle: [BasicStateStylingBlock<DataImageCarouselIndicatorStyles>]?
+    let seenIndicatorStyle: [BasicStateStylingBlock<DataImageCarouselIndicatorStyles>]?
+    let activeIndicatorStyle: [BasicStateStylingBlock<DataImageCarouselIndicatorStyles>]?
+    let progressIndicatorContainer: [BasicStateStylingBlock<DataImageCarouselIndicatorStyles>]?
+
+    weak var layoutState: (any LayoutStateRepresenting)?
+    var imageLoader: RoktUXImageLoader? {
+        layoutState?.imageLoader
+    }
+
+    init(images: [CreativeImage]?,
+         ownStyle: [BasicStateStylingBlock<DataImageCarouselStyles>]?,
+         indicatorStyle: [BasicStateStylingBlock<DataImageCarouselIndicatorStyles>]?,
+         seenIndicatorStyle: [BasicStateStylingBlock<DataImageCarouselIndicatorStyles>]?,
+         activeIndicatorStyle: [BasicStateStylingBlock<DataImageCarouselIndicatorStyles>]?,
+         progressIndicatorContainer: [BasicStateStylingBlock<DataImageCarouselIndicatorStyles>]?,
+         layoutState: (any LayoutStateRepresenting)?) {
+        self.images = images
+        self.defaultStyle = ownStyle?.compactMap {$0.default}
+        self.pressedStyle = ownStyle?.compactMap {$0.pressed}
+        self.hoveredStyle = ownStyle?.compactMap {$0.hovered}
+        self.disabledStyle = ownStyle?.compactMap {$0.disabled}
+        self.indicatorStyle = indicatorStyle
+        self.seenIndicatorStyle = seenIndicatorStyle
+        self.activeIndicatorStyle = activeIndicatorStyle
+        self.progressIndicatorContainer = progressIndicatorContainer
+        self.layoutState = layoutState
+    }
+}

--- a/Sources/RoktUXHelper/UI/Components/ViewModel/DataImageCarouselViewModel.swift
+++ b/Sources/RoktUXHelper/UI/Components/ViewModel/DataImageCarouselViewModel.swift
@@ -19,6 +19,7 @@ class DataImageCarouselViewModel: Hashable, Identifiable, ObservableObject, Scre
     let id: UUID = UUID()
 
     let images: [CreativeImage]?
+    let duration: Int32
     let defaultStyle: [DataImageCarouselStyles]?
     let pressedStyle: [DataImageCarouselStyles]?
     let hoveredStyle: [DataImageCarouselStyles]?
@@ -35,6 +36,7 @@ class DataImageCarouselViewModel: Hashable, Identifiable, ObservableObject, Scre
     }
 
     init(images: [CreativeImage]?,
+         duration: Int32,
          ownStyle: [BasicStateStylingBlock<DataImageCarouselStyles>]?,
          indicatorStyle: [BasicStateStylingBlock<DataImageCarouselIndicatorStyles>]?,
          seenIndicatorStyle: [BasicStateStylingBlock<DataImageCarouselIndicatorStyles>]?,
@@ -42,6 +44,7 @@ class DataImageCarouselViewModel: Hashable, Identifiable, ObservableObject, Scre
          progressIndicatorContainer: [BasicStateStylingBlock<DataImageCarouselIndicatorStyles>]?,
          layoutState: (any LayoutStateRepresenting)?) {
         self.images = images
+        self.duration = duration
         self.defaultStyle = ownStyle?.compactMap {$0.default}
         self.pressedStyle = ownStyle?.compactMap {$0.pressed}
         self.hoveredStyle = ownStyle?.compactMap {$0.hovered}

--- a/Sources/RoktUXHelper/UI/Components/ViewModel/LayoutSchemaViewModel.swift
+++ b/Sources/RoktUXHelper/UI/Components/ViewModel/LayoutSchemaViewModel.swift
@@ -37,6 +37,7 @@ enum LayoutSchemaViewModel: Hashable {
     case staticLink(StaticLinkViewModel)
     case progressControl(ProgressControlViewModel)
     case toggleButton(ToggleButtonViewModel)
+    case dataImageCarousel(DataImageCarouselViewModel)
     case empty
 
     static func == (lhs: LayoutSchemaViewModel, rhs: LayoutSchemaViewModel) -> Bool {
@@ -78,6 +79,8 @@ enum LayoutSchemaViewModel: Hashable {
         case (.progressControl(let lhsModel), .progressControl(let rhsModel)):
             return lhsModel == rhsModel
         case (.toggleButton(let lhsModel), .toggleButton(let rhsModel)):
+            return lhsModel == rhsModel
+        case (.dataImageCarousel(let lhsModel), .dataImageCarousel(let rhsModel)):
             return lhsModel == rhsModel
         case (.empty, .empty):
             return true

--- a/Tests/RoktUXHelperTests/Data/Model/ModelTestData.swift
+++ b/Tests/RoktUXHelperTests/Data/Model/ModelTestData.swift
@@ -202,6 +202,13 @@ class ModelTestData: NSObject {
         }
     }
     
+    enum DataImageCarouselData {
+        static func dataImageCarousel() -> DataImageCarouselModel<WhenPredicate> {
+            let data = toData(jsonFilename: "node_data_image_carousel")
+            return try! JSONDecoder().decode(DataImageCarouselModel.self, from: data)
+        }
+    }
+
     enum StaticImageData {
         static func staticImage() -> StaticImageModel<WhenPredicate> {
             let data = toData(jsonFilename: "node_static_image")

--- a/Tests/RoktUXHelperTests/Services/LayoutTransformer/TestStyleTransformer.swift
+++ b/Tests/RoktUXHelperTests/Services/LayoutTransformer/TestStyleTransformer.swift
@@ -587,4 +587,85 @@ final class TestStyleTransformer: XCTestCase {
         // Assert
         XCTAssertThrowsError(try StyleTransformer.getUpdatedStyle(defaultStyle, newStyle: nil))
     }
+
+    func test_get_updated_carousel_indicator_styles() throws {
+        // Arrange
+        let defaultStyle = DataImageCarouselIndicatorStyles(container: nil,
+                                                            background: nil,
+                                                            border: nil,
+                                                            dimension: nil,
+                                                            flexChild: nil,
+                                                            spacing: SpacingStylingProperties(padding: "0",
+                                                                                              margin: nil,
+                                                                                              offset: nil))
+
+        let activeStyle = DataImageCarouselIndicatorStyles(container: nil,
+                                                           background: nil,
+                                                           border: nil,
+                                                           dimension: nil,
+                                                           flexChild: nil,
+                                                           spacing: SpacingStylingProperties(padding: nil,
+                                                                                             margin: "1",
+                                                                                             offset: nil))
+
+        let indicator = [BasicStateStylingBlock(default: defaultStyle, pressed: nil, hovered: nil, disabled: nil)]
+        let active = [BasicStateStylingBlock(default: activeStyle, pressed: nil, hovered: nil, disabled: nil)]
+
+        // ACT
+        let transformedStyle = try StyleTransformer.updatedCarouselIndicatorStyles(indicator, newStyles: active)
+
+        // Assert
+        XCTAssertEqual(transformedStyle.first?.default.spacing?.margin, "1")
+        XCTAssertEqual(transformedStyle.first?.default.spacing?.padding, "0")
+    }
+
+    func test_get_updated_carousel_indicator_styles_with_breakpoints() throws {
+        // Arrange
+        let defaultStyle1 = DataImageCarouselIndicatorStyles(container: nil,
+                                                             background: nil,
+                                                             border: nil,
+                                                             dimension: nil,
+                                                             flexChild: nil,
+                                                             spacing: SpacingStylingProperties(padding: "0",
+                                                                                               margin: nil,
+                                                                                               offset: nil))
+
+        let backgroundColor = ThemeColor(light: "#000000", dark: nil)
+        let pressedStyle1 = DataImageCarouselIndicatorStyles(container: nil,
+                                                             background: BackgroundStylingProperties(backgroundColor: backgroundColor,
+                                                                                                     backgroundImage: nil),
+                                                             border: nil,
+                                                             dimension: nil,
+                                                             flexChild: nil,
+                                                             spacing: nil)
+
+        let defaultStyle2 = DataImageCarouselIndicatorStyles(container: nil,
+                                                             background: nil,
+                                                             border: nil,
+                                                             dimension: nil,
+                                                             flexChild: nil,
+                                                             spacing: nil)
+
+        let activeStyle1 = DataImageCarouselIndicatorStyles(container: nil,
+                                                            background: nil,
+                                                            border: nil,
+                                                            dimension: nil,
+                                                            flexChild: nil,
+                                                            spacing: SpacingStylingProperties(padding: nil,
+                                                                                              margin: "1",
+                                                                                              offset: nil))
+
+        let indicator = [BasicStateStylingBlock(default: defaultStyle1, pressed: pressedStyle1, hovered: nil, disabled: nil),
+                         BasicStateStylingBlock(default: defaultStyle2, pressed: nil, hovered: nil, disabled: nil)]
+        let active = [BasicStateStylingBlock(default: activeStyle1, pressed: nil, hovered: nil, disabled: nil)]
+
+        // ACT
+        let transformedStyle = try StyleTransformer.updatedCarouselIndicatorStyles(indicator, newStyles: active)
+
+        // Assert
+        // Check the second breakpoint
+        XCTAssertEqual(transformedStyle[1].pressed?.spacing?.margin, "1")
+        XCTAssertEqual(transformedStyle[1].pressed?.spacing?.padding, "0")
+        XCTAssertEqual(transformedStyle[1].pressed?.background?.backgroundColor, backgroundColor)
+    }
 }

--- a/Tests/RoktUXHelperTests/Supporting Files/DataImageCarousel/node_data_image_carousel.json
+++ b/Tests/RoktUXHelperTests/Supporting Files/DataImageCarousel/node_data_image_carousel.json
@@ -1,0 +1,14 @@
+{
+    "type": "DataImageCarousel",
+    "imageKey": "creativeCarouselImageVertical",
+    "duration": 3000,
+    "style": {
+        "elements": {
+            "own": {},
+            "indicator": {},
+            "activeIndicator": {},
+            "seenIndicator": {},
+            "progressIndicatorContainer": {}
+        }
+    }
+}

--- a/Tests/RoktUXHelperTests/UI/Components/TestImageCarouselComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestImageCarouselComponent.swift
@@ -1,0 +1,85 @@
+//
+//  TestImageCarouselComponent.swift
+//  RoktUXHelper
+//
+//  Copyright 2020 Rokt Pte Ltd
+//
+//  Licensed under the Rokt Software Development Kit (SDK) Terms of Use
+//  Version 2.0 (the "License");
+//
+//  You may not use this file except in compliance with the License.
+//
+//  You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
+
+import XCTest
+import SwiftUI
+import ViewInspector
+@testable import RoktUXHelper
+import DcuiSchema
+
+@available(iOS 15.0, *)
+final class TestImageCarouselComponent: XCTestCase {
+#if compiler(>=6)
+    func test_data_image() throws {
+        let view = TestPlaceHolder(layout: LayoutSchemaViewModel.dataImageCarousel(try get_model()))
+
+        let image = try view.inspect().find(TestPlaceHolder.self)
+            .find(EmbeddedComponent.self)
+            .find(ViewType.VStack.self)[0]
+            .find(LayoutSchemaComponent.self)
+            .find(DataImageCarouselComponent.self)
+
+        XCTAssertNotNil(image)
+    }
+#else
+    func test_data_image() throws {
+        let view = TestPlaceHolder(layout: LayoutSchemaViewModel.dataImageCarousel(try get_model()))
+
+        let image = try view.inspect().view(TestPlaceHolder.self)
+            .view(EmbeddedComponent.self)
+            .vStack()[0]
+            .view(LayoutSchemaComponent.self)
+            .view(DataImageCarouselComponent.self)
+            .actualView()
+
+        XCTAssertNotNil(image)
+    }
+#endif
+
+    func get_model() throws -> DataImageCarouselViewModel {
+
+        let transformer = LayoutTransformer(
+            layoutPlugin: get_mock_layout_plugin(slots: [get_slot()])
+        )
+        return try transformer.getDataImageCarousel(
+            ModelTestData.DataImageCarouselData.dataImageCarousel(),
+            context: .inner(.generic(get_slot().offer!))
+        )
+    }
+
+    func get_slot() -> SlotModel {
+        let image = "https://docs.rokt.com/assets/images/embedded-placement-1-5ab04a718fe7dda94ac24aa7b89aac92.png"
+        return SlotModel(instanceGuid: "",
+                         offer: OfferModel(campaignId: "", creative:
+                                            CreativeModel(referralCreativeId: "",
+                                                          instanceGuid: "",
+                                                          copy: [:],
+                                                          images: [
+                                                              "creativeCarouselImageVertical.1": CreativeImage(
+                                                                light: image,
+                                                                dark: nil, alt: "",
+                                                                title: nil
+                                                            ),
+                                                              "creativeCarouselImageVertical.2": CreativeImage(
+                                                                light: image,
+                                                                dark: nil, alt: "",
+                                                                title: nil
+                                                            )
+                                                          ],
+                                                          links: nil,
+                                                          responseOptionsMap: nil,
+                                                          jwtToken: "creative-token")),
+                         layoutVariant: nil,
+                         jwtToken: "slot-token")
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

Need to consume the DCUI 2.2.0-alpha2 with new node DataImageCarousel

Fixes [([issue](https://rokt.atlassian.net/browse/NI-570))]

### What Has Changed

* DCUI schema updated
* LayoutTransformer updated to support the new node
* StyleTransformer update to support new styles
* Empty DataImageCarousel created

### How Has This Been Tested?

Unit test added.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
