### PR TITLE
fix: Update Xcode version in CI workflow

### DIFF
--- a/.github/composite_actions/run_xcodebuild_tests/action.yml
+++ b/.github/composite_actions/run_xcodebuild_tests/action.yml
@@ -1,12 +1,7 @@
 name: Run unit tests
-description: Action runs `xcodebuild test` on xcode 15.4
+description: Action runs `xcodebuild test` on xcode 16.x
 
 inputs:
-  use-swift-5:
-    description: The Swift version 5
-    required: true
-    type: boolean
-    default: false
   codecov-token:
     description: Codecov token
     type: string
@@ -15,28 +10,12 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set up Xcode 15
-      if: ${{ inputs.use-swift-5 == 'true' }}
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: "15.4"
-
-    - name: Run unit tests
-      if: ${{ inputs.use-swift-5 == 'true' }}
-      run: >
-        set -o pipefail &&
-        xcodebuild -skipPackagePluginValidation -scheme RoktUXHelper -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.5' -enableCodeCoverage YES -derivedDataPath DerivedData clean build test
-        | xcbeautify --renderer github-actions
-      shell: bash
-
     - name: Set up Xcode 16
-      if: ${{ inputs.use-swift-5 == 'false' }}
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: 16.3.0
+        xcode-version: 16.4.0
 
     - name: Run unit tests
-      if: ${{ inputs.use-swift-5 == 'false' }}
       run: >
         set -o pipefail &&
         xcodebuild -skipPackagePluginValidation -scheme RoktUXHelper -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' -enableCodeCoverage YES -derivedDataPath DerivedData clean build test

--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -33,7 +33,6 @@ jobs:
       - name: Run unit tests
         uses: ./.github/composite_actions/run_xcodebuild_tests
         with:
-          use-swift-5: true
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
       - uses: ffurrer2/extract-release-notes@cae32133495112d23e3569ad04fef240ba4e7bc8 # v2.3.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 gem 'fastlane'
 gem 'activesupport', '~> 7.0.8'
+gem 'rexml', '>= 3.4.2'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,4 +241,4 @@ DEPENDENCIES
   rexml (>= 3.4.2)
 
 BUNDLED WITH
-   2.5.6
+   2.5.11

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,7 +183,7 @@ GEM
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.3.9)
+    rexml (3.4.4)
     rouge (2.0.7)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
@@ -238,6 +238,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport (~> 7.0.8)
   fastlane
+  rexml (>= 3.4.2)
 
 BUNDLED WITH
-   2.5.11
+   2.5.6


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Background

- Changed the Xcode version from 15.4 to 16.4.0
- Removed the `use-swift-5` input parameter as it is no longer needed.
- Updated the test command to reflect the new Xcode version and simulator settings.

### What Has Changed


### How Has This Been Tested?


### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have updated CHANGELOG.md relevant notes.
