### PR TITLE
fix: Add support for negative values in progression predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Handle negative values in `Progression` predicate of `When` component
+
 ## [0.7.0] - 2025-08-19
 
 ### Added

--- a/Sources/RoktUXHelper/UI/Components/ViewModel/PredicateHandling.swift
+++ b/Sources/RoktUXHelper/UI/Components/ViewModel/PredicateHandling.swift
@@ -39,6 +39,10 @@ extension PredicateHandling {
         layoutState?.items[LayoutState.currentProgressKey] as? Binding<Int> ?? .constant(0)
     }
 
+    var viewableItems: Binding<Int> {
+        layoutState?.items[LayoutState.viewableItemsKey] as? Binding<Int> ?? .constant(1)
+    }
+
     var totalItems: Int {
         layoutState?.items[LayoutState.totalItemsKey] as? Int ?? 0
     }
@@ -133,7 +137,8 @@ extension PredicateHandling {
                 // If the predicate value is negative, the value should be calculated from last
                 // Eg: Total items = 4, Predicate value = -1 then the result should be 3(last position)
                 //     Total items = 4, Predicate value = -2 then the result should be 2(second last position)
-                let progression = value >= 0 ? value : totalItems + value
+                let totalPages = Int(ceil(Double(totalItems))/Double(viewableItems.wrappedValue))
+                let progression = value >= 0 ? value : totalPages + value
                 switch predicate.condition {
                 case .is:
                     matched = matched && currentProgress == progression

--- a/Sources/RoktUXHelper/UI/Components/ViewModel/PredicateHandling.swift
+++ b/Sources/RoktUXHelper/UI/Components/ViewModel/PredicateHandling.swift
@@ -130,15 +130,19 @@ extension PredicateHandling {
 
         progressionPredicates.forEach { predicate in
             if let value = Int(predicate.value) {
+                // If the predicate value is negative, the value should be calculated from last
+                // Eg: Total items = 4, Predicate value = -1 then the result should be 3(last position)
+                //     Total items = 4, Predicate value = -2 then the result should be 2(second last position)
+                let progression = value >= 0 ? value : totalItems + value
                 switch predicate.condition {
                 case .is:
-                    matched = matched && currentProgress == value
+                    matched = matched && currentProgress == progression
                 case .isNot:
-                    matched = matched && currentProgress != value
+                    matched = matched && currentProgress != progression
                 case .isAbove:
-                    matched = matched && currentProgress > value
+                    matched = matched && currentProgress > progression
                 case .isBelow:
-                    matched = matched && currentProgress < value
+                    matched = matched && currentProgress < progression
                 }
             }
         }

--- a/Tests/RoktUXHelperTests/UI/ViewModel/TestWhenViewModel.swift
+++ b/Tests/RoktUXHelperTests/UI/ViewModel/TestWhenViewModel.swift
@@ -126,6 +126,54 @@ final class TestWhenViewModel: XCTestCase {
         XCTAssertFalse(shouldApply)
     }
     
+    func test_should_apply_progression_negative_is_valid() {
+        // Arrange
+        let predicate = WhenPredicate.progression(
+            ProgressionPredicate(condition: .is, value: "-1"))
+        let whenVM = get_when_view_model(predicates: [predicate])
+        // Act - totalOffers: 3, currentProgress: 2, expecting progression "-1" to match position 2 (3 + (-1) = 2)
+        let shouldApply = whenVM.shouldApply(get_mock_uistate(currentProgress: 2, totalOffers: 3))
+
+        // Assert
+        XCTAssertTrue(shouldApply)
+    }
+
+    func test_should_apply_progression_negative_is_invalid() {
+        // Arrange
+        let predicate = WhenPredicate.progression(
+            ProgressionPredicate(condition: .is, value: "-1"))
+        let whenVM = get_when_view_model(predicates: [predicate])
+        // Act - totalOffers: 3, currentProgress: 1, expecting progression "-1" to match position 2 (3 + (-1) = 2), but current is 1
+        let shouldApply = whenVM.shouldApply(get_mock_uistate(currentProgress: 1, totalOffers: 3))
+
+        // Assert
+        XCTAssertFalse(shouldApply)
+    }
+
+    func test_should_apply_progression_negative_above_valid() {
+        // Arrange
+        let predicate = WhenPredicate.progression(
+            ProgressionPredicate(condition: .isAbove, value: "-2"))
+        let whenVM = get_when_view_model(predicates: [predicate])
+        // Act - totalOffers: 4, progression "-2" equals 2 (4 + (-2) = 2), currentProgress: 3 should be above 2
+        let shouldApply = whenVM.shouldApply(get_mock_uistate(currentProgress: 3, totalOffers: 4))
+
+        // Assert
+        XCTAssertTrue(shouldApply)
+    }
+
+    func test_should_apply_progression_negative_below_valid() {
+        // Arrange
+        let predicate = WhenPredicate.progression(
+            ProgressionPredicate(condition: .isBelow, value: "-1"))
+        let whenVM = get_when_view_model(predicates: [predicate])
+        // Act - totalOffers: 5, progression "-1" equals 4 (5 + (-1) = 4), currentProgress: 3 should be below 4
+        let shouldApply = whenVM.shouldApply(get_mock_uistate(currentProgress: 3, totalOffers: 5))
+
+        // Assert
+        XCTAssertTrue(shouldApply)
+    }
+
     // MARK: position
 
     func test_should_apply_position_is_valid() {

--- a/Tests/RoktUXHelperTests/UI/ViewModel/TestWhenViewModel.swift
+++ b/Tests/RoktUXHelperTests/UI/ViewModel/TestWhenViewModel.swift
@@ -21,13 +21,14 @@ final class TestWhenViewModel: XCTestCase {
                              predicates: [WhenPredicate]? = [],
                              transition: WhenTransition? = nil,
                              copy: [String: String] = [String: String](),
-                             breakPoint: BreakPoint? = nil) -> WhenViewModel {
+                             breakPoint: BreakPoint? = nil,
+                             layoutState: LayoutState = LayoutState()) -> WhenViewModel {
         return WhenViewModel(children: children,
                              predicates: predicates,
                              transition: transition,
                              offers: [get_slot_offer(copy: copy)],
                              globalBreakPoints: breakPoint,
-                             layoutState: LayoutState())
+                             layoutState: layoutState)
     }
     
     func test_should_apply_progression_is_valid() {
@@ -130,7 +131,9 @@ final class TestWhenViewModel: XCTestCase {
         // Arrange
         let predicate = WhenPredicate.progression(
             ProgressionPredicate(condition: .is, value: "-1"))
-        let whenVM = get_when_view_model(predicates: [predicate])
+        let layoutState = LayoutState()
+        layoutState.items[LayoutState.totalItemsKey] = 3
+        let whenVM = get_when_view_model(predicates: [predicate], layoutState: layoutState)
         // Act - totalOffers: 3, currentProgress: 2, expecting progression "-1" to match position 2 (3 + (-1) = 2)
         let shouldApply = whenVM.shouldApply(get_mock_uistate(currentProgress: 2, totalOffers: 3))
 
@@ -142,7 +145,9 @@ final class TestWhenViewModel: XCTestCase {
         // Arrange
         let predicate = WhenPredicate.progression(
             ProgressionPredicate(condition: .is, value: "-1"))
-        let whenVM = get_when_view_model(predicates: [predicate])
+        let layoutState = LayoutState()
+        layoutState.items[LayoutState.totalItemsKey] = 3
+        let whenVM = get_when_view_model(predicates: [predicate], layoutState: layoutState)
         // Act - totalOffers: 3, currentProgress: 1, expecting progression "-1" to match position 2 (3 + (-1) = 2), but current is 1
         let shouldApply = whenVM.shouldApply(get_mock_uistate(currentProgress: 1, totalOffers: 3))
 
@@ -154,7 +159,9 @@ final class TestWhenViewModel: XCTestCase {
         // Arrange
         let predicate = WhenPredicate.progression(
             ProgressionPredicate(condition: .isAbove, value: "-2"))
-        let whenVM = get_when_view_model(predicates: [predicate])
+        let layoutState = LayoutState()
+        layoutState.items[LayoutState.totalItemsKey] = 4
+        let whenVM = get_when_view_model(predicates: [predicate], layoutState: layoutState)
         // Act - totalOffers: 4, progression "-2" equals 2 (4 + (-2) = 2), currentProgress: 3 should be above 2
         let shouldApply = whenVM.shouldApply(get_mock_uistate(currentProgress: 3, totalOffers: 4))
 
@@ -166,7 +173,10 @@ final class TestWhenViewModel: XCTestCase {
         // Arrange
         let predicate = WhenPredicate.progression(
             ProgressionPredicate(condition: .isBelow, value: "-1"))
-        let whenVM = get_when_view_model(predicates: [predicate])
+        let layoutState = LayoutState()
+        layoutState.items[LayoutState.totalItemsKey] = 5
+        let whenVM = get_when_view_model(predicates: [predicate], layoutState: layoutState)
+        whenVM.layoutState?.items[LayoutState.totalItemsKey] = 5
         // Act - totalOffers: 5, progression "-1" equals 4 (5 + (-1) = 4), currentProgress: 3 should be below 4
         let shouldApply = whenVM.shouldApply(get_mock_uistate(currentProgress: 3, totalOffers: 5))
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

The `Progression` predicates in `When` component are not handling negative values as it is implemented in the `Position` predicate.
```json
{
  "type": "When",
  "node": {
    "predicates": [
      {
        "type": "Progression",
        "predicate": { "condition": "is-not", "value": "-1" }
      }
    ],
    "children": []
  }
}
```
The above component should evaluate true for all offer position except for the last one.

Fixes [SDKE-100](https://rokt.atlassian.net/browse/SDKE-100)

### What Has Changed

- Updated PredicateHandling to correctly calculate progression for negative predicate values.
- Added unit tests to validate behaviour for negative progression conditions (is, isAbove, isBelow).

### How Has This Been Tested?

Tested locally with mock JSON

https://github.com/user-attachments/assets/6c72fac1-8a40-435a-824e-de0e5d767a5e


### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated CHANGELOG.md relevant notes.
