### PR TITLE
feat: LayoutTransformer to support fallback images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Fallback `imageKey` support in `DataImage` and `DataImageCarousel` nodes
+
 ## [0.5.1] - 2025-06-18
 
 ### Added

--- a/Tests/RoktUXHelperTests/Data/Model/ModelTestData.swift
+++ b/Tests/RoktUXHelperTests/Data/Model/ModelTestData.swift
@@ -200,11 +200,19 @@ class ModelTestData: NSObject {
             let data = toData(jsonFilename: "node_data_image")
             return try! JSONDecoder().decode(DataImageModel.self, from: data)
         }
+        static func dataImageWithFallback() -> DataImageModel<WhenPredicate> {
+            let data = toData(jsonFilename: "node_data_image_fallback")
+            return try! JSONDecoder().decode(DataImageModel.self, from: data)
+        }
     }
     
     enum DataImageCarouselData {
         static func dataImageCarousel() -> DataImageCarouselModel<WhenPredicate> {
             let data = toData(jsonFilename: "node_data_image_carousel")
+            return try! JSONDecoder().decode(DataImageCarouselModel.self, from: data)
+        }
+        static func dataImageCarouselWithFallback() -> DataImageCarouselModel<WhenPredicate> {
+            let data = toData(jsonFilename: "node_data_image_carousel_fallback")
             return try! JSONDecoder().decode(DataImageCarouselModel.self, from: data)
         }
     }

--- a/Tests/RoktUXHelperTests/Services/LayoutTransformer/TestLayoutTransformer.swift
+++ b/Tests/RoktUXHelperTests/Services/LayoutTransformer/TestLayoutTransformer.swift
@@ -390,6 +390,179 @@ final class TestLayoutTransformer: XCTestCase {
         }
     }
 
+    // MARK: - GetDataImage
+
+    func test_getDataImage_withSingleKey_returnsImage() throws {
+        // Arrange
+        let image = CreativeImage(light: "https://rokt.com/image.png", dark: nil, alt: "alt", title: nil)
+        let offer = get_offer_with_images(["creativeImage": image])
+        let model = DataImageModel<WhenPredicate>(styles: nil, imageKey: "creativeImage")
+        let layoutTransformer = LayoutTransformer(layoutPlugin: get_layout_plugin(layout: nil, slots: []))
+
+        // Act
+        let dataImageViewModel = try layoutTransformer.getDataImage(model, context: .inner(.generic(offer)))
+
+        // Assert
+        XCTAssertEqual(dataImageViewModel.image, image)
+    }
+
+    func test_getDataImage_withSingleKey_and_addToCart_context_returnsImage() throws {
+        // Arrange
+        let image = CreativeImage(light: "https://rokt.com/image.png", dark: nil, alt: "alt", title: nil)
+        let catalogItem = get_catalog_item(image: image)
+        let model = DataImageModel<WhenPredicate>(styles: nil, imageKey: "creativeImage")
+        let layoutTransformer = LayoutTransformer(layoutPlugin: get_layout_plugin(layout: nil, slots: []))
+
+        // Act
+        let dataImageViewModel = try layoutTransformer.getDataImage(model, context: .inner(.addToCart(catalogItem)))
+
+        // Assert
+        XCTAssertEqual(dataImageViewModel.image, image)
+    }
+
+    func test_getDataImage_withMultipleKeys_firstKeyValid_returnsImage() throws {
+        // Arrange
+        let image1 = CreativeImage(light: "https://rokt.com/image1.png", dark: nil, alt: "alt1", title: nil)
+        let image2 = CreativeImage(light: "https://rokt.com/image2.png", dark: nil, alt: "alt2", title: nil)
+        let offer = get_offer_with_images(["image1": image1, "image2": image2])
+        let model = DataImageModel<WhenPredicate>(styles: nil, imageKey: "image1|image2")
+        let layoutTransformer = LayoutTransformer(layoutPlugin: get_layout_plugin(layout: nil, slots: []))
+
+        // Act
+        let dataImageViewModel = try layoutTransformer.getDataImage(model, context: .inner(.generic(offer)))
+
+        // Assert
+        XCTAssertEqual(dataImageViewModel.image, image1)
+    }
+
+    func test_getDataImage_withMultipleKeys_secondKeyValid_returnsImage() throws {
+        // Arrange
+        let image2 = CreativeImage(light: "https://rokt.com/image2.png", dark: nil, alt: "alt2", title: nil)
+        let offer = get_offer_with_images(["image2": image2])
+        let model = DataImageModel<WhenPredicate>(styles: nil, imageKey: "invalidKey|image2")
+        let layoutTransformer = LayoutTransformer(layoutPlugin: get_layout_plugin(layout: nil, slots: []))
+
+        // Act
+        let dataImageViewModel = try layoutTransformer.getDataImage(model, context: .inner(.generic(offer)))
+
+        // Assert
+        XCTAssertEqual(dataImageViewModel.image, image2)
+    }
+
+    func test_getDataImage_withMultipleKeys_withSpaces_returnsImage() throws {
+        // Arrange
+        let image2 = CreativeImage(light: "https://rokt.com/image2.png", dark: nil, alt: "alt2", title: nil)
+        let offer = get_offer_with_images(["image2": image2])
+        let model = DataImageModel<WhenPredicate>(styles: nil, imageKey: "invalidKey | image2")
+        let layoutTransformer = LayoutTransformer(layoutPlugin: get_layout_plugin(layout: nil, slots: []))
+
+        // Act
+        let dataImageViewModel = try layoutTransformer.getDataImage(model, context: .inner(.generic(offer)))
+
+        // Assert
+        XCTAssertEqual(dataImageViewModel.image, image2)
+    }
+
+    func test_getDataImage_withNoValidKeys_returnsNil() throws {
+        // Arrange
+        let offer = get_offer_with_images([:])
+        let model = DataImageModel<WhenPredicate>(styles: nil, imageKey: "invalidKey|anotherInvalidKey")
+        let layoutTransformer = LayoutTransformer(layoutPlugin: get_layout_plugin(layout: nil, slots: []))
+
+        // Act
+        let dataImageViewModel = try layoutTransformer.getDataImage(model, context: .inner(.generic(offer)))
+
+        // Assert
+        XCTAssertNil(dataImageViewModel.image)
+    }
+
+    // MARK: - GetDataImageCarousel
+
+    func test_getDataImageCarousel_withSingleKey_returnsMatchingImages() throws {
+        // Arrange
+        let image1 = CreativeImage(light: "https://rokt.com/carousel_1.png", dark: nil, alt: "alt1", title: nil)
+        let image2 = CreativeImage(light: "https://rokt.com/carousel_2.png", dark: nil, alt: "alt2", title: nil)
+        let otherImage = CreativeImage(light: "https://rokt.com/other.png", dark: nil, alt: "alt other", title: nil)
+        let offer = get_offer_with_images([
+            "carousel.1": image1,
+            "carousel.2": image2,
+            "other_1": otherImage
+        ])
+        let model = DataImageCarouselModel<WhenPredicate>(styles: nil, imageKey: "carousel", duration: 5000, a11yLabel: nil)
+        let layoutTransformer = LayoutTransformer(layoutPlugin: get_layout_plugin(layout: nil, slots: []))
+
+        // Act
+        let viewModel = try layoutTransformer.getDataImageCarousel(model, context: .inner(.generic(offer)))
+
+        // Assert
+        XCTAssertEqual(viewModel.images.count, 2)
+        XCTAssertEqual(viewModel.images, [image1, image2])
+    }
+
+    func test_getDataImageCarousel_withMultipleKeys_returnsMatchingImages() throws {
+        // Arrange
+        let image1 = CreativeImage(light: "https://rokt.com/image1.png", dark: nil, alt: "alt1", title: nil)
+        let image2 = CreativeImage(light: "https://rokt.com/image2.png", dark: nil, alt: "alt2", title: nil)
+        let image3 = CreativeImage(light: "https://rokt.com/image3.png", dark: nil, alt: "alt3", title: nil)
+        let offer = get_offer_with_images(["carousel1.1": image1, "carousel2.1": image2, "carousel3.1": image3])
+        let model = DataImageCarouselModel<WhenPredicate>(
+            styles: nil,
+            imageKey: "invalidKey|carousel2",
+            duration: 5000,
+            a11yLabel: nil
+        )
+        let layoutTransformer = LayoutTransformer(layoutPlugin: get_layout_plugin(layout: nil, slots: []))
+
+        // Act
+        let dataImageCarouselViewModel = try layoutTransformer.getDataImageCarousel(model, context: .inner(.generic(offer)))
+
+        // Assert
+        XCTAssertEqual(dataImageCarouselViewModel.images.count, 1)
+        XCTAssertEqual(dataImageCarouselViewModel.images[0], image2)
+    }
+
+    func test_getDataImageCarousel_withMultipleKeysAndSpaces_returnsMatchingImages() throws {
+        // Arrange
+        let image1 = CreativeImage(light: "https://rokt.com/image1.png", dark: nil, alt: "alt1", title: nil)
+        let image2 = CreativeImage(light: "https://rokt.com/image2.png", dark: nil, alt: "alt2", title: nil)
+        let image3 = CreativeImage(light: "https://rokt.com/image3.png", dark: nil, alt: "alt3", title: nil)
+        let offer = get_offer_with_images(["carousel1.1": image1, "carousel1.2": image2, "carousel3.1": image3])
+        let model = DataImageCarouselModel<WhenPredicate>(
+            styles: nil,
+            imageKey: "invalidKey | carousel1",
+            duration: 5000,
+            a11yLabel: nil
+        )
+        let layoutTransformer = LayoutTransformer(layoutPlugin: get_layout_plugin(layout: nil, slots: []))
+
+        // Act
+        let dataImageCarouselViewModel = try layoutTransformer.getDataImageCarousel(model, context: .inner(.generic(offer)))
+
+        // Assert
+        XCTAssertEqual(dataImageCarouselViewModel.images.count, 2)
+        XCTAssertEqual(dataImageCarouselViewModel.images[0], image1)
+        XCTAssertEqual(dataImageCarouselViewModel.images[1], image2)
+    }
+
+    func test_getDataImageCarousel_withNoMatchingKeys_returnsEmptyArray() throws {
+        // Arrange
+        let image1 = CreativeImage(light: "https://rokt.com/image1.png", dark: nil, alt: "alt1", title: nil)
+        let offer = get_offer_with_images(["carousel1.1": image1])
+        let model = DataImageCarouselModel<WhenPredicate>(
+            styles: nil,
+            imageKey: "carousel2|carousel3",
+            duration: 5000,
+            a11yLabel: nil
+        )
+        let layoutTransformer = LayoutTransformer(layoutPlugin: get_layout_plugin(layout: nil, slots: []))
+
+        // Act
+        let dataImageCarouselViewModel = try layoutTransformer.getDataImageCarousel(model, context: .inner(.generic(offer)))
+
+        // Assert
+        XCTAssertEqual(dataImageCarouselViewModel.images.count, 0)
+    }
+
     //MARK: mock objects
 
     func get_layout_plugin(layout: LayoutSchemaModel?, slots: [SlotModel]) -> LayoutPlugin {
@@ -405,6 +578,43 @@ final class TestLayoutTransformer: XCTestCase {
                 layoutVariantSchema: .creativeResponse(layoutVariant!), moduleName: ""
             ),
             jwtToken: "slot-token"
+        )
+    }
+
+    func get_offer_with_images(_ images: [String: CreativeImage]?) -> OfferModel {
+        let creative = CreativeModel(
+            referralCreativeId: "referralCreativeId",
+            instanceGuid: "instanceGuid",
+            copy: [:],
+            images: images,
+            links: nil,
+            responseOptionsMap: nil,
+            jwtToken: "token"
+        )
+        return OfferModel(
+            campaignId: "campaignId",
+            creative: creative,
+            catalogItems: nil
+        )
+    }
+
+    func get_catalog_item(image: CreativeImage) -> CatalogItem {
+        return CatalogItem(
+            images: ["creativeImage": image],
+            catalogItemId: "catalogItemId",
+            cartItemId: "cartItemId",
+            instanceGuid: "instanceGuid",
+            title: "title",
+            description: "description",
+            price: nil,
+            originalPrice: nil,
+            originalPriceFormatted: nil,
+            currency: "USD",
+            linkedProductId: nil,
+            positiveResponseText: "Add to cart",
+            negativeResponseText: "No thanks",
+            providerData: "{}",
+            token: "token"
         )
     }
 }

--- a/Tests/RoktUXHelperTests/Supporting Files/DataImage/node_data_image_fallback.json
+++ b/Tests/RoktUXHelperTests/Supporting Files/DataImage/node_data_image_fallback.json
@@ -1,0 +1,29 @@
+{
+    "imageKey": "invalidKey|creativeImage",
+    "styles": {
+        "elements": {
+            "own": [
+                {
+                    "default": {
+                        "dimension": {
+                            "height": {
+                                "type": "fixed",
+                                "value": 100
+                            }
+                        },
+                        "background": {
+                            "backgroundColor": {
+                                "light": "#F5C1C4",
+                                "dark": "#F5C1C4"
+                            }
+                        },
+                        "spacing": {
+                            "padding": "18 24 0 24",
+                            "margin": "0 0 0 0",
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/Tests/RoktUXHelperTests/Supporting Files/DataImageCarousel/node_data_image_carousel_fallback.json
+++ b/Tests/RoktUXHelperTests/Supporting Files/DataImageCarousel/node_data_image_carousel_fallback.json
@@ -1,0 +1,14 @@
+{
+    "type": "DataImageCarousel",
+    "imageKey": "invalidKey|creativeCarouselImageVertical",
+    "duration": 3000,
+    "style": {
+        "elements": {
+            "own": {},
+            "indicator": {},
+            "activeIndicator": {},
+            "seenIndicator": {},
+            "progressIndicatorContainer": {}
+        }
+    }
+}

--- a/Tests/RoktUXHelperTests/UI/Components/TestDataImageComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestDataImageComponent.swift
@@ -52,7 +52,20 @@ final class TestDataImageComponent: XCTestCase {
         // Invalid Image should be removed from view
         XCTAssertNil(try? image.find(AsyncImageView.self))
     }
-    
+
+    func test_data_image_with_fallback() throws {
+        let view = TestPlaceHolder(layout: LayoutSchemaViewModel.dataImage(try get_model(isValid: true, isFallback: true)))
+
+        try view.inspect().view(TestPlaceHolder.self)
+            .view(EmbeddedComponent.self)
+            .vStack()[0]
+            .view(LayoutSchemaComponent.self)
+            .view(DataImageViewComponent.self)
+            .actualView()
+            .inspect()
+            .find(AsyncImageView.self)
+    }
+
     func test_dataImage_computedProperties_usesModelProperties() throws {
         let view = TestPlaceHolder(layout: LayoutSchemaViewModel.dataImage(try get_model()))
         
@@ -82,14 +95,14 @@ final class TestDataImageComponent: XCTestCase {
                        ))
     }
 
-    func get_model(isValid: Bool = true) throws -> DataImageViewModel {
+    func get_model(isValid: Bool = true, isFallback: Bool = false) throws -> DataImageViewModel {
         let validImage = "https://docs.rokt.com/assets/images/embedded-placement-1-5ab04a718fe7dda94ac24aa7b89aac92.png"
         let invalidImage = ""
         let transformer = LayoutTransformer(
             layoutPlugin: get_mock_layout_plugin(slots: [get_slot(image: isValid ? validImage : invalidImage)])
         )
         return try transformer.getDataImage(
-            ModelTestData.DataImageData.dataImage(),
+            isFallback ? ModelTestData.DataImageData.dataImageWithFallback() : ModelTestData.DataImageData.dataImage(),
             context: .inner(.generic(get_slot(image: isValid ? validImage : invalidImage).offer!))
         )
     }

--- a/Tests/RoktUXHelperTests/UI/Components/TestImageCarouselComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestImageCarouselComponent.swift
@@ -33,13 +33,27 @@ final class TestImageCarouselComponent: XCTestCase {
         XCTAssertNotNil(image)
     }
 
-    func get_model() throws -> DataImageCarouselViewModel {
+    func test_data_image_carousel_with_fallback() throws {
+        let view = TestPlaceHolder(layout: LayoutSchemaViewModel.dataImageCarousel(try get_model(isFallback: true)))
+
+         let image = try view.inspect().view(TestPlaceHolder.self)
+            .view(EmbeddedComponent.self)
+            .vStack()[0]
+            .view(LayoutSchemaComponent.self)
+            .view(DataImageCarouselComponent.self)
+            .actualView()
+
+        XCTAssertNotNil(image)
+    }
+
+    func get_model(isFallback: Bool = false) throws -> DataImageCarouselViewModel {
 
         let transformer = LayoutTransformer(
             layoutPlugin: get_mock_layout_plugin(slots: [get_slot()])
         )
         return try transformer.getDataImageCarousel(
-            ModelTestData.DataImageCarouselData.dataImageCarousel(),
+            isFallback ? ModelTestData.DataImageCarouselData.dataImageCarouselWithFallback() : ModelTestData.DataImageCarouselData
+                .dataImageCarousel(),
             context: .inner(.generic(get_slot().offer!))
         )
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

Add support for fallback imageKeys in `DataImage` and `DataImageCarousel` nodes

Fixes [SQDSDKS-7515](https://mparticle-eng.atlassian.net/browse/SQDSDKS-7515)

### What Has Changed

- Support pipe separated imageKeys in `DataImage` and `DataImageCarousel` nodes
- Updated tests to cover scenarios for fallback images and multiple image keys

### How Has This Been Tested?

Tested with mock JSON
Added unit and UI tests

### Notes

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated CHANGELOG.md relevant notes.
