### PR TITLE
feat: Add support for `DATA.catalogItem.copy` placeholders

### DIFF
--- a/Tests/RoktUXHelperTests/Data/Expansion/Extractor/CatalogDataExtractorTests.swift
+++ b/Tests/RoktUXHelperTests/Data/Expansion/Extractor/CatalogDataExtractorTests.swift
@@ -79,4 +79,36 @@ final class CatalogDataExtractorTests: XCTestCase {
             .value("$14.99")
         )
     }
+
+    func test_extractDataRepresentedBy_usingCatalogCopyKey_returnsCopyValue() {
+        XCTAssertEqual(
+            try sut?.extractDataRepresentedBy(
+                String.self,
+                propertyChain: "DATA.catalogItem.copy.provider.variationTitle",
+                responseKey: nil,
+                from: catalogItem
+            ),
+            .value("Burnt Clay")
+        )
+
+        XCTAssertEqual(
+            try sut?.extractDataRepresentedBy(
+                String.self,
+                propertyChain: "DATA.catalogItem.copy.provider.discountLabel",
+                responseKey: nil,
+                from: catalogItem
+            ),
+            .value("Save 20%")
+        )
+
+        XCTAssertEqual(
+            try sut?.extractDataRepresentedBy(
+                String.self,
+                propertyChain: "DATA.catalogItem.copy.provider.pricing.shippingFees",
+                responseKey: nil,
+                from: catalogItem
+            ),
+            .value("4.90")
+        )
+    }
 }

--- a/Tests/RoktUXHelperTests/Supporting Files/add_to_cart_page_model.json
+++ b/Tests/RoktUXHelperTests/Supporting Files/add_to_cart_page_model.json
@@ -100,7 +100,13 @@
                                   "addOns": [],
                                   "addOnPluginUrl": "https://www.rokt.com",
                                   "addOnPluginName": "arrive-plugin",
-                                  "token": "catalog1Token"
+                                  "token": "catalog1Token",
+                                  "copy": {
+                                      "provider.discountLabel": "Save 20%",
+                                      "provider.color.hex": "#E6B8A2",
+                                      "provider.variationTitle": "Burnt Clay",
+                                      "provider.pricing.shippingFees": "4.90"
+                                  }
                               },
                               {
                                   "images": {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

The placeholders with `DATA.catalogItem.copy` prefix are not supported on iOS

## What Has Changed

- Refactor CatalogDataExtractor and add support for extracting copy properties
- Added unit tests

## Screenshots/Video


## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- {Any additional information or context relevant to this PR}

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes [ticket](https://go/j/[ticket-number])
