### PR TITLE
fix: SignalViewed trigger when initial reported state is different

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- SignalViewed reporting for offers
+
 ## [0.6.0] - 2025-08-05
 
 ### Added

--- a/Sources/RoktUXHelper/Data/Model/Constants.swift
+++ b/Sources/RoktUXHelper/Data/Model/Constants.swift
@@ -73,11 +73,6 @@ let kErrorSeverity = "severity"
 
 let kSharedDataItemsQueueLabel = "com.rokt.shareddata.items.queue"
 
-// MARK: - SignalViewed constants
-
-let kSignalViewedIntersectThreshold = 0.5
-let kSignalViewedTimeThreshold = 1.0
-
 // MARK: - Accessibility
 
 let kPageAnnouncement = "Page %d of %d"

--- a/Sources/RoktUXHelper/UI/Components/Common/View+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/View+Extension.swift
@@ -152,15 +152,15 @@ private struct BecomingViewedModifier: ViewModifier {
     }
 
     private func handleVisibilityChange(intersectPercent: CGFloat, proxy: GeometryProxy) {
-        let aboveThreshold = intersectPercent > kSignalViewedIntersectThreshold
+        let aboveThreshold = intersectPercent > 0.5
 
         if aboveThreshold {
             guard shouldTriggerForCurrentOffer() else { return }
 
             if visibilityTimer == nil {
-                visibilityTimer = Timer.scheduledTimer(withTimeInterval: kSignalViewedTimeThreshold, repeats: false) { _ in
+                visibilityTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { _ in
                     let currentIntersect = UIScreen.main.bounds.intersectPercent(proxy)
-                    if currentIntersect > kSignalViewedIntersectThreshold {
+                    if currentIntersect > 0.5 {
                         let info = ComponentVisibilityInfo(
                             isVisible: true,
                             isObscured: currentIntersect < 1.0,
@@ -184,6 +184,7 @@ private struct BecomingViewedModifier: ViewModifier {
         visibilityTimer = nil
     }
 
+    // To skip multiple executions for the same offer in OneByOne distribution
     private func shouldTriggerForCurrentOffer() -> Bool {
         guard let offer = currentOffer else { return true }
         return lastTriggeredOffer != offer

--- a/Sources/RoktUXHelper/UI/Components/Common/View+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/View+Extension.swift
@@ -69,64 +69,13 @@ extension View {
         }
     }
 
-    // When the view moves inside the SignalViewed area, start timer.
-    // When timer is over and view is still inside this area, execute closure.
+    // Ensure continuous visibility above threshold for the full time window,
+    // cancel when dropping below threshold, and trigger once per offer.
     func onBecomingViewed(
         currentOffer: Int? = nil,
         execute: ((_ visibilityInfo: ComponentVisibilityInfo) -> Void)?
     ) -> some View {
-        background(
-            GeometryReader { geometryProxy in
-                let intersectPercent = UIScreen.main.bounds.intersectPercent(geometryProxy)
-                let isVisible = intersectPercent > kSignalViewedIntersectThreshold
-                let isObscured = intersectPercent < 1.0
-                let incorrectlySized = geometryProxy.size.width <= 0 || geometryProxy.size.height <= 0
-
-                Color.clear
-                    .onAppear {
-                        if isVisible {
-                            Timer.scheduledTimer(withTimeInterval: kSignalViewedTimeThreshold, repeats: false) { _ in
-                                if UIScreen.main.bounds.intersectPercent(geometryProxy) > kSignalViewedIntersectThreshold {
-                                    let visibilityInfo = ComponentVisibilityInfo(
-                                        isVisible: isVisible,
-                                        isObscured: isObscured,
-                                        incorrectlySized: incorrectlySized
-                                    )
-                                    execute?(visibilityInfo)
-                                }
-                            }
-                        }
-                    }
-                    .onChange(of: intersectPercent) { value in
-                        if value > kSignalViewedIntersectThreshold {
-                            Timer.scheduledTimer(withTimeInterval: kSignalViewedTimeThreshold, repeats: false) { _ in
-                                if UIScreen.main.bounds.intersectPercent(geometryProxy) > kSignalViewedIntersectThreshold {
-                                    let visibilityInfo = ComponentVisibilityInfo(
-                                        isVisible: isVisible,
-                                        isObscured: isObscured,
-                                        incorrectlySized: incorrectlySized
-                                    )
-                                    execute?(visibilityInfo)
-                                }
-                            }
-                        }
-                    }
-                    .onChange(of: currentOffer) { _ in
-                        if intersectPercent > kSignalViewedIntersectThreshold {
-                            Timer.scheduledTimer(withTimeInterval: kSignalViewedTimeThreshold, repeats: false) { _ in
-                                if UIScreen.main.bounds.intersectPercent(geometryProxy) > kSignalViewedIntersectThreshold {
-                                    let visibilityInfo = ComponentVisibilityInfo(
-                                        isVisible: isVisible,
-                                        isObscured: isObscured,
-                                        incorrectlySized: incorrectlySized
-                                    )
-                                    execute?(visibilityInfo)
-                                }
-                            }
-                        }
-                    }
-            }
-        )
+        modifier(BecomingViewedModifier(currentOffer: currentOffer, execute: execute))
     }
 
     @ViewBuilder func `ifLet`<Content: View, T>(
@@ -166,5 +115,77 @@ class ComponentVisibilityInfo {
 
     var isInViewAndCorrectSize: Bool {
         return isVisible && !isObscured && !incorrectlySized
+    }
+}
+
+// MARK: - Internal visibility tracking
+
+@available(iOS 15, *)
+private struct BecomingViewedModifier: ViewModifier {
+    let currentOffer: Int?
+    let execute: ((_ visibilityInfo: ComponentVisibilityInfo) -> Void)?
+
+    @State private var visibilityTimer: Timer?
+    @State private var lastTriggeredOffer: Int?
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                GeometryReader { proxy in
+                    let intersectPercent = UIScreen.main.bounds.intersectPercent(proxy)
+                    Color.clear
+                        .onAppear {
+                            handleVisibilityChange(intersectPercent: intersectPercent, proxy: proxy)
+                        }
+                        .onChange(of: intersectPercent) { newValue in
+                            handleVisibilityChange(intersectPercent: newValue, proxy: proxy)
+                        }
+                        .onChange(of: currentOffer) { _ in
+                            // Reset once per offer gate and cancel any pending timer when the offer changes
+                            cancelTimer()
+                            lastTriggeredOffer = nil
+                            handleVisibilityChange(intersectPercent: intersectPercent, proxy: proxy)
+                        }
+                        .onDisappear { cancelTimer() }
+                }
+            )
+    }
+
+    private func handleVisibilityChange(intersectPercent: CGFloat, proxy: GeometryProxy) {
+        let aboveThreshold = intersectPercent > kSignalViewedIntersectThreshold
+
+        if aboveThreshold {
+            guard shouldTriggerForCurrentOffer() else { return }
+
+            if visibilityTimer == nil {
+                visibilityTimer = Timer.scheduledTimer(withTimeInterval: kSignalViewedTimeThreshold, repeats: false) { _ in
+                    let currentIntersect = UIScreen.main.bounds.intersectPercent(proxy)
+                    if currentIntersect > kSignalViewedIntersectThreshold {
+                        let info = ComponentVisibilityInfo(
+                            isVisible: true,
+                            isObscured: currentIntersect < 1.0,
+                            incorrectlySized: proxy.size.width <= 0 || proxy.size.height <= 0
+                        )
+                        execute?(info)
+                        if info.isInViewAndCorrectSize {
+                            lastTriggeredOffer = currentOffer
+                        }
+                    }
+                    cancelTimer()
+                }
+            }
+        } else {
+            cancelTimer()
+        }
+    }
+
+    private func cancelTimer() {
+        visibilityTimer?.invalidate()
+        visibilityTimer = nil
+    }
+
+    private func shouldTriggerForCurrentOffer() -> Bool {
+        guard let offer = currentOffer else { return true }
+        return lastTriggeredOffer != offer
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

The isVisible state was getting cached and the timer was considering old value when sending the status to the callback.

Fixes [SQDSDKS-7461](https://mparticle-eng.atlassian.net/browse/SQDSDKS-7461)

### What Has Changed

- Extracted the logic into `BecomingViewedModifier` and reuse the handling
- 
### How Has This Been Tested?

Tested locally

https://github.com/user-attachments/assets/a75eed3d-307f-4df6-8883-9581393e0c4f

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have updated CHANGELOG.md relevant notes.
