### PR TITLE
fix rowComponent to use ObservedObject

### DIFF
--- a/Sources/RoktUXHelper/UI/Components/RowComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/RowComponent.swift
@@ -41,7 +41,7 @@ struct RowComponent: View {
     var backgroundStyle: BackgroundStylingProperties? { (currentStyle ?? style)?.background }
 
     let config: ComponentConfig
-    @StateObject var model: RowViewModel
+    @ObservedObject var model: RowViewModel
 
     @Binding var parentWidth: CGFloat?
     @Binding var parentHeight: CGFloat?

--- a/Sources/RoktUXHelper/UI/Components/WhenComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/WhenComponent.swift
@@ -15,7 +15,7 @@ import Combine
 @available(iOS 15, *)
 struct WhenComponent: View {
     let config: ComponentConfig
-    @StateObject private var model: WhenViewModel
+    @ObservedObject private var model: WhenViewModel
 
     @Binding var parentWidth: CGFloat?
     @Binding var parentHeight: CGFloat?
@@ -59,7 +59,7 @@ struct WhenComponent: View {
         parentOverride: ComponentParentOverride?
     ) {
         self.config = config
-        self._model = StateObject(wrappedValue: model)
+        self._model = ObservedObject(wrappedValue: model)
 
         _parentWidth = parentWidth
         _parentHeight = parentHeight


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background
since we are injecting the View Models from the parent we should use ObservedObject.


### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated CHANGELOG.md relevant notes.
