### PR TITLE
feat: add AFTERPAY case to supported payment methods enum

### DIFF
--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/TransactionData.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/TransactionData.swift
@@ -19,6 +19,7 @@ struct PaymentMethod: Codable {
         case applePay = "APPLE_PAY"
         case paypal = "PAYPAL"
         case googlePay = "GOOGLE_PAY"
+        case afterpay = "AFTERPAY"
         case unknown
 
         init(from decoder: Decoder) throws {

--- a/Tests/RoktUXHelperTests/Data/Model/ExperienceResponse/TransactionDataTests.swift
+++ b/Tests/RoktUXHelperTests/Data/Model/ExperienceResponse/TransactionDataTests.swift
@@ -23,7 +23,8 @@ final class TransactionDataTests: XCTestCase {
             "paymentType": "amex",
             "supportedPaymentMethods": [
                 { "type": "CARD" },
-                { "type": "APPLE_PAY" }
+                { "type": "APPLE_PAY" },
+                { "type": "AFTERPAY" }
             ],
             "isPartnerManagedPurchase": false,
             "partnerPaymentReference": "hg206hsc",
@@ -38,7 +39,7 @@ final class TransactionDataTests: XCTestCase {
         XCTAssertEqual(sut.shippingAddress?.zip, "90210")
         XCTAssertNil(sut.billingAddress)
         XCTAssertEqual(sut.paymentType, "amex")
-        XCTAssertEqual(sut.supportedPaymentMethods?.map { $0.type }, [.card, .applePay])
+        XCTAssertEqual(sut.supportedPaymentMethods?.map { $0.type }, [.card, .applePay, .afterpay])
         XCTAssertFalse(sut.isPartnerManagedPurchase)
         XCTAssertEqual(sut.partnerPaymentReference, "hg206hsc")
         XCTAssertEqual(sut.confirmationRef, "hg206hsc")

--- a/Tests/RoktUXHelperTests/UI/Components/TestCatalogDropdownComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestCatalogDropdownComponent.swift
@@ -131,7 +131,8 @@ final class TestCatalogDropdownComponent: XCTestCase {
                 jwtToken: ""
             ),
             catalogItems: items,
-            catalogItemGroup: group
+            catalogItemGroup: group,
+            transactionData: nil
         )
         layoutState.items[LayoutState.fullOfferKey] = offer
         return layoutState

--- a/Tests/RoktUXHelperTests/UI/ViewModel/CatalogDropdownViewModelTests.swift
+++ b/Tests/RoktUXHelperTests/UI/ViewModel/CatalogDropdownViewModelTests.swift
@@ -80,7 +80,8 @@ final class CatalogDropdownViewModelTests: XCTestCase {
                 jwtToken: ""
             ),
             catalogItems: [CatalogItem.mock(catalogItemId: "item1", inventoryStatus: "InStock")],
-            catalogItemGroup: nil
+            catalogItemGroup: nil,
+            transactionData: nil
         )
         layoutState.items[LayoutState.fullOfferKey] = offer
 


### PR DESCRIPTION
## Background

- A follow-up to [UTYP-1396](https://go/j/UTYP-1396) which added decoding for `transactionData` on the experiences response. Afterpay support is currently being added to PPU, and the backend is expected to send it as one of the values in `supportedPaymentMethods[].type`. Adding the enum case preemptively so the iOS UX Helper can decode it without falling back to `.unknown`.

## What Has Changed

- Added `afterpay = "AFTERPAY"` to `PaymentMethod.MethodType` in `TransactionData.swift`.
- Updated `TransactionDataTests` to cover decoding the new raw value.
- Fixed two preexisting compile errors in test targets where `transactionData: nil` was missing on `OfferModel` construction (caused by merge-order between PRs #250 and #251 on `main`):
  - `TestCatalogDropdownComponent.swift`
  - `CatalogDropdownViewModelTests.swift`

## Screenshots/Video

- N/A (no UI change)

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- The raw value `"AFTERPAY"` is an inference based on the backend's existing SCREAMING_SNAKE_CASE convention (e.g. `APPLE_PAY`, `GOOGLE_PAY`, `PAYPAL`) and the brand being written as one word. It has **not** been confirmed with the backend owner — if they ship `AFTER_PAY` instead, decoding still succeeds (falls through to `.unknown` via the existing fallback in the custom `init(from:)`), and the raw value can be updated in a follow-up release. No consumer code in `Sources/` currently branches on `MethodType.afterpay`, so a casing mismatch has no runtime behavior impact in this release.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes [ticket](https://go/j/UTYP-1396)

[UTYP-1396]: https://rokt.atlassian.net/browse/UTYP-1396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ