### PR TITLE
LAYOUT-2267 - Add user interaction as a proxy for SignalViewed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Refactored BNF mapping logic to simplify logic
+- Enhanced offer viewed signals
 
 ## [0.3.1] - 2025-02-27
 

--- a/Sources/RoktUXHelper/UI/Components/CarouselComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/CarouselComponent.swift
@@ -256,6 +256,9 @@ struct CarouselComponent: View {
                 .onBecomingViewed {
                     model.sendCreativeViewedEvent(currentOffer: childIndex)
                 }
+                .onUserInteraction {
+                    model.sendCreativeViewedEvent(currentOffer: childIndex)
+                }
             }
         }
     }

--- a/Sources/RoktUXHelper/UI/Components/GroupedDistributionComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/GroupedDistributionComponent.swift
@@ -207,6 +207,9 @@ struct GroupedDistributionComponent: View {
                     .onBecomingViewed {
                         model.sendCreativeViewedEvent(currentOffer: childIndex)
                     }
+                    .onUserInteraction {
+                        model.sendCreativeViewedEvent(currentOffer: childIndex)
+                    }
                 }
             }
 

--- a/Sources/RoktUXHelper/UI/Components/OneByOneComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/OneByOneComponent.swift
@@ -149,6 +149,9 @@ struct OneByOneComponent: View {
                 .onBecomingViewed(currentOffer: currentOffer) {
                     model.sendCreativeViewedEvent(currentOffer: currentOffer)
                 }
+                .onUserInteraction {
+                    model.sendCreativeViewedEvent(currentOffer: currentOffer)
+                }
             }
             .accessibilityElement(children: .contain)
             .accessibilityFocused($shouldFocusAccessibility)

--- a/Sources/RoktUXHelper/UI/Components/Style/StyleComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/Style/StyleComponent.swift
@@ -267,6 +267,10 @@ internal extension View {
     func onFirstTouch(perform action: (() -> Void)? = nil) -> some View {
         modifier(FirstTouchModifier(perform: action))
     }
+    
+    func onUserInteraction(perform action: (() -> Void)? = nil) -> some View {
+        modifier(UserInteractionModifier(perform: action))
+    }
 
     // return type must be `Alignment` since Width/Height uses the axis-independent type in `frame`
     func rowPrimaryAxisAlignment(justifyContent: FlexJustification?) -> Alignment {
@@ -657,6 +661,24 @@ struct FirstTouchModifier: ViewModifier {
                     loaded = true
                     action?()
                 }
+            })
+        )
+    }
+}
+
+@available(iOS 15, *)
+struct UserInteractionModifier: ViewModifier {
+    
+    private let action: (() -> Void)?
+    
+    init(perform action: (() -> Void)? = nil) {
+        self.action = action
+    }
+    
+    func body(content: Content) -> some View {
+        content.simultaneousGesture(
+            TapGesture().onEnded({
+                action?()
             })
         )
     }


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -->

### Background

Implement user interaction as a proxy for SignalViewed to track user engagement with offer components.

Fixes [LAYOUT-2267](https://rokt.atlassian.net/browse/LAYOUT-2267)

### What Has Changed

Add modifiers to offer components and trigger signal viewed

### How Has This Been Tested?

Tested locally with logs added.

### Notes

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
