### PR TITLE
fix: harden GitHub Actions workflows and add zizmor CI check

### DIFF
--- a/.github/workflows/maintenance-trunk-upgrade.yml
+++ b/.github/workflows/maintenance-trunk-upgrade.yml
@@ -38,7 +38,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Trunk Check
         uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Trunk Check
         uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
         with:
@@ -30,6 +32,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Lint podspec
         run: pod lib lint RoktUXHelper.podspec --allow-warnings --verbose
@@ -39,6 +43,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Resolve Packages
         run: swift package resolve --verbose

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get current version
         id: version-file
@@ -59,6 +61,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Publish to CocoaPods
         env:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -24,7 +24,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Install zizmor

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,38 @@
+name: Zizmor Security Scan
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+      - .github/composite_actions/**
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+      - .github/composite_actions/**
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Scan GitHub Actions workflows
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install zizmor
+        run: pipx install zizmor==1.23.1
+      # continue-on-error: true until pre-existing findings are resolved.
+      # Once triaged, remove this flag to make zizmor a hard blocker.
+      - name: Run zizmor
+        continue-on-error: true
+        run: zizmor --format plain .
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Add `persist-credentials: false` to 7 checkout steps across 4 files (3 existing workflows + new zizmor.yml) — prevents credential leakage via artifacts
- Normalize version comment formatting on maintenance-trunk-upgrade.yml
- Add `zizmor.yml` CI workflow that scans GitHub Actions on every PR touching workflow files:
  - Pinned to zizmor v1.23.1 via pipx
  - Pinned to ubuntu-24.04 runner
  - Passes `GH_TOKEN` for richer audits (`contents: read` scope — sufficient for reading workflow files)
  - Uses `continue-on-error: true` at step level until pre-existing findings are triaged
  - Push trigger on main catches direct pushes that bypass PRs
  - `timeout-minutes: 5`
  - Includes `workflow_dispatch` for manual runs

**Intentionally not changed:**
- `release-draft.yml` — uses `peter-evans/create-pull-request`, needs git credentials
- `release-patch.yml` — does `git push`, needs git credentials
- `utility-create-workstation.yml` — does `git push`, needs git credentials

**Permissions unchanged** — existing workflow-level permissions left as-is to avoid CI breakage (tracked as follow-up for future hardening pass).

## Test plan
- [x] Verify CI/CD pipelines run successfully (trunk-check, podspec-lint passing; unit-test pending)
- [ ] Confirm zizmor workflow runs after merge (new workflow — only triggers once merged to main)

## Rollback plan
Revert this PR.