### PR TITLE
Fix/SQDSDKS-7522 - iOS embedded size changed is emitting too frequently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Ignore sub-pixel height changes by rounding before size-change callback
+
 ## [0.5.1] - 2025-06-18
 
 ### Added

--- a/Sources/RoktUXHelper/UI/Components/EmbeddedComponent/EmbeddedComponentViewModel.swift
+++ b/Sources/RoktUXHelper/UI/Components/EmbeddedComponent/EmbeddedComponentViewModel.swift
@@ -56,9 +56,13 @@ class EmbeddedComponentViewModel: ObservableObject {
     }
 
     func updateHeight(_ newHeight: CGFloat) {
-        if lastUpdatedHeight != newHeight {
+        let roundedHeight = round(newHeight)
+        let roundedLastUpdatedHeight = round(lastUpdatedHeight)
+        if roundedLastUpdatedHeight != roundedHeight {
             onSizeChange?(newHeight)
             lastUpdatedHeight = newHeight
+        } else {
+            layoutState?.config?.debugLog("Rokt: Embedded view size update ignored due to subpixel precision.")
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background
Fix sub-pixel noise in the embedded size callback by rounding before comparison.

Fixes [SQDSDKS-7522](https://mparticle-eng.atlassian.net/browse/SQDSDKS-7522)

### What Has Changed

- In updateEmbeddedSize(_:), round the incoming size to a whole pixel
- Add a guard to skip updates when the rounded height equals latestHeight
- Store the rounded value back into latestHeight

### How Has This Been Tested?

#### Before:
![Image 7-25-25 at 1 31 PM](https://github.com/user-attachments/assets/98ecb942-c6f1-4e47-a1f2-b12837ed9296)

#### After: 
![Image 7-25-25 at 1 24 PM](https://github.com/user-attachments/assets/ee138e59-675f-4fba-8309-3f982172905f)

### Notes

N/A

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated CHANGELOG.md relevant notes.
