### PR TITLE
chore: Configure dependabot for Swift

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
     open-pull-requests-limit: 2
     labels:
       - dependabot
+  - package-ecosystem: swift
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+    labels:
+      - dependabot


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

Adds config for dependabot for Swift
