### PR TITLE
feat: expose TransactionData on CartItemDevicePay event

### DIFF
--- a/Sources/RoktUXHelper/Data/Model/Event/RoktUXEvent.swift
+++ b/Sources/RoktUXHelper/Data/Model/Event/RoktUXEvent.swift
@@ -184,6 +184,10 @@ public class RoktUXEvent {
         public let totalPrice: Decimal?
         public let unitPrice: Decimal?
         public let paymentProvider: PaymentProvider
+        /// Backend-provided transaction data (billing / shipping address, supported
+        /// payment methods, partner payment reference). `nil` if the offer did not
+        /// include transaction data.
+        public let transactionData: TransactionData?
 
         init(layoutId: String,
              name: String,
@@ -196,7 +200,8 @@ public class RoktUXEvent {
              quantity: Decimal,
              totalPrice: Decimal?,
              unitPrice: Decimal?,
-             paymentProvider: PaymentProvider) {
+             paymentProvider: PaymentProvider,
+             transactionData: TransactionData?) {
             self.layoutId = layoutId
             self.name = name
             self.cartItemId = cartItemId
@@ -209,6 +214,7 @@ public class RoktUXEvent {
             self.totalPrice = totalPrice
             self.unitPrice = unitPrice
             self.paymentProvider = paymentProvider
+            self.transactionData = transactionData
         }
     }
 

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/TransactionData.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/TransactionData.swift
@@ -1,18 +1,23 @@
 import Foundation
 
-struct TransactionData: Codable {
-    let shippingAddress: Address?
-    let billingAddress: Address?
-    let paymentType: String?
-    let supportedPaymentMethods: [PaymentMethod]?
-    let isPartnerManagedPurchase: Bool
-    let partnerPaymentReference: String?
-    let confirmationRef: String?
-    let metadata: [String: String]
+/// Transaction-level data decoded from the backend experience response.
+///
+/// Exposed publicly so the Rokt SDK (and partner apps, via `RoktUXEvent.CartItemDevicePay`)
+/// can read the pre-collected billing / shipping / supported-methods information the
+/// backend provides, instead of requiring partners to re-supply these as attributes.
+public struct TransactionData: Codable {
+    public let shippingAddress: Address?
+    public let billingAddress: Address?
+    public let paymentType: String?
+    public let supportedPaymentMethods: [PaymentMethod]?
+    public let isPartnerManagedPurchase: Bool
+    public let partnerPaymentReference: String?
+    public let confirmationRef: String?
+    public let metadata: [String: String]
 }
 
-struct PaymentMethod: Codable {
-    enum MethodType: String, Codable {
+public struct PaymentMethod: Codable {
+    public enum MethodType: String, Codable {
         case unspecified = "UNSPECIFIED"
         case other = "OTHER"
         case card = "CARD"
@@ -22,23 +27,23 @@ struct PaymentMethod: Codable {
         case afterpay = "AFTERPAY"
         case unknown
 
-        init(from decoder: Decoder) throws {
+        public init(from decoder: Decoder) throws {
             let raw = try decoder.singleValueContainer().decode(String.self)
             self = MethodType(rawValue: raw) ?? .unknown
         }
     }
 
-    let type: MethodType
+    public let type: MethodType
 }
 
-struct Address: Codable {
-    let name: String
-    let address1: String
-    let address2: String?
-    let city: String
-    let state: String
-    let stateCode: String
-    let country: String
-    let countryCode: String
-    let zip: String?
+public struct Address: Codable {
+    public let name: String
+    public let address1: String
+    public let address2: String?
+    public let city: String
+    public let state: String
+    public let stateCode: String
+    public let country: String
+    public let countryCode: String
+    public let zip: String?
 }

--- a/Sources/RoktUXHelper/RoktUX.swift
+++ b/Sources/RoktUXHelper/RoktUX.swift
@@ -607,7 +607,12 @@ public class RoktUX: UXEventsDelegate {
         ))
     }
 
-    func onCartItemDevicePay(_ layoutId: String, catalogItem: CatalogItem, paymentProvider: PaymentProvider) {
+    func onCartItemDevicePay(
+        _ layoutId: String,
+        catalogItem: CatalogItem,
+        paymentProvider: PaymentProvider,
+        transactionData: TransactionData?
+    ) {
         onRoktEvent?(RoktUXEvent.CartItemDevicePay(
             layoutId: layoutId,
             name: catalogItem.title,
@@ -620,7 +625,8 @@ public class RoktUX: UXEventsDelegate {
             quantity: 1,
             totalPrice: catalogItem.originalPrice,
             unitPrice: catalogItem.originalPrice,
-            paymentProvider: paymentProvider
+            paymentProvider: paymentProvider,
+            transactionData: transactionData
         ))
     }
 

--- a/Sources/RoktUXHelper/Services/Events/EventService.swift
+++ b/Sources/RoktUXHelper/Services/Events/EventService.swift
@@ -208,6 +208,7 @@ class EventService: Hashable, EventDiagnosticServicing {
     func cartItemDevicePay(
         catalogItem: CatalogItem,
         paymentProvider: PaymentProvider,
+        transactionData: TransactionData?,
         completion: @escaping (_ status: DevicePayStatus) -> Void
     ) {
         let objectData = [
@@ -215,7 +216,12 @@ class EventService: Hashable, EventDiagnosticServicing {
             kQuantity: "1"
         ]
         sendCartItemEvent(eventType: .SignalCartItemInstantPurchaseInitiated, catalogItem: catalogItem, objectData: objectData)
-        uxEventDelegate?.onCartItemDevicePay(pluginId, catalogItem: catalogItem, paymentProvider: paymentProvider)
+        uxEventDelegate?.onCartItemDevicePay(
+            pluginId,
+            catalogItem: catalogItem,
+            paymentProvider: paymentProvider,
+            transactionData: transactionData
+        )
 
         self.devicePayCompletion = completion
     }

--- a/Sources/RoktUXHelper/Services/Events/EventServicing.swift
+++ b/Sources/RoktUXHelper/Services/Events/EventServicing.swift
@@ -20,6 +20,7 @@ protocol EventServicing: AnyObject {
     func cartItemDevicePay(
         catalogItem: CatalogItem,
         paymentProvider: PaymentProvider,
+        transactionData: TransactionData?,
         completion: @escaping (_ status: DevicePayStatus) -> Void
     )
     func cartItemDevicePaySuccess(itemId: String)

--- a/Sources/RoktUXHelper/Services/LayoutTransformer/LayoutTransformer.swift
+++ b/Sources/RoktUXHelper/Services/LayoutTransformer/LayoutTransformer.swift
@@ -542,6 +542,7 @@ where CreativeSyntaxMapper.Context == CreativeContext, AddToCartMapper.Context =
             break
         }
 
+        let transactionData = (layoutState.items[LayoutState.fullOfferKey] as? OfferModel)?.transactionData
         let updateStyles = try StyleTransformer.updatedStyles(model.styles?.elements?.own)
         return CatalogDevicePayButtonViewModel(
             catalogItem: catalogItem,
@@ -553,7 +554,8 @@ where CreativeSyntaxMapper.Context == CreativeContext, AddToCartMapper.Context =
             pressedStyle: updateStyles.compactMap { $0.pressed },
             hoveredStyle: updateStyles.compactMap { $0.hovered },
             disabledStyle: updateStyles.compactMap { $0.disabled },
-            validatorTriggerConfig: model.validatorTriggerConfig
+            validatorTriggerConfig: model.validatorTriggerConfig,
+            transactionData: transactionData
         )
     }
 

--- a/Sources/RoktUXHelper/Services/UXEventsDelegate.swift
+++ b/Sources/RoktUXHelper/Services/UXEventsDelegate.swift
@@ -23,6 +23,11 @@ protocol UXEventsDelegate: AnyObject {
                  onError: @escaping (String, Error?) -> Void)
 
     func onCartItemInstantPurchase(_ layoutId: String, catalogItem: CatalogItem)
-    func onCartItemDevicePay(_ layoutId: String, catalogItem: CatalogItem, paymentProvider: PaymentProvider)
+    func onCartItemDevicePay(
+        _ layoutId: String,
+        catalogItem: CatalogItem,
+        paymentProvider: PaymentProvider,
+        transactionData: TransactionData?
+    )
     func onCartItemForwardPayment(_ layoutId: String, catalogItem: CatalogItem, partnerPaymentReference: String?)
 }

--- a/Sources/RoktUXHelper/UI/Components/ViewModel/CatalogDevicePayButtonViewModel.swift
+++ b/Sources/RoktUXHelper/UI/Components/ViewModel/CatalogDevicePayButtonViewModel.swift
@@ -19,6 +19,7 @@ class CatalogDevicePayButtonViewModel: Identifiable, Hashable, ScreenSizeAdaptiv
     let hoveredStyle: [CatalogDevicePayButtonStyles]?
     let disabledStyle: [CatalogDevicePayButtonStyles]?
     let validatorTriggerConfig: ValidationTriggerConfig?
+    let transactionData: TransactionData?
     let customStateKey = CustomStateIdentifiable.Keys.paymentResult.rawValue
     var position: Int?
 
@@ -32,7 +33,8 @@ class CatalogDevicePayButtonViewModel: Identifiable, Hashable, ScreenSizeAdaptiv
         pressedStyle: [CatalogDevicePayButtonStyles]?,
         hoveredStyle: [CatalogDevicePayButtonStyles]?,
         disabledStyle: [CatalogDevicePayButtonStyles]?,
-        validatorTriggerConfig: ValidationTriggerConfig?
+        validatorTriggerConfig: ValidationTriggerConfig?,
+        transactionData: TransactionData? = nil
     ) {
         self.catalogItem = catalogItem
         self.children = children
@@ -44,6 +46,7 @@ class CatalogDevicePayButtonViewModel: Identifiable, Hashable, ScreenSizeAdaptiv
         self.layoutState = layoutState
         self.eventService = eventService
         self.validatorTriggerConfig = validatorTriggerConfig
+        self.transactionData = transactionData
     }
 
     func handleTap() {
@@ -62,6 +65,7 @@ class CatalogDevicePayButtonViewModel: Identifiable, Hashable, ScreenSizeAdaptiv
         eventService?.cartItemDevicePay(
             catalogItem: catalogItem,
             paymentProvider: provider,
+            transactionData: transactionData,
             completion: { [weak self] status in
                 guard let self else { return }
                 self.handleDevicePayCompletion(status: status)

--- a/Tests/RoktUXHelperTests/Services/Events/TestEventService.swift
+++ b/Tests/RoktUXHelperTests/Services/Events/TestEventService.swift
@@ -719,8 +719,10 @@ class MockUXHelper: UXEventsDelegate {
         self.roktEvents.append(.CartItemInstantPurchase)
     }
 
-    func onCartItemDevicePay(_ layoutId: String, catalogItem: RoktUXHelper.CatalogItem,
-                             paymentProvider: DcuiSchema.PaymentProvider) {
+    func onCartItemDevicePay(_ layoutId: String,
+                             catalogItem: RoktUXHelper.CatalogItem,
+                             paymentProvider: DcuiSchema.PaymentProvider,
+                             transactionData: TransactionData?) {
         self.roktEvents.append(.CartItemDevicePay)
     }
 

--- a/Tests/RoktUXHelperTests/UI/ViewModel/Mocks/MockEventService.swift
+++ b/Tests/RoktUXHelperTests/UI/ViewModel/Mocks/MockEventService.swift
@@ -121,13 +121,16 @@ class MockEventService: EventDiagnosticServicing {
     }
 
     var cartItemDevicePayCompletionCallback: ((DevicePayStatus) -> Void)?
+    var cartItemDevicePayLastTransactionData: TransactionData?
 
     func cartItemDevicePay(
         catalogItem: CatalogItem,
         paymentProvider: DcuiSchema.PaymentProvider,
+        transactionData: TransactionData?,
         completion: @escaping (DevicePayStatus) -> Void
     ) {
         cartItemDevicePayCalled = true
+        cartItemDevicePayLastTransactionData = transactionData
         cartItemDevicePayCompletionCallback = completion
     }
 


### PR DESCRIPTION
## Background

- The backend includes `TransactionData` (billing/shipping address, supported payment methods, partner payment reference, etc.) on catalog offers, and it is already decoded inside the UX helper.
- Downstream consumers (`rokt-sdk-ios` → Payment Extension) do not have access to this data via the `CartItemDevicePay` event chain, so the SDK currently re-derives address info from `selectShoppableAds(attributes:)` — forcing partners to pass data the backend already owns.
- This PR plumbs `TransactionData` through the event so the SDK and partner apps can consume it directly. This is Step 1 of the broader Afterpay / flexible payment-extension follow-up.

## What Has Changed

- `TransactionData`, `PaymentMethod`, `PaymentMethod.MethodType`, and `Address` promoted from internal to `public` so the SDK (and partners, via the public `RoktUXEvent.CartItemDevicePay`) can read them.
- Added `transactionData: TransactionData?` to `RoktUXEvent.CartItemDevicePay` (additive, nullable — source-compatible for existing consumers).
- Threaded `transactionData` through the event chain: `CatalogDevicePayButtonViewModel` → `EventService.cartItemDevicePay` → `UXEventsDelegate.onCartItemDevicePay` → `RoktUX` event emission.
- `LayoutTransformer.getCatalogDevicePayButton` now reads the offer's `transactionData` from `layoutState.items[LayoutState.fullOfferKey]` (same pattern already used by `CatalogResponseButton`) and injects it into the view model.

## Screenshots/Video

- N/A — backend-facing plumbing only, no UI changes.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Nullable/additive change: no consumer is forced to update. The SDK can adopt `event.transactionData` at its own pace and fall back to partner-provided attributes while older UX helper versions are still in the wild.
- Minor mock updates (`MockEventService`, `MockUXHelper`) to match the new signatures; `MockEventService` also captures the last `transactionData` for future assertions.
- No schema or protocol bump required — `TransactionData` decoding already lives in this package; this PR just surfaces it.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- N/A