### PR TITLE
fix when component

### DIFF
--- a/Sources/RoktUXHelper/UI/Components/WhenComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/WhenComponent.swift
@@ -39,6 +39,17 @@ struct WhenComponent: View {
         toggleTransition ? 1 : 0
     }
 
+    private var shouldApply: Bool {
+        model.shouldApply(
+            WhenComponentUIState(
+                currentProgress: currentProgress,
+                totalOffers: totalOffers,
+                position: config.position,
+                width: globalScreenSize.width ?? 0,
+                isDarkMode: colorScheme == .dark,
+                customStateMap: customStateMap))
+    }
+
     init(
         config: ComponentConfig,
         model: WhenViewModel,
@@ -63,12 +74,12 @@ struct WhenComponent: View {
 
     var body: some View {
         Group {
-            if visible == true || model.shouldApply() {
+            if visible == true || shouldApply {
                 buildComponent()
             }
         }
         .opacity(getOpacity)
-        .onChange(of: model.animate) { newValue in
+        .onChange(of: shouldApply) { newValue in
             if newValue {
                 transitionIn()
             } else {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

I am not able to read binded state updates such as items["currentProgress"] unless it is attached to a swiftUI view, so I have to revert WhenComponent's implementation to use the view's state variables rather than accessing it directly from the LayoutState items dictionary.


### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
