### PR TITLE
fix: make RoktIntegrationInfoDetails properties public

### DIFF
--- a/Sources/RoktUXHelper/Data/Model/RoktIntegrationInfoDetails.swift
+++ b/Sources/RoktUXHelper/Data/Model/RoktIntegrationInfoDetails.swift
@@ -33,7 +33,7 @@ public struct RoktIntegrationInfoDetails: Codable {
     let deviceModel: String
     let deviceLocale: String
     let framework: String
-    let layoutSchemaVersion: String
+    public let layoutSchemaVersion: String
     let name: String
     let version: String
     let operatingSystem: String

--- a/Sources/RoktUXHelper/Data/Model/RoktIntegrationInfoDetails.swift
+++ b/Sources/RoktUXHelper/Data/Model/RoktIntegrationInfoDetails.swift
@@ -29,18 +29,18 @@ public struct RoktIntegrationInfo: Encodable {
 }
 
 public struct RoktIntegrationInfoDetails: Codable {
-    let deviceType: String
-    let deviceModel: String
-    let deviceLocale: String
-    let framework: String
+    public let deviceType: String
+    public let deviceModel: String
+    public let deviceLocale: String
+    public let framework: String
     public let layoutSchemaVersion: String
-    let name: String
-    let version: String
-    let operatingSystem: String
-    let operatingSystemVersion: String
-    let packageVersion: String?
-    let packageName: String?
-    let platform: String
+    public let name: String
+    public let version: String
+    public let operatingSystem: String
+    public let operatingSystemVersion: String
+    public let packageVersion: String?
+    public let packageName: String?
+    public let platform: String
 
     init(
         deviceType: String = UIDevice.current.userInterfaceIdiom.string,


### PR DESCRIPTION
## Background

`RoktIntegrationInfoDetails` is a `public struct` but all its stored properties were `internal` by default. This prevented consumers from accessing fields like `layoutSchemaVersion` directly, requiring JSON workarounds.

## What Has Changed

- Made all stored properties on `RoktIntegrationInfoDetails` explicitly `public`
- Enables direct access via `RoktUX.integrationInfo.integration.layoutSchemaVersion` (and all other fields) from consumer modules

## How Has This Been Tested

Build verified locally. No logic changed — access levels only.

## Notes

Prerequisite for [rokt-sdk-ios#136](https://github.com/ROKT/rokt-sdk-ios/pull/136) which uses `layoutSchemaVersion` to derive the `rokt-layout-schema-version` request header dynamically.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.