### PR TITLE
feat: implement the carousel and page styling

### DIFF
--- a/.github/composite_actions/run_xcodebuild_tests/action.yml
+++ b/.github/composite_actions/run_xcodebuild_tests/action.yml
@@ -39,7 +39,7 @@ runs:
       if: ${{ inputs.use-swift-5 == 'false' }}
       run: >
         set -o pipefail &&
-        xcodebuild -skipPackagePluginValidation -scheme RoktUXHelper -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' -enableCodeCoverage YES -derivedDataPath DerivedData clean build test
+        xcodebuild -skipPackagePluginValidation -scheme RoktUXHelper -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' -enableCodeCoverage YES -derivedDataPath DerivedData clean build test
         | xcbeautify --renderer github-actions
       shell: bash
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SignalViewed reporting for offers
 
+### Changed
+
+- `CarouselDistribution` styling behavior and dynamic page height
+
 ## [0.6.0] - 2025-08-05
 
 ### Added

--- a/Sources/RoktUXHelper/UI/Components/Distribution/CarouselDistributionComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/Distribution/CarouselDistributionComponent.swift
@@ -144,23 +144,6 @@ struct CarouselDistributionComponent: View {
                         .offset(x: (containerProxy.size.width - pageWidth)/2 - peekThrough)
                     }
                 }
-                .applyLayoutModifier(verticalAlignmentProperty: verticalAlignment,
-                                     horizontalAlignmentProperty: horizontalAlignment,
-                                     spacing: spacingStyle,
-                                     dimension: dimensionStyle,
-                                     flex: flexStyle,
-                                     border: borderStyle,
-                                     background: backgroundStyle,
-                                     parent: config.parent,
-                                     parentWidth: $parentWidth,
-                                     parentHeight: $parentHeight,
-                                     parentOverride: nil,
-                                     defaultHeight: .wrapContent,
-                                     defaultWidth: .wrapContent,
-                                     isContainer: true,
-                                     containerType: .row,
-                                     frameChangeIndex: $model.frameChangeIndex,
-                                     imageLoader: model.imageLoader)
                 .offset(x: pageOffset + indexOffset + offset + peekThroughOffset + gapOffset)
                 .gesture(
                     DragGesture()
@@ -174,7 +157,25 @@ struct CarouselDistributionComponent: View {
                             model.updateStatesOnDragEnded(roundProgress)
                         })
                 )
+                .clipped()
             }
+            .applyLayoutModifier(verticalAlignmentProperty: verticalAlignment,
+                                 horizontalAlignmentProperty: horizontalAlignment,
+                                 spacing: spacingStyle,
+                                 dimension: dimensionStyle,
+                                 flex: flexStyle,
+                                 border: borderStyle,
+                                 background: backgroundStyle,
+                                 parent: config.parent,
+                                 parentWidth: $parentWidth,
+                                 parentHeight: $parentHeight,
+                                 parentOverride: nil,
+                                 defaultHeight: .wrapContent,
+                                 defaultWidth: .wrapContent,
+                                 isContainer: true,
+                                 containerType: .row,
+                                 frameChangeIndex: $model.frameChangeIndex,
+                                 imageLoader: model.imageLoader)
             .onLoad {
                 model.setupLayoutState()
                 shouldFocusAccessibility = true
@@ -215,9 +216,9 @@ struct CarouselDistributionComponent: View {
                     let newHeight = size.height
                     if carouselHeightMap[childIndex] != newHeight {
                         carouselHeightMap[childIndex] = newHeight
-                        // Update maxHeight only if it's significantly different to prevent infinite loops
+                        // Update maxHeight only if it's different to prevent infinite loops
                         let newMaxHeight = carouselHeightMap.values.max() ?? 0
-                        if abs(maxHeight - newMaxHeight) > 1.0 { // 1pt threshold
+                        if abs(maxHeight - newMaxHeight) > 1.0 {
                             DispatchQueue.main.async {
                                 maxHeight = newMaxHeight
                             }
@@ -290,7 +291,6 @@ struct CarouselDistributionComponent: View {
         let modifier = MarginModifier(spacing: spacingStyle, applyMargin: false)
         let margin = modifier.getMargin()
         let padding = modifier.getPadding()
-        // Use cached maxHeight instead of recalculating to prevent infinite loops
         return maxHeight + margin.top + margin.bottom + padding.top + padding.bottom
     }
 }

--- a/Sources/RoktUXHelper/UI/Components/Distribution/CarouselDistributionComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/Distribution/CarouselDistributionComponent.swift
@@ -46,6 +46,7 @@ struct CarouselDistributionComponent: View {
     @ObservedObject var model: CarouselViewModel
 
     @State private var carouselHeightMap: [Int: CGFloat] = [:]
+    @State private var maxHeight: CGFloat = 0
 
     @AccessibilityFocusState private var shouldFocusAccessibility: Bool
 
@@ -143,6 +144,23 @@ struct CarouselDistributionComponent: View {
                         .offset(x: (containerProxy.size.width - pageWidth)/2 - peekThrough)
                     }
                 }
+                .applyLayoutModifier(verticalAlignmentProperty: verticalAlignment,
+                                     horizontalAlignmentProperty: horizontalAlignment,
+                                     spacing: spacingStyle,
+                                     dimension: dimensionStyle,
+                                     flex: flexStyle,
+                                     border: borderStyle,
+                                     background: backgroundStyle,
+                                     parent: config.parent,
+                                     parentWidth: $parentWidth,
+                                     parentHeight: $parentHeight,
+                                     parentOverride: nil,
+                                     defaultHeight: .wrapContent,
+                                     defaultWidth: .wrapContent,
+                                     isContainer: true,
+                                     containerType: .row,
+                                     frameChangeIndex: $model.frameChangeIndex,
+                                     imageLoader: model.imageLoader)
                 .offset(x: pageOffset + indexOffset + offset + peekThroughOffset + gapOffset)
                 .gesture(
                     DragGesture()
@@ -179,7 +197,7 @@ struct CarouselDistributionComponent: View {
             }
             .animation(.linear, value: model.currentLeadingOfferIndex)
             // workaround to set dynamic height otherwise GeometryReader fills available space
-            .frame(height: carouselHeightMap.max(by: {$0.value < $1.value})?.value ?? 0)
+            .frame(height: getContentHeight())
         }
     }
 
@@ -191,28 +209,20 @@ struct CarouselDistributionComponent: View {
                                       layout: child,
                                       parentWidth: $parentWidth,
                                       parentHeight: $carouselHeightMap[childIndex],
-                                      styleState: $styleState,
-                                      parentOverride: parentOverride?.updateBackground(passableBackgroundStyle))
-                .applyLayoutModifier(verticalAlignmentProperty: verticalAlignment,
-                                     horizontalAlignmentProperty: horizontalAlignment,
-                                     spacing: spacingStyle,
-                                     dimension: dimensionStyle,
-                                     flex: flexStyle,
-                                     border: borderStyle,
-                                     background: backgroundStyle,
-                                     parent: config.parent,
-                                     parentWidth: $parentWidth,
-                                     parentHeight: $parentHeight,
-                                     parentOverride: parentOverride?.updateBackground(passableBackgroundStyle),
-                                     defaultHeight: .wrapContent,
-                                     defaultWidth: .wrapContent,
-                                     isContainer: true,
-                                     containerType: .row,
-                                     frameChangeIndex: $model.frameChangeIndex,
-                                     imageLoader: model.imageLoader)
+                                      styleState: $styleState)
                 .frame(width: offerWidth)
                 .readSize { size in
-                    carouselHeightMap[childIndex] = size.height
+                    let newHeight = size.height
+                    if carouselHeightMap[childIndex] != newHeight {
+                        carouselHeightMap[childIndex] = newHeight
+                        // Update maxHeight only if it's significantly different to prevent infinite loops
+                        let newMaxHeight = carouselHeightMap.values.max() ?? 0
+                        if abs(maxHeight - newMaxHeight) > 1.0 { // 1pt threshold
+                            DispatchQueue.main.async {
+                                maxHeight = newMaxHeight
+                            }
+                        }
+                    }
                 }
                 .accessibilityElement(children: .contain)
                 .accessibilityFocused($shouldFocusAccessibility)
@@ -274,5 +284,13 @@ struct CarouselDistributionComponent: View {
         } else {
             return model.currentPage == 0 ? 0 : (model.currentPage == totalPages - 1 ? peekThrough * 2 : peekThrough)
         }
+    }
+
+    private func getContentHeight() -> CGFloat {
+        let modifier = MarginModifier(spacing: spacingStyle, applyMargin: false)
+        let margin = modifier.getMargin()
+        let padding = modifier.getPadding()
+        // Use cached maxHeight instead of recalculating to prevent infinite loops
+        return maxHeight + margin.top + margin.bottom + padding.top + padding.bottom
     }
 }

--- a/Tests/RoktUXHelperTests/UI/Components/Distribution/TestCarouselDistributionComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/Distribution/TestCarouselDistributionComponent.swift
@@ -36,19 +36,19 @@ final class TestCarouselDistributionComponent: XCTestCase {
             .view(CarouselDistributionComponent.self)
             .actualView()
 
-        let carousel = try carouselComponent
-            .inspect()
-            .find(LayoutSchemaComponent.self)
+        let geometryReader = try carouselComponent.inspect().geometryReader()
 
         // test custom modifier class
-        let paddingModifier = try carousel.modifier(PaddingModifier.self)
+        let paddingModifier = try geometryReader.modifier(PaddingModifier.self)
         XCTAssertEqual(try paddingModifier.actualView().padding, FrameAlignmentProperty(top: 3, right: 4, bottom: 5, left: 6))
 
         // test the effect of custom modifier
-        let padding = try carousel.padding()
+        let padding = try geometryReader.padding()
         XCTAssertEqual(padding, EdgeInsets(top: 3.0, leading: 6.0, bottom: 5.0, trailing: 4.0))
 
-        XCTAssertEqual(try carousel.accessibilityLabel().string(), "Page 1 of 1")
+        // Test accessibility label on the carousel item (LayoutSchemaComponent)
+        let carouselItem = try geometryReader.find(LayoutSchemaComponent.self)
+        XCTAssertEqual(try carouselItem.accessibilityLabel().string(), "Page 1 of 1")
 
         carouselComponent.model.goToNextOffer(nil)
         XCTAssertTrue(closeActionCalled)


### PR DESCRIPTION
### Background

The `CarouselDistribution` was missing the styling capability of it's own. The styles applied to the carousel was getting transferred to the pages and not to the container itself.

Fixes [(issue)]

### What Has Changed

- Apply the styles to `HStack` container hosting the pages.
- Change the max height updation logic to add margin and padding

### How Has This Been Tested?

Tested locally with mock JSON

https://github.com/user-attachments/assets/46d4268d-8b16-4c7d-b725-989ff05f1ad2

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have updated CHANGELOG.md relevant notes.
