### PR TITLE
fix hide indicator if no images in dark mode

### DIFF
--- a/Sources/RoktUXHelper/UI/Components/DataImageCarouselComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/DataImageCarouselComponent.swift
@@ -112,8 +112,7 @@ struct DataImageCarouselComponent: View {
                         .opacity(index < opacities.count ? opacities[index] : 0)
                 }
 
-                // Custom progress indicator to be implemented separately
-                if model.images.count > 1 {
+                if model.requiresIndicator(colorScheme) {
                     ImageCarouselIndicator(
                         config: config,
                         model: model.indicatorViewModel,

--- a/Sources/RoktUXHelper/UI/Components/ViewModel/DataImageCarouselViewModel.swift
+++ b/Sources/RoktUXHelper/UI/Components/ViewModel/DataImageCarouselViewModel.swift
@@ -13,6 +13,7 @@
 
 import Foundation
 import DcuiSchema
+import SwiftUI
 
 @available(iOS 15, *)
 class DataImageCarouselViewModel: Hashable, Identifiable, ObservableObject, ScreenSizeAdaptive {
@@ -84,8 +85,8 @@ class DataImageCarouselViewModel: Hashable, Identifiable, ObservableObject, Scre
             guard let self else { return }
             timer?.invalidate()
             currentProgress = 1
-            timer = Timer.scheduledTimer(withTimeInterval: TimeInterval(duration)/1000.0, repeats: true) { [weak self] _ in
-                guard let self else { return }
+            timer = Timer.scheduledTimer(withTimeInterval: TimeInterval(duration)/1000.0, repeats: true) { [weak self] timer in
+                guard let self, timer.isValid else { return }
                 incrementStateMap()
             }
         }
@@ -97,6 +98,13 @@ class DataImageCarouselViewModel: Hashable, Identifiable, ObservableObject, Scre
             guard let self else { return }
             timer?.invalidate()
         }
+    }
+
+    func requiresIndicator(_ colorScheme: ColorScheme) -> Bool {
+        images.filter {
+            ($0.light?.isEmpty == false && colorScheme == .light) ||
+            ($0.dark?.isEmpty == false && colorScheme == .dark)
+        }.count > 1
     }
 
     private func incrementStateMap() {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

- add an additional check for images corresponding to the color scheme of the app.
- only show indicator if image is loaded.

| before | after |
|:------:|:------:|
| ![Simulator Screenshot - iPhone 16 Pro - 2025-04-01 at 14 19 57](https://github.com/user-attachments/assets/e0cf017b-36cf-4555-87c0-7a7a7810754a) | ![Simulator Screenshot - iPhone 15 Pro - 2025-04-01 at 14 20 00](https://github.com/user-attachments/assets/e5c4c900-68b0-4985-b695-f72b0716c7e9) | 

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
