### PR TITLE
NI-552 - consume event data from api

### DIFF
--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/RoktUXEventData.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/RoktUXEventData.swift
@@ -1,0 +1,16 @@
+//
+//  RoktUXEventData.swift
+//  
+//
+//  Licensed under the Rokt Software Development Kit (SDK) Terms of Use
+//  Version 2.0 (the "License");
+//
+//  You may not use this file except in compliance with the License.
+//
+//  You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
+
+import Foundation
+
+public struct RoktUXEventData: Codable {
+    public let events: [String: RoktUXRealTimeEvent]?
+}

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/RoktUXExperienceResponse.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/RoktUXExperienceResponse.swift
@@ -32,12 +32,12 @@ public class RoktUXExperienceResponse: RoktUXPlacementResponse, PluginResponse {
         guard let outerLayer = getOuterLayoutSchema(plugins: plugins),
               outerLayer.layout != nil && getAllInnerlayoutSchema(plugins: plugins) != nil
         else { return nil }
-
         return RoktUXPageModel(
             pageId: page?.pageId,
             sessionId: sessionId,
             pageInstanceGuid: placementContext.pageInstanceGuid,
             layoutPlugins: getPlugins(plugins: plugins),
+            eventData: eventData,
             token: placementContext.placementContextJWTToken,
             options: .some([.useDiagnosticEvents])
         )

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/RoktUXPageModel.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/RoktUXPageModel.swift
@@ -17,6 +17,7 @@ public struct RoktUXPageModel {
     public let sessionId: String
     public let pageInstanceGuid: String
     public let layoutPlugins: [LayoutPlugin]?
+    public let eventData: [String: RoktUXEventData]?
     var startDate: Date = Date()
     var responseReceivedDate: Date = Date()
     let token: String

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/RoktUXPlacementResponse.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/RoktUXPlacementResponse.swift
@@ -19,8 +19,10 @@ public class RoktUXPlacementResponse: Decodable {
     public let placements: [RoktUXPlacement]
     // outermost `token`
     public let responseJWTToken: String
+    public let eventData: [String: RoktUXEventData]?
 
     enum CodingKeys: String, CodingKey {
+        case eventData
         case sessionId
         case page
         case placementContext
@@ -36,5 +38,6 @@ public class RoktUXPlacementResponse: Decodable {
         placementContext = try container.decode(RoktUXPlacementContext.self, forKey: .placementContext)
         placements = try container.decode([RoktUXPlacement].self, forKey: .placements)
         responseJWTToken = try container.decode(String.self, forKey: .responseJWTToken)
+        eventData = try? container.decode([String: RoktUXEventData].self, forKey: .eventData)
     }
 }

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/RoktUXRealTimeEvent.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/RoktUXRealTimeEvent.swift
@@ -1,0 +1,24 @@
+//
+//  RoktUXRealTimeEvent.swift
+//
+//
+//  Licensed under the Rokt Software Development Kit (SDK) Terms of Use
+//  Version 2.0 (the "License");
+//
+//  You may not use this file except in compliance with the License.
+//
+//  You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
+
+import Foundation
+
+public struct RoktUXRealTimeEvent: Codable, Hashable {
+    public let instanceGuid: String?
+    public let eventType: String?
+    public let payload: String?
+
+    public init(instanceGuid: String?, eventType: String?, payload: String?) {
+        self.instanceGuid = instanceGuid
+        self.eventType = eventType
+        self.payload = payload
+    }
+}

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/RoktUXS2SExperienceResponse.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/RoktUXS2SExperienceResponse.swift
@@ -45,6 +45,7 @@ public class RoktUXS2SExperienceResponse: Decodable, PluginResponse {
             sessionId: sessionId,
             pageInstanceGuid: pageContext.pageInstanceGuid,
             layoutPlugins: getPlugins(plugins: plugins),
+            eventData: nil,
             token: pageContext.token,
             options: options
         )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background
- Consume event data from api 
- more tests to TestEventProcessor

Fixes [([issue](https://rokt.atlassian.net/browse/NI-552))]

### What Has Changed

- add RoktUXRealTimeEvent and RoktUXEventData

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated CHANGELOG.md relevant notes.
