### PR TITLE
feat: decode transactionData on Offer for PPU on iOS (UTYP-1396)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add CatalogImageGallery snapshot test covering navigation buttons, pill indicator, and gallery image rendering
 - Document CatalogImageGallery in TESTING.md coverage matrix and add data URI / ARGB hex guidance
+- Decode `transactionData` (with `Address` and `PaymentMethod` types) on `OfferModel` to support PPU on iOS
 
 ### Fixed
 

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/OfferModel.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/OfferModel.swift
@@ -5,6 +5,7 @@ struct OfferModel: Codable {
     let creative: CreativeModel
     let catalogItems: [CatalogItem]?
     let catalogItemGroup: CatalogItemGroup?
+    let transactionData: TransactionData?
 }
 
 struct CreativeModel: Codable {

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/TransactionData.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/TransactionData.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+struct TransactionData: Codable {
+    let shippingAddress: Address?
+    let billingAddress: Address?
+    let paymentType: String?
+    let supportedPaymentMethods: [PaymentMethod]?
+    let isPartnerManagedPurchase: Bool
+    let partnerPaymentReference: String?
+    let confirmationRef: String?
+    let metadata: [String: String]
+}
+
+struct PaymentMethod: Codable {
+    enum MethodType: String, Codable {
+        case unspecified = "UNSPECIFIED"
+        case other = "OTHER"
+        case card = "CARD"
+        case applePay = "APPLE_PAY"
+        case paypal = "PAYPAL"
+        case googlePay = "GOOGLE_PAY"
+        case unknown
+
+        init(from decoder: Decoder) throws {
+            let raw = try decoder.singleValueContainer().decode(String.self)
+            self = MethodType(rawValue: raw) ?? .unknown
+        }
+    }
+
+    let type: MethodType
+}
+
+struct Address: Codable {
+    let name: String
+    let address1: String
+    let address2: String?
+    let city: String
+    let state: String
+    let stateCode: String
+    let country: String
+    let countryCode: String
+    let zip: String?
+}

--- a/Tests/RoktUXHelperTests/Data/Model/ExperienceResponse/TransactionDataTests.swift
+++ b/Tests/RoktUXHelperTests/Data/Model/ExperienceResponse/TransactionDataTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import RoktUXHelper
+
+@available(iOS 15, *)
+final class TransactionDataTests: XCTestCase {
+
+    private let decoder = JSONDecoder()
+
+    func test_decodes_full_payload() throws {
+        let json = """
+        {
+            "shippingAddress": {
+                "name": "",
+                "address1": "123 Mock St",
+                "address2": "Apt 4B",
+                "city": "Mock City",
+                "state": "CA",
+                "stateCode": "",
+                "country": "US",
+                "countryCode": "",
+                "zip": "90210"
+            },
+            "paymentType": "amex",
+            "supportedPaymentMethods": [
+                { "type": "CARD" },
+                { "type": "APPLE_PAY" }
+            ],
+            "isPartnerManagedPurchase": false,
+            "partnerPaymentReference": "hg206hsc",
+            "confirmationRef": "hg206hsc",
+            "metadata": {}
+        }
+        """.data(using: .utf8)!
+
+        let sut = try decoder.decode(TransactionData.self, from: json)
+
+        XCTAssertEqual(sut.shippingAddress?.address1, "123 Mock St")
+        XCTAssertEqual(sut.shippingAddress?.zip, "90210")
+        XCTAssertNil(sut.billingAddress)
+        XCTAssertEqual(sut.paymentType, "amex")
+        XCTAssertEqual(sut.supportedPaymentMethods?.map { $0.type }, [.card, .applePay])
+        XCTAssertFalse(sut.isPartnerManagedPurchase)
+        XCTAssertEqual(sut.partnerPaymentReference, "hg206hsc")
+        XCTAssertEqual(sut.confirmationRef, "hg206hsc")
+        XCTAssertEqual(sut.metadata, [:])
+    }
+
+    func test_decodes_minimal_payload() throws {
+        let json = """
+        {
+            "isPartnerManagedPurchase": true,
+            "metadata": { "foo": "bar" }
+        }
+        """.data(using: .utf8)!
+
+        let sut = try decoder.decode(TransactionData.self, from: json)
+
+        XCTAssertNil(sut.shippingAddress)
+        XCTAssertNil(sut.billingAddress)
+        XCTAssertNil(sut.paymentType)
+        XCTAssertNil(sut.supportedPaymentMethods)
+        XCTAssertTrue(sut.isPartnerManagedPurchase)
+        XCTAssertNil(sut.partnerPaymentReference)
+        XCTAssertNil(sut.confirmationRef)
+        XCTAssertEqual(sut.metadata, ["foo": "bar"])
+    }
+
+    func test_missing_metadata_throws() {
+        let json = """
+        { "isPartnerManagedPurchase": false }
+        """.data(using: .utf8)!
+
+        XCTAssertThrowsError(try decoder.decode(TransactionData.self, from: json))
+    }
+
+    func test_unknown_payment_method_type_falls_back_to_unknown() throws {
+        let json = """
+        { "type": "CRYPTO" }
+        """.data(using: .utf8)!
+
+        let sut = try decoder.decode(PaymentMethod.self, from: json)
+
+        XCTAssertEqual(sut.type, .unknown)
+    }
+
+    func test_offer_without_transaction_data_decodes() throws {
+        let json = """
+        {
+            "campaignId": "c1",
+            "creative": {
+                "referralCreativeId": "r1",
+                "instanceGuid": "i1",
+                "copy": {},
+                "token": "t1"
+            }
+        }
+        """.data(using: .utf8)!
+
+        let sut = try decoder.decode(OfferModel.self, from: json)
+
+        XCTAssertNil(sut.transactionData)
+    }
+
+    func test_offer_decodes_transaction_data() throws {
+        let json = """
+        {
+            "campaignId": "c1",
+            "creative": {
+                "referralCreativeId": "r1",
+                "instanceGuid": "i1",
+                "copy": {},
+                "token": "t1"
+            },
+            "transactionData": {
+                "isPartnerManagedPurchase": false,
+                "metadata": {}
+            }
+        }
+        """.data(using: .utf8)!
+
+        let sut = try decoder.decode(OfferModel.self, from: json)
+
+        XCTAssertNotNil(sut.transactionData)
+        XCTAssertFalse(sut.transactionData?.isPartnerManagedPurchase ?? true)
+    }
+}

--- a/Tests/RoktUXHelperTests/Services/LayoutTransformer/TestLayoutTransformer.swift
+++ b/Tests/RoktUXHelperTests/Services/LayoutTransformer/TestLayoutTransformer.swift
@@ -669,7 +669,8 @@ final class TestLayoutTransformer: XCTestCase {
             campaignId: "campaignId",
             creative: creative,
             catalogItems: nil,
-            catalogItemGroup: nil
+            catalogItemGroup: nil,
+            transactionData: nil
         )
     }
 

--- a/Tests/RoktUXHelperTests/UI/Components/TestDataImageComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestDataImageComponent.swift
@@ -113,7 +113,8 @@ final class TestDataImageComponent: XCTestCase {
                                                           responseOptionsMap: nil,
                                                           jwtToken: "creative-token"),
                                            catalogItems: nil,
-                                           catalogItemGroup: nil),
+                                           catalogItemGroup: nil,
+                                           transactionData: nil),
                          layoutVariant: nil,
                          jwtToken: "slot-token")
     }

--- a/Tests/RoktUXHelperTests/UI/Components/TestImageCarouselComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestImageCarouselComponent.swift
@@ -68,7 +68,8 @@ final class TestImageCarouselComponent: XCTestCase {
                                                           responseOptionsMap: nil,
                                                           jwtToken: "creative-token"),
                                            catalogItems: nil,
-                                           catalogItemGroup: nil),
+                                           catalogItemGroup: nil,
+                                           transactionData: nil),
                          layoutVariant: nil,
                          jwtToken: "slot-token")
     }

--- a/Tests/RoktUXHelperTests/UI/Utils/MockModels.swift
+++ b/Tests/RoktUXHelperTests/UI/Utils/MockModels.swift
@@ -90,7 +90,8 @@ extension OfferModel {
                 jwtToken: token
             ),
             catalogItems: catalogItems,
-            catalogItemGroup: nil
+            catalogItemGroup: nil,
+            transactionData: nil
         )
     }
 }

--- a/Tests/RoktUXHelperTests/UI/ViewModel/CatalogDropdownViewModelTests.swift
+++ b/Tests/RoktUXHelperTests/UI/ViewModel/CatalogDropdownViewModelTests.swift
@@ -102,7 +102,8 @@ final class CatalogDropdownViewModelTests: XCTestCase {
                 jwtToken: ""
             ),
             catalogItems: [item1, item2],
-            catalogItemGroup: group
+            catalogItemGroup: group,
+            transactionData: nil
         )
         layoutState.items[LayoutState.fullOfferKey] = offer
 

--- a/Tests/RoktUXHelperTests/UI/ViewModel/TestWhenViewModel.swift
+++ b/Tests/RoktUXHelperTests/UI/ViewModel/TestWhenViewModel.swift
@@ -1149,7 +1149,8 @@ final class TestWhenViewModel: XCTestCase {
                 responseOptionsMap: nil,
                 jwtToken: "jwtToken1"),
             catalogItems: catalogItems,
-            catalogItemGroup: nil)
+            catalogItemGroup: nil,
+            transactionData: nil)
     }
     
     func get_shared_data_with_breakpoints() -> BreakPoint {


### PR DESCRIPTION
## Background

- Part of the PPU on iOS initiative. The experiences API now returns a `transactionData` object on each offer (shipping/billing addresses, payment type, supported payment methods, partner-managed purchase metadata). The iOS UX Helper needs to decode this so downstream PPU flows can consume it.

## What Has Changed

- New Codable types `TransactionData`, `PaymentMethod`, and `Address` under `Sources/RoktUXHelper/Data/Model/ExperienceResponse/`.
- `OfferModel` gains an optional `transactionData: TransactionData?` field.
- `PaymentMethod.MethodType` falls back to `.unknown` for unrecognized strings via a custom `init(from:)`, so future server-side enum values do not break decoding.
- `metadata` and `isPartnerManagedPurchase` are required by the contract — decoding throws if absent.
- Test fixtures updated to pass `transactionData: nil` to `OfferModel` constructors.

## Screenshots/Video

- N/A — model-layer change, no UI.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- 6 new unit tests cover: full payload decode, minimal payload decode, missing required \`metadata\` throws, unknown \`PaymentMethod.type\` falls back to \`.unknown\`, and \`OfferModel\` decodes with and without \`transactionData\`.
- Full local suite green: 640 tests passing.
- No UI/consumer wiring in scope — separate follow-up.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes [ticket](https://go/j/UTYP-1396)

🤖 Generated with [Claude Code](https://claude.com/claude-code)