### PR TITLE
LAYOUT-2195 - Implement URL Passthrough option for OpenLinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
 - DataImageCarousel node supported
+- `Passthrough` support in `LinkOpenTarget`
 
 ### Changed
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ROKT/dcui-swift-schema.git",
       "state" : {
-        "revision" : "34b7fba97a03da2b6940a2f2dcda21125e9aba3e",
-        "version" : "2.2.0-alpha2"
+        "revision" : "abbd24409c5ff4185c43e61d61e54f129a622797",
+        "version" : "2.2.0-alpha3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/ROKT/dcui-swift-schema.git", exact: "2.2.0-alpha2"),
+        .package(url: "https://github.com/ROKT/dcui-swift-schema.git", exact: "2.2.0-alpha3"),
         .package(url: "https://github.com/nalexn/ViewInspector.git", exact: "0.10.0")
     ],
     targets: [

--- a/Sources/RoktUXHelper/Data/Model/Event/RoktUXEvent.swift
+++ b/Sources/RoktUXHelper/Data/Model/Event/RoktUXEvent.swift
@@ -115,6 +115,7 @@ public class RoktUXEvent {
     public class OpenUrl: RoktUXEvent {
         public let url: String
         public let id: String
+        public let layoutId: String?
         public let type: RoktUXOpenURLType
         public let onClose: ((String) -> Void)?
         public let onError: ((String, Error?) -> Void)?
@@ -123,16 +124,19 @@ public class RoktUXEvent {
         /// - Parameters:
         ///   - url: The URL to open.
         ///   - id: The identifier associated with the URL.
+        ///   - layoutId: The identifier of the layout.
         ///   - type: The type of the URL.
         ///   - onClose: Closure to handle URL close event.
         ///   - onError: Closure to handle URL error event.
         init(url: String,
              id: String,
+             layoutId: String?,
              type: RoktUXOpenURLType,
              onClose: @escaping (String) -> Void,
              onError: @escaping (String, Error?) -> Void) {
             self.url = url
             self.id = id
+            self.layoutId = layoutId
             self.type = type
             self.onClose = onClose
             self.onError = onError

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/RoktUXOpenURLType.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/RoktUXOpenURLType.swift
@@ -15,15 +15,18 @@ import DcuiSchema
 /// This enum defines whether to open a URL using an internal browser or delegate the task to the device's external browser.
 /// - `internally`: Opens the URL within the app's internal browser, typically for in-app web view use cases.
 /// - `externally`: Opens the URL using the device's default external browser, like Safari or Chrome.
-public enum RoktUXOpenURLType {
+/// - `passthrough`: Send the event to the consumer to handle the URL.
+public enum RoktUXOpenURLType: Equatable {
     case `internally`(sessionId: String?)
     case externally
+    case passthrough
 
     init(_ linkOpenTarget: LinkOpenTarget?, sessionId: String? = nil) {
         switch linkOpenTarget {
-        case .externally,
-             .passthrough:
+        case .externally:
             self = .externally
+        case .passthrough:
+            self = .passthrough
         default:
             self = .internally(sessionId: sessionId)
         }

--- a/Sources/RoktUXHelper/RoktUX.swift
+++ b/Sources/RoktUXHelper/RoktUX.swift
@@ -508,9 +508,10 @@ public class RoktUX: UXEventsDelegate {
 
     func openURL(url: String,
                  id: String,
+                 layoutId: String?,
                  type: RoktUXOpenURLType,
                  onClose: @escaping (String) -> Void,
                  onError: @escaping (String, Error?) -> Void) {
-        onRoktEvent?(RoktUXEvent.OpenUrl(url: url, id: id, type: type, onClose: onClose, onError: onError))
+        onRoktEvent?(RoktUXEvent.OpenUrl(url: url, id: id, layoutId: layoutId, type: type, onClose: onClose, onError: onError))
     }
 }

--- a/Sources/RoktUXHelper/Services/Events/EventService.swift
+++ b/Sources/RoktUXHelper/Services/Events/EventService.swift
@@ -157,7 +157,7 @@ class EventService: Hashable, EventDiagnosticServicing {
     func openURL(url: URL, type: RoktUXOpenURLType, completionHandler: @escaping () -> Void) {
         canOpenUrl(url)
         let id = UUID().uuidString
-        uxEventDelegate?.openURL(url: url.absoluteString, id: id, type: type, onClose: { incomingId in
+        uxEventDelegate?.openURL(url: url.absoluteString, id: id, layoutId: pluginId, type: type, onClose: { incomingId in
             if id == incomingId {
                 completionHandler()
             }

--- a/Sources/RoktUXHelper/Services/UXEventsDelegate.swift
+++ b/Sources/RoktUXHelper/Services/UXEventsDelegate.swift
@@ -27,6 +27,7 @@ protocol UXEventsDelegate: AnyObject {
     )
     func openURL(url: String,
                  id: String,
+                 layoutId: String?,
                  type: RoktUXOpenURLType,
                  onClose: @escaping (String) -> Void,
                  onError: @escaping (String, Error?) -> Void)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

Add `Passthrough` support in `OpenLinks`

Fixes [LAYOUT-2195](https://rokt.atlassian.net/browse/LAYOUT-2195)

### What Has Changed

* Update schema version to "2.2.0-alpha3"
* Added Passthrough as an option to the OpenLinks and RoktUXOpenURLType.
* Update `OpenUrl` UXEvent to include `layoutId`
* Add unit tests

### How Has This Been Tested?

Added unit tests

### Notes

The PR target is `workstation/dataImageCarousel` as the schema version is dependent on that 

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
