### PR TITLE
fix: Do not capture GeometryProxy in Timer

### DIFF
--- a/Sources/RoktUXHelper/UI/Components/Common/CGRect+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/CGRect+Extension.swift
@@ -19,4 +19,10 @@ extension CGRect {
         let intersection = intersection(geometrySpace)
         return (intersection.width * intersection.height)/(geometrySpace.width * geometrySpace.height)
     }
+
+    func intersectPercentWithFrame(_ frame: CGRect) -> CGFloat {
+        guard intersects(frame) else { return 0 }
+        let intersection = intersection(frame)
+        return (intersection.width * intersection.height)/(frame.width * frame.height)
+    }
 }

--- a/Sources/RoktUXHelper/UI/Components/Common/CGRect+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/CGRect+Extension.swift
@@ -23,6 +23,6 @@ extension CGRect {
     func intersectPercentWithFrame(_ frame: CGRect) -> CGFloat {
         guard intersects(frame) else { return 0 }
         let intersection = intersection(frame)
-        return (intersection.width * intersection.height)/(frame.width * frame.height)
+        return (intersection.width * intersection.height)/(self.width * self.height)
     }
 }

--- a/Sources/RoktUXHelper/UI/Components/Common/CGRect+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/CGRect+Extension.swift
@@ -16,12 +16,14 @@ extension CGRect {
     func intersectPercent(_ geoProxy: GeometryProxy) -> CGFloat {
         let geometrySpace = geoProxy.frame(in: .global)
         guard intersects(geometrySpace) else { return 0 }
+        guard geometrySpace.width > 0 && geometrySpace.height > 0 else { return 0 }
         let intersection = intersection(geometrySpace)
         return (intersection.width * intersection.height)/(geometrySpace.width * geometrySpace.height)
     }
 
     func intersectPercentWithFrame(_ frame: CGRect) -> CGFloat {
         guard intersects(frame) else { return 0 }
+        guard self.width > 0 && self.height > 0 else { return 0 }
         let intersection = intersection(frame)
         return (intersection.width * intersection.height)/(self.width * self.height)
     }

--- a/Sources/RoktUXHelper/UI/Components/Common/View+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/View+Extension.swift
@@ -158,13 +158,15 @@ private struct BecomingViewedModifier: ViewModifier {
             guard shouldTriggerForCurrentOffer() else { return }
 
             if visibilityTimer == nil {
+                let proxySize = proxy.size
+                let proxyFrame = proxy.frame(in: .global)
                 visibilityTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { _ in
-                    let currentIntersect = UIScreen.main.bounds.intersectPercent(proxy)
+                    let currentIntersect = UIScreen.main.bounds.intersectPercentWithFrame(proxyFrame)
                     if currentIntersect > 0.5 {
                         let info = ComponentVisibilityInfo(
                             isVisible: true,
                             isObscured: currentIntersect < 1.0,
-                            incorrectlySized: proxy.size.width <= 0 || proxy.size.height <= 0
+                            incorrectlySized: proxySize.width <= 0 || proxySize.height <= 0
                         )
                         execute?(info)
                         if info.isInViewAndCorrectSize {

--- a/Tests/RoktUXHelperTests/UI/Components/Common/TestCGRectExtension.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/Common/TestCGRectExtension.swift
@@ -1,0 +1,91 @@
+//
+//  TestCGRectExtension.swift
+//  RoktUXHelper
+//
+//  Licensed under the Rokt Software Development Kit (SDK) Terms of Use
+//  Version 2.0 (the "License");
+//
+//  You may not use this file except in compliance with the License.
+//
+//  You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
+
+import Foundation
+import XCTest
+import SwiftUI
+@testable import RoktUXHelper
+
+@available(iOS 15, *)
+class TestCGRectExtension: XCTestCase {
+
+    func testIntersectPercentWithFrame_NoIntersection() {
+        let rect1 = CGRect(x: 0, y: 0, width: 100, height: 100)
+        let rect2 = CGRect(x: 200, y: 200, width: 50, height: 50)
+
+        let result = rect1.intersectPercentWithFrame(rect2)
+        XCTAssertEqual(result, 0.0, "Should return 0 when rectangles don't intersect")
+    }
+
+    func testIntersectPercentWithFrame_FullIntersection() {
+        let rect1 = CGRect(x: 0, y: 0, width: 100, height: 100)
+        let rect2 = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+        let result = rect1.intersectPercentWithFrame(rect2)
+        XCTAssertEqual(result, 1.0, "Should return 1.0 when rectangles fully overlap")
+    }
+
+    func testIntersectPercentWithFrame_PartialIntersection() {
+        let rect1 = CGRect(x: 0, y: 0, width: 100, height: 100)
+        let rect2 = CGRect(x: 0, y: 0, width: 50, height: 50)
+
+        let result = rect1.intersectPercentWithFrame(rect2)
+        XCTAssertEqual(result, 0.25, "Should return 0.25 when rect2 is 1/4 the size of rect1")
+    }
+
+    func testIntersectPercentWithFrame_QuarterIntersection() {
+        let rect1 = CGRect(x: 0, y: 0, width: 100, height: 100)
+        let rect2 = CGRect(x: 50, y: 50, width: 50, height: 50)
+
+        let result = rect1.intersectPercentWithFrame(rect2)
+        XCTAssertEqual(result, 0.25, "Should return 0.25 when rect2 overlaps in bottom-right quarter")
+    }
+
+    func testIntersectPercentWithFrame_EdgeCase_ZeroSize() {
+        let rect1 = CGRect(x: 0, y: 0, width: 100, height: 100)
+        let rect2 = CGRect(x: 0, y: 0, width: 0, height: 0)
+
+        let result = rect1.intersectPercentWithFrame(rect2)
+        XCTAssertEqual(result, 0.0, "Should return 0 when rect2 has zero size")
+    }
+
+    func testIntersectPercentWithFrame_EdgeCase_NegativeCoordinates() {
+        let rect1 = CGRect(x: 0, y: 0, width: 100, height: 100)
+        let rect2 = CGRect(x: -50, y: -50, width: 100, height: 100)
+
+        let result = rect1.intersectPercentWithFrame(rect2)
+        XCTAssertEqual(result, 0.25, "Should return 0.25 when rect2 extends into negative coordinates")
+    }
+
+    func testIntersectPercentWithFrame_EdgeCase_ExactHalf() {
+        let rect1 = CGRect(x: 0, y: 0, width: 100, height: 100)
+        let rect2 = CGRect(x: 0, y: 0, width: 100, height: 50)
+
+        let result = rect1.intersectPercentWithFrame(rect2)
+        XCTAssertEqual(result, 0.5, "Should return 0.5 when rect2 covers exactly half of rect1")
+    }
+
+    func testIntersectPercentWithFrame_EdgeCase_ExactQuarter() {
+        let rect1 = CGRect(x: 0, y: 0, width: 100, height: 100)
+        let rect2 = CGRect(x: 0, y: 0, width: 50, height: 50)
+
+        let result = rect1.intersectPercentWithFrame(rect2)
+        XCTAssertEqual(result, 0.25, "Should return 0.25 when rect2 covers exactly quarter of rect1")
+    }
+
+    func testIntersectPercentWithFrame_EdgeCase_ExactEighth() {
+        let rect1 = CGRect(x: 0, y: 0, width: 100, height: 100)
+        let rect2 = CGRect(x: 0, y: 0, width: 25, height: 50)
+
+        let result = rect1.intersectPercentWithFrame(rect2)
+        XCTAssertEqual(result, 0.125, "Should return 0.125 when rect2 covers exactly 1/8 of rect1")
+    }
+}

--- a/Tests/RoktUXHelperTests/UI/Components/Common/TestCGRectExtension.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/Common/TestCGRectExtension.swift
@@ -57,6 +57,30 @@ class TestCGRectExtension: XCTestCase {
         XCTAssertEqual(result, 0.0, "Should return 0 when rect2 has zero size")
     }
 
+    func testIntersectPercentWithFrame_EdgeCase_SelfZeroSize() {
+        let rect1 = CGRect(x: 0, y: 0, width: 0, height: 0)
+        let rect2 = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+        let result = rect1.intersectPercentWithFrame(rect2)
+        XCTAssertEqual(result, 0.0, "Should return 0 when self has zero size to prevent divide by zero")
+    }
+
+    func testIntersectPercentWithFrame_EdgeCase_SelfZeroWidth() {
+        let rect1 = CGRect(x: 0, y: 0, width: 0, height: 100)
+        let rect2 = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+        let result = rect1.intersectPercentWithFrame(rect2)
+        XCTAssertEqual(result, 0.0, "Should return 0 when self has zero width to prevent divide by zero")
+    }
+
+    func testIntersectPercentWithFrame_EdgeCase_SelfZeroHeight() {
+        let rect1 = CGRect(x: 0, y: 0, width: 100, height: 0)
+        let rect2 = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+        let result = rect1.intersectPercentWithFrame(rect2)
+        XCTAssertEqual(result, 0.0, "Should return 0 when self has zero height to prevent divide by zero")
+    }
+
     func testIntersectPercentWithFrame_EdgeCase_NegativeCoordinates() {
         let rect1 = CGRect(x: 0, y: 0, width: 100, height: 100)
         let rect2 = CGRect(x: -50, y: -50, width: 100, height: 100)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,30 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+ignore:
+  - Example/**
+  - Tests/**
+  - fastlane/**
+  - .github/**
+  - DerivedData/**
+  - .swiftpm/**
+  - "*.md"
+  - "*.yml"
+  - "*.yaml"
+  - "*.lock"
+  - Gemfile*
+  - Package.resolved
+  - VERSION
+  - LICENSE.md
+  - SECURITY.md
+  - MIGRATING.md
+  - README.md
+  - CHANGELOG.md


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

Timer closures can execute on different threads than the UI thread where SwiftUI views run. Swift 6 requires captured values to be Sendable so we're capturing size and frame outside of the timer context which are both sendable

<img width="600" src="https://github.com/user-attachments/assets/965f989a-f2df-4ae1-8dcf-193d64ecc499" />

### What Has Changed

handleVisibilityChange

### How Has This Been Tested?

- Breakpoints on distributions using onBecomingViewed

### Notes

N/A

### Checklist

- [X] I have performed a self-review of my own code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.