### PR TITLE
feat: expose TransactionData on CartItemForwardPayment event (UTYP-1406)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ROKT/dcui-swift-schema.git",
       "state" : {
-        "revision" : "a1b236c4b405de304da1a597bfdb4379bcf57284",
-        "version" : "2.5.0"
+        "revision" : "760d75d48a16a87b5abcb363b2167390cc7c0341",
+        "version" : "2.6.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/ROKT/dcui-swift-schema.git", exact: "2.5.0"),
+        .package(url: "https://github.com/ROKT/dcui-swift-schema.git", exact: "2.6.0"),
         .package(url: "https://github.com/nalexn/ViewInspector.git", exact: "0.10.3"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", exact: "1.19.2")
     ],

--- a/RoktUXHelper.podspec
+++ b/RoktUXHelper.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.resource_bundles = { 'RoktUXHelper' => ['Sources/RoktUXHelper/PrivacyInfo.xcprivacy'] }
   s.frameworks       = 'Foundation', 'UIKit', 'SwiftUI', 'Combine'
 
-  s.dependency 'DcuiSchema', '~> 2.5'
+  s.dependency 'DcuiSchema', '~> 2.6'
 end

--- a/Sources/RoktUXHelper/Data/Model/Event/RoktUXEvent.swift
+++ b/Sources/RoktUXHelper/Data/Model/Event/RoktUXEvent.swift
@@ -231,6 +231,10 @@ public class RoktUXEvent {
         public let totalPrice: Decimal?
         public let unitPrice: Decimal?
         public let partnerPaymentReference: String?
+        /// Backend-provided transaction data (billing / shipping address, supported
+        /// payment methods, partner payment reference). `nil` if the offer did not
+        /// include transaction data.
+        public let transactionData: TransactionData?
 
         init(layoutId: String,
              name: String,
@@ -243,7 +247,8 @@ public class RoktUXEvent {
              quantity: Decimal,
              totalPrice: Decimal?,
              unitPrice: Decimal?,
-             partnerPaymentReference: String?) {
+             partnerPaymentReference: String?,
+             transactionData: TransactionData?) {
             self.layoutId = layoutId
             self.name = name
             self.cartItemId = cartItemId
@@ -256,6 +261,7 @@ public class RoktUXEvent {
             self.totalPrice = totalPrice
             self.unitPrice = unitPrice
             self.partnerPaymentReference = partnerPaymentReference
+            self.transactionData = transactionData
         }
     }
 }

--- a/Sources/RoktUXHelper/Data/Model/Event/RoktUXEvent.swift
+++ b/Sources/RoktUXHelper/Data/Model/Event/RoktUXEvent.swift
@@ -230,7 +230,6 @@ public class RoktUXEvent {
         public let quantity: Decimal
         public let totalPrice: Decimal?
         public let unitPrice: Decimal?
-        public let partnerPaymentReference: String?
         /// Backend-provided transaction data (billing / shipping address, supported
         /// payment methods, partner payment reference). `nil` if the offer did not
         /// include transaction data.
@@ -247,7 +246,6 @@ public class RoktUXEvent {
              quantity: Decimal,
              totalPrice: Decimal?,
              unitPrice: Decimal?,
-             partnerPaymentReference: String?,
              transactionData: TransactionData?) {
             self.layoutId = layoutId
             self.name = name
@@ -260,7 +258,6 @@ public class RoktUXEvent {
             self.quantity = quantity
             self.totalPrice = totalPrice
             self.unitPrice = unitPrice
-            self.partnerPaymentReference = partnerPaymentReference
             self.transactionData = transactionData
         }
     }

--- a/Sources/RoktUXHelper/RoktUX.swift
+++ b/Sources/RoktUXHelper/RoktUX.swift
@@ -633,7 +633,8 @@ public class RoktUX: UXEventsDelegate {
     func onCartItemForwardPayment(
         _ layoutId: String,
         catalogItem: CatalogItem,
-        partnerPaymentReference: String?
+        partnerPaymentReference: String?,
+        transactionData: TransactionData?
     ) {
         onRoktEvent?(RoktUXEvent.CartItemForwardPayment(
             layoutId: layoutId,
@@ -647,7 +648,8 @@ public class RoktUX: UXEventsDelegate {
             quantity: 1,
             totalPrice: catalogItem.originalPrice,
             unitPrice: catalogItem.originalPrice,
-            partnerPaymentReference: partnerPaymentReference
+            partnerPaymentReference: partnerPaymentReference,
+            transactionData: transactionData
         ))
     }
 }

--- a/Sources/RoktUXHelper/RoktUX.swift
+++ b/Sources/RoktUXHelper/RoktUX.swift
@@ -633,7 +633,6 @@ public class RoktUX: UXEventsDelegate {
     func onCartItemForwardPayment(
         _ layoutId: String,
         catalogItem: CatalogItem,
-        partnerPaymentReference: String?,
         transactionData: TransactionData?
     ) {
         onRoktEvent?(RoktUXEvent.CartItemForwardPayment(
@@ -648,7 +647,6 @@ public class RoktUX: UXEventsDelegate {
             quantity: 1,
             totalPrice: catalogItem.originalPrice,
             unitPrice: catalogItem.originalPrice,
-            partnerPaymentReference: partnerPaymentReference,
             transactionData: transactionData
         ))
     }

--- a/Sources/RoktUXHelper/Services/Events/EventService.swift
+++ b/Sources/RoktUXHelper/Services/Events/EventService.swift
@@ -245,6 +245,7 @@ class EventService: Hashable, EventDiagnosticServicing {
     func cartItemForwardPayment(
         catalogItem: CatalogItem,
         partnerPaymentReference: String?,
+        transactionData: TransactionData?,
         completion: @escaping (_ status: ForwardPaymentStatus) -> Void
     ) {
         guard forwardPaymentCompletion == nil else {
@@ -261,7 +262,8 @@ class EventService: Hashable, EventDiagnosticServicing {
         uxEventDelegate?.onCartItemForwardPayment(
             pluginId,
             catalogItem: catalogItem,
-            partnerPaymentReference: partnerPaymentReference
+            partnerPaymentReference: partnerPaymentReference,
+            transactionData: transactionData
         )
     }
 

--- a/Sources/RoktUXHelper/Services/Events/EventService.swift
+++ b/Sources/RoktUXHelper/Services/Events/EventService.swift
@@ -244,7 +244,6 @@ class EventService: Hashable, EventDiagnosticServicing {
 
     func cartItemForwardPayment(
         catalogItem: CatalogItem,
-        partnerPaymentReference: String?,
         transactionData: TransactionData?,
         completion: @escaping (_ status: ForwardPaymentStatus) -> Void
     ) {
@@ -262,7 +261,6 @@ class EventService: Hashable, EventDiagnosticServicing {
         uxEventDelegate?.onCartItemForwardPayment(
             pluginId,
             catalogItem: catalogItem,
-            partnerPaymentReference: partnerPaymentReference,
             transactionData: transactionData
         )
     }

--- a/Sources/RoktUXHelper/Services/Events/EventServicing.swift
+++ b/Sources/RoktUXHelper/Services/Events/EventServicing.swift
@@ -27,7 +27,6 @@ protocol EventServicing: AnyObject {
     func cartItemDevicePayFailure(itemId: String)
     func cartItemForwardPayment(
         catalogItem: CatalogItem,
-        partnerPaymentReference: String?,
         transactionData: TransactionData?,
         completion: @escaping (_ status: ForwardPaymentStatus) -> Void
     )

--- a/Sources/RoktUXHelper/Services/Events/EventServicing.swift
+++ b/Sources/RoktUXHelper/Services/Events/EventServicing.swift
@@ -28,6 +28,7 @@ protocol EventServicing: AnyObject {
     func cartItemForwardPayment(
         catalogItem: CatalogItem,
         partnerPaymentReference: String?,
+        transactionData: TransactionData?,
         completion: @escaping (_ status: ForwardPaymentStatus) -> Void
     )
     func cartItemForwardPaymentSuccess(itemId: String)

--- a/Sources/RoktUXHelper/Services/LayoutTransformer/LayoutTransformer.swift
+++ b/Sources/RoktUXHelper/Services/LayoutTransformer/LayoutTransformer.swift
@@ -882,7 +882,6 @@ where CreativeSyntaxMapper.Context == CreativeContext, AddToCartMapper.Context =
             pressedStyle: updateStyles.compactMap { $0.pressed },
             hoveredStyle: updateStyles.compactMap { $0.hovered },
             disabledStyle: updateStyles.compactMap { $0.disabled },
-            isPartnerManagedPurchase: transactionData?.isPartnerManagedPurchase ?? true,
             transactionData: transactionData
         )
     }

--- a/Sources/RoktUXHelper/Services/LayoutTransformer/LayoutTransformer.swift
+++ b/Sources/RoktUXHelper/Services/LayoutTransformer/LayoutTransformer.swift
@@ -883,7 +883,8 @@ where CreativeSyntaxMapper.Context == CreativeContext, AddToCartMapper.Context =
             hoveredStyle: updateStyles.compactMap { $0.hovered },
             disabledStyle: updateStyles.compactMap { $0.disabled },
             isPartnerManagedPurchase: transactionData?.isPartnerManagedPurchase ?? true,
-            partnerPaymentReference: transactionData?.partnerPaymentReference
+            partnerPaymentReference: transactionData?.partnerPaymentReference,
+            transactionData: transactionData
         )
     }
 

--- a/Sources/RoktUXHelper/Services/LayoutTransformer/LayoutTransformer.swift
+++ b/Sources/RoktUXHelper/Services/LayoutTransformer/LayoutTransformer.swift
@@ -883,7 +883,6 @@ where CreativeSyntaxMapper.Context == CreativeContext, AddToCartMapper.Context =
             hoveredStyle: updateStyles.compactMap { $0.hovered },
             disabledStyle: updateStyles.compactMap { $0.disabled },
             isPartnerManagedPurchase: transactionData?.isPartnerManagedPurchase ?? true,
-            partnerPaymentReference: transactionData?.partnerPaymentReference,
             transactionData: transactionData
         )
     }

--- a/Sources/RoktUXHelper/Services/UXEventsDelegate.swift
+++ b/Sources/RoktUXHelper/Services/UXEventsDelegate.swift
@@ -29,5 +29,10 @@ protocol UXEventsDelegate: AnyObject {
         paymentProvider: PaymentProvider,
         transactionData: TransactionData?
     )
-    func onCartItemForwardPayment(_ layoutId: String, catalogItem: CatalogItem, partnerPaymentReference: String?)
+    func onCartItemForwardPayment(
+        _ layoutId: String,
+        catalogItem: CatalogItem,
+        partnerPaymentReference: String?,
+        transactionData: TransactionData?
+    )
 }

--- a/Sources/RoktUXHelper/Services/UXEventsDelegate.swift
+++ b/Sources/RoktUXHelper/Services/UXEventsDelegate.swift
@@ -32,7 +32,6 @@ protocol UXEventsDelegate: AnyObject {
     func onCartItemForwardPayment(
         _ layoutId: String,
         catalogItem: CatalogItem,
-        partnerPaymentReference: String?,
         transactionData: TransactionData?
     )
 }

--- a/Sources/RoktUXHelper/UI/Components/ViewModel/CatalogResponseButtonViewModel.swift
+++ b/Sources/RoktUXHelper/UI/Components/ViewModel/CatalogResponseButtonViewModel.swift
@@ -20,8 +20,11 @@ class CatalogResponseButtonViewModel: Identifiable, Hashable, ScreenSizeAdaptive
     let hoveredStyle: [CatalogResponseButtonStyles]?
     let disabledStyle: [CatalogResponseButtonStyles]?
 
-    let isPartnerManagedPurchase: Bool
     let transactionData: TransactionData?
+
+    var isPartnerManagedPurchase: Bool {
+        transactionData?.isPartnerManagedPurchase ?? true
+    }
 
     init(catalogItem: CatalogItem?,
          children: [LayoutSchemaViewModel]?,
@@ -31,7 +34,6 @@ class CatalogResponseButtonViewModel: Identifiable, Hashable, ScreenSizeAdaptive
          pressedStyle: [CatalogResponseButtonStyles]?,
          hoveredStyle: [CatalogResponseButtonStyles]?,
          disabledStyle: [CatalogResponseButtonStyles]?,
-         isPartnerManagedPurchase: Bool = true,
          transactionData: TransactionData? = nil) {
         self.catalogItem = catalogItem
         self.children = children
@@ -41,7 +43,6 @@ class CatalogResponseButtonViewModel: Identifiable, Hashable, ScreenSizeAdaptive
         self.disabledStyle = disabledStyle
         self.layoutState = layoutState
         self.eventService = eventService
-        self.isPartnerManagedPurchase = isPartnerManagedPurchase
         self.transactionData = transactionData
     }
 

--- a/Sources/RoktUXHelper/UI/Components/ViewModel/CatalogResponseButtonViewModel.swift
+++ b/Sources/RoktUXHelper/UI/Components/ViewModel/CatalogResponseButtonViewModel.swift
@@ -21,7 +21,6 @@ class CatalogResponseButtonViewModel: Identifiable, Hashable, ScreenSizeAdaptive
     let disabledStyle: [CatalogResponseButtonStyles]?
 
     let isPartnerManagedPurchase: Bool
-    let partnerPaymentReference: String?
     let transactionData: TransactionData?
 
     init(catalogItem: CatalogItem?,
@@ -33,7 +32,6 @@ class CatalogResponseButtonViewModel: Identifiable, Hashable, ScreenSizeAdaptive
          hoveredStyle: [CatalogResponseButtonStyles]?,
          disabledStyle: [CatalogResponseButtonStyles]?,
          isPartnerManagedPurchase: Bool = true,
-         partnerPaymentReference: String? = nil,
          transactionData: TransactionData? = nil) {
         self.catalogItem = catalogItem
         self.children = children
@@ -44,7 +42,6 @@ class CatalogResponseButtonViewModel: Identifiable, Hashable, ScreenSizeAdaptive
         self.layoutState = layoutState
         self.eventService = eventService
         self.isPartnerManagedPurchase = isPartnerManagedPurchase
-        self.partnerPaymentReference = partnerPaymentReference
         self.transactionData = transactionData
     }
 
@@ -62,7 +59,6 @@ class CatalogResponseButtonViewModel: Identifiable, Hashable, ScreenSizeAdaptive
         } else {
             eventService?.cartItemForwardPayment(
                 catalogItem: catalogItem,
-                partnerPaymentReference: partnerPaymentReference,
                 transactionData: transactionData,
                 completion: { [weak self] status in
                     self?.handleForwardPaymentCompletion(status: status, position: position)

--- a/Sources/RoktUXHelper/UI/Components/ViewModel/CatalogResponseButtonViewModel.swift
+++ b/Sources/RoktUXHelper/UI/Components/ViewModel/CatalogResponseButtonViewModel.swift
@@ -22,6 +22,7 @@ class CatalogResponseButtonViewModel: Identifiable, Hashable, ScreenSizeAdaptive
 
     let isPartnerManagedPurchase: Bool
     let partnerPaymentReference: String?
+    let transactionData: TransactionData?
 
     init(catalogItem: CatalogItem?,
          children: [LayoutSchemaViewModel]?,
@@ -32,7 +33,8 @@ class CatalogResponseButtonViewModel: Identifiable, Hashable, ScreenSizeAdaptive
          hoveredStyle: [CatalogResponseButtonStyles]?,
          disabledStyle: [CatalogResponseButtonStyles]?,
          isPartnerManagedPurchase: Bool = true,
-         partnerPaymentReference: String? = nil) {
+         partnerPaymentReference: String? = nil,
+         transactionData: TransactionData? = nil) {
         self.catalogItem = catalogItem
         self.children = children
         self.defaultStyle = defaultStyle
@@ -43,6 +45,7 @@ class CatalogResponseButtonViewModel: Identifiable, Hashable, ScreenSizeAdaptive
         self.eventService = eventService
         self.isPartnerManagedPurchase = isPartnerManagedPurchase
         self.partnerPaymentReference = partnerPaymentReference
+        self.transactionData = transactionData
     }
 
     func cartItemInstantPurchase(position: Int?) {
@@ -60,6 +63,7 @@ class CatalogResponseButtonViewModel: Identifiable, Hashable, ScreenSizeAdaptive
             eventService?.cartItemForwardPayment(
                 catalogItem: catalogItem,
                 partnerPaymentReference: partnerPaymentReference,
+                transactionData: transactionData,
                 completion: { [weak self] status in
                     self?.handleForwardPaymentCompletion(status: status, position: position)
                 }

--- a/Tests/RoktUXHelperTests/Services/Events/TestEventService.swift
+++ b/Tests/RoktUXHelperTests/Services/Events/TestEventService.swift
@@ -403,6 +403,7 @@ final class TestEventService: XCTestCase {
         eventService.cartItemForwardPayment(
             catalogItem: .mock(),
             partnerPaymentReference: "ref-1",
+            transactionData: nil,
             completion: { _ in }
         )
 
@@ -428,6 +429,7 @@ final class TestEventService: XCTestCase {
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
             partnerPaymentReference: nil,
+            transactionData: nil,
             completion: { capturedStatus = $0 }
         )
         events.removeAll()
@@ -455,6 +457,7 @@ final class TestEventService: XCTestCase {
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
             partnerPaymentReference: nil,
+            transactionData: nil,
             completion: { capturedStatus = $0 }
         )
         events.removeAll()
@@ -486,6 +489,7 @@ final class TestEventService: XCTestCase {
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
             partnerPaymentReference: nil,
+            transactionData: nil,
             completion: { capturedStatus = $0 }
         )
 
@@ -497,6 +501,7 @@ final class TestEventService: XCTestCase {
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
             partnerPaymentReference: nil,
+            transactionData: nil,
             completion: { secondStatus = $0 }
         )
         XCTAssertNotNil(secondStatus, "second attempt should not be blocked by stale completion")
@@ -512,6 +517,7 @@ final class TestEventService: XCTestCase {
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
             partnerPaymentReference: nil,
+            transactionData: nil,
             completion: { _ in invocationCount += 1 }
         )
 
@@ -535,6 +541,7 @@ final class TestEventService: XCTestCase {
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
             partnerPaymentReference: nil,
+            transactionData: nil,
             completion: { _ in firstCount += 1 }
         )
         let eventsAfterFirst = events.count
@@ -542,6 +549,7 @@ final class TestEventService: XCTestCase {
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
             partnerPaymentReference: nil,
+            transactionData: nil,
             completion: { _ in secondCount += 1 }
         )
 
@@ -563,6 +571,7 @@ final class TestEventService: XCTestCase {
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
             partnerPaymentReference: nil,
+            transactionData: nil,
             completion: { capturedStatus = $0 }
         )
 
@@ -576,6 +585,7 @@ final class TestEventService: XCTestCase {
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
             partnerPaymentReference: nil,
+            transactionData: nil,
             completion: { secondStatus = $0 }
         )
         eventService.cartItemForwardPaymentSuccess(itemId: "catalogItemId")
@@ -595,6 +605,7 @@ final class TestEventService: XCTestCase {
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
             partnerPaymentReference: nil,
+            transactionData: nil,
             completion: { capturedStatus = $0 }
         )
 
@@ -617,6 +628,7 @@ final class TestEventService: XCTestCase {
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
             partnerPaymentReference: nil,
+            transactionData: nil,
             completion: { _ in }
         )
         events.removeAll()
@@ -638,6 +650,7 @@ final class TestEventService: XCTestCase {
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
             partnerPaymentReference: nil,
+            transactionData: nil,
             completion: { _ in invocationCount += 1 }
         )
 
@@ -727,12 +740,15 @@ class MockUXHelper: UXEventsDelegate {
     }
 
     var forwardPaymentReference: String?
+    var forwardPaymentTransactionData: TransactionData?
     var onForwardPaymentInvoked: ((_ layoutId: String, _ catalogItem: RoktUXHelper.CatalogItem) -> Void)?
     func onCartItemForwardPayment(_ layoutId: String,
                                   catalogItem: RoktUXHelper.CatalogItem,
-                                  partnerPaymentReference: String?) {
+                                  partnerPaymentReference: String?,
+                                  transactionData: TransactionData?) {
         self.roktEvents.append(.CartItemForwardPayment)
         self.forwardPaymentReference = partnerPaymentReference
+        self.forwardPaymentTransactionData = transactionData
         onForwardPaymentInvoked?(layoutId, catalogItem)
     }
 }

--- a/Tests/RoktUXHelperTests/Services/Events/TestEventService.swift
+++ b/Tests/RoktUXHelperTests/Services/Events/TestEventService.swift
@@ -400,10 +400,19 @@ final class TestEventService: XCTestCase {
             self.events.append(event)
         })
 
+        let transactionData = TransactionData(
+            shippingAddress: nil,
+            billingAddress: nil,
+            paymentType: nil,
+            supportedPaymentMethods: nil,
+            isPartnerManagedPurchase: false,
+            partnerPaymentReference: "ref-1",
+            confirmationRef: nil,
+            metadata: [:]
+        )
         eventService.cartItemForwardPayment(
             catalogItem: .mock(),
-            partnerPaymentReference: "ref-1",
-            transactionData: nil,
+            transactionData: transactionData,
             completion: { _ in }
         )
 
@@ -414,7 +423,7 @@ final class TestEventService: XCTestCase {
 
         XCTAssertEqual(stubUXHelper.roktEvents.count, 1)
         XCTAssertTrue(stubUXHelper.roktEvents.contains(.CartItemForwardPayment))
-        XCTAssertEqual(stubUXHelper.forwardPaymentReference, "ref-1")
+        XCTAssertEqual(stubUXHelper.forwardPaymentTransactionData?.partnerPaymentReference, "ref-1")
     }
 
     func test_send_forward_payment_success_emits_signal_and_invokes_completion() {
@@ -428,7 +437,6 @@ final class TestEventService: XCTestCase {
         var capturedStatus: ForwardPaymentStatus?
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
-            partnerPaymentReference: nil,
             transactionData: nil,
             completion: { capturedStatus = $0 }
         )
@@ -456,7 +464,6 @@ final class TestEventService: XCTestCase {
         var capturedStatus: ForwardPaymentStatus?
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
-            partnerPaymentReference: nil,
             transactionData: nil,
             completion: { capturedStatus = $0 }
         )
@@ -488,7 +495,6 @@ final class TestEventService: XCTestCase {
         var capturedStatus: ForwardPaymentStatus?
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
-            partnerPaymentReference: nil,
             transactionData: nil,
             completion: { capturedStatus = $0 }
         )
@@ -500,7 +506,6 @@ final class TestEventService: XCTestCase {
         var secondStatus: ForwardPaymentStatus?
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
-            partnerPaymentReference: nil,
             transactionData: nil,
             completion: { secondStatus = $0 }
         )
@@ -516,7 +521,6 @@ final class TestEventService: XCTestCase {
         var invocationCount = 0
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
-            partnerPaymentReference: nil,
             transactionData: nil,
             completion: { _ in invocationCount += 1 }
         )
@@ -540,7 +544,6 @@ final class TestEventService: XCTestCase {
         var secondCount = 0
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
-            partnerPaymentReference: nil,
             transactionData: nil,
             completion: { _ in firstCount += 1 }
         )
@@ -548,7 +551,6 @@ final class TestEventService: XCTestCase {
 
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
-            partnerPaymentReference: nil,
             transactionData: nil,
             completion: { _ in secondCount += 1 }
         )
@@ -570,7 +572,6 @@ final class TestEventService: XCTestCase {
         var capturedStatus: ForwardPaymentStatus?
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
-            partnerPaymentReference: nil,
             transactionData: nil,
             completion: { capturedStatus = $0 }
         )
@@ -584,7 +585,6 @@ final class TestEventService: XCTestCase {
         var secondStatus: ForwardPaymentStatus?
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
-            partnerPaymentReference: nil,
             transactionData: nil,
             completion: { secondStatus = $0 }
         )
@@ -604,7 +604,6 @@ final class TestEventService: XCTestCase {
         var capturedStatus: ForwardPaymentStatus?
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
-            partnerPaymentReference: nil,
             transactionData: nil,
             completion: { capturedStatus = $0 }
         )
@@ -627,7 +626,6 @@ final class TestEventService: XCTestCase {
 
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
-            partnerPaymentReference: nil,
             transactionData: nil,
             completion: { _ in }
         )
@@ -649,7 +647,6 @@ final class TestEventService: XCTestCase {
         var invocationCount = 0
         eventService.cartItemForwardPayment(
             catalogItem: .mock(catalogItemId: "catalogItemId"),
-            partnerPaymentReference: nil,
             transactionData: nil,
             completion: { _ in invocationCount += 1 }
         )
@@ -739,15 +736,12 @@ class MockUXHelper: UXEventsDelegate {
         self.roktEvents.append(.CartItemDevicePay)
     }
 
-    var forwardPaymentReference: String?
     var forwardPaymentTransactionData: TransactionData?
     var onForwardPaymentInvoked: ((_ layoutId: String, _ catalogItem: RoktUXHelper.CatalogItem) -> Void)?
     func onCartItemForwardPayment(_ layoutId: String,
                                   catalogItem: RoktUXHelper.CatalogItem,
-                                  partnerPaymentReference: String?,
                                   transactionData: TransactionData?) {
         self.roktEvents.append(.CartItemForwardPayment)
-        self.forwardPaymentReference = partnerPaymentReference
         self.forwardPaymentTransactionData = transactionData
         onForwardPaymentInvoked?(layoutId, catalogItem)
     }

--- a/Tests/RoktUXHelperTests/UI/ViewModel/CatalogResponseButtonViewModelTests.swift
+++ b/Tests/RoktUXHelperTests/UI/ViewModel/CatalogResponseButtonViewModelTests.swift
@@ -58,6 +58,44 @@ final class CatalogResponseButtonViewModelTests: XCTestCase {
         XCTAssertEqual(eventService.lastForwardPaymentCatalogItem?.catalogItemId, "item-1")
     }
 
+    func test_cartItemInstantPurchase_forwardPayment_forwardsTransactionData() {
+        let eventService = MockEventService()
+        let transactionData = TransactionData(
+            shippingAddress: Address(
+                name: "",
+                address1: "123 Main St",
+                address2: "Apt 4B",
+                city: "New York",
+                state: "NY",
+                stateCode: "",
+                country: "US",
+                countryCode: "",
+                zip: "10001"
+            ),
+            billingAddress: nil,
+            paymentType: nil,
+            supportedPaymentMethods: nil,
+            isPartnerManagedPurchase: false,
+            partnerPaymentReference: "ref-xyz",
+            confirmationRef: nil,
+            metadata: [:]
+        )
+        let sut = makeSUT(
+            catalogItem: makeCatalogItem(id: "item-1"),
+            eventService: eventService,
+            isPartnerManagedPurchase: false,
+            partnerPaymentReference: "ref-xyz",
+            transactionData: transactionData
+        )
+
+        sut.cartItemInstantPurchase(position: nil)
+
+        XCTAssertTrue(eventService.cartItemForwardPaymentCalled)
+        XCTAssertEqual(eventService.lastForwardPaymentTransactionData?.shippingAddress?.address1, "123 Main St")
+        XCTAssertEqual(eventService.lastForwardPaymentTransactionData?.shippingAddress?.zip, "10001")
+        XCTAssertEqual(eventService.lastForwardPaymentTransactionData?.partnerPaymentReference, "ref-xyz")
+    }
+
     func test_cartItemInstantPurchase_nilCatalogItem_dismisses() {
         let eventService = MockEventService()
         let layoutState = MockLayoutState()
@@ -141,7 +179,8 @@ final class CatalogResponseButtonViewModelTests: XCTestCase {
         layoutState: MockLayoutState = MockLayoutState(),
         eventService: MockEventService = MockEventService(),
         isPartnerManagedPurchase: Bool = true,
-        partnerPaymentReference: String? = nil
+        partnerPaymentReference: String? = nil,
+        transactionData: TransactionData? = nil
     ) -> CatalogResponseButtonViewModel {
         CatalogResponseButtonViewModel(
             catalogItem: catalogItem,
@@ -153,7 +192,8 @@ final class CatalogResponseButtonViewModelTests: XCTestCase {
             hoveredStyle: nil,
             disabledStyle: nil,
             isPartnerManagedPurchase: isPartnerManagedPurchase,
-            partnerPaymentReference: partnerPaymentReference
+            partnerPaymentReference: partnerPaymentReference,
+            transactionData: transactionData
         )
     }
 

--- a/Tests/RoktUXHelperTests/UI/ViewModel/CatalogResponseButtonViewModelTests.swift
+++ b/Tests/RoktUXHelperTests/UI/ViewModel/CatalogResponseButtonViewModelTests.swift
@@ -21,7 +21,7 @@ final class CatalogResponseButtonViewModelTests: XCTestCase {
             catalogItem: makeCatalogItem(id: "item-1"),
             layoutState: layoutState,
             eventService: eventService,
-            isPartnerManagedPurchase: true
+            transactionData: makeTransactionData(isPartnerManagedPurchase: true)
         )
 
         sut.cartItemInstantPurchase(position: nil)
@@ -63,7 +63,6 @@ final class CatalogResponseButtonViewModelTests: XCTestCase {
             catalogItem: makeCatalogItem(id: "item-1"),
             layoutState: layoutState,
             eventService: eventService,
-            isPartnerManagedPurchase: false,
             transactionData: transactionData
         )
 
@@ -107,7 +106,7 @@ final class CatalogResponseButtonViewModelTests: XCTestCase {
             catalogItem: makeCatalogItem(id: "item-1"),
             layoutState: layoutState,
             eventService: eventService,
-            isPartnerManagedPurchase: false
+            transactionData: makeTransactionData(isPartnerManagedPurchase: false)
         )
 
         sut.cartItemInstantPurchase(position: 0)
@@ -135,7 +134,7 @@ final class CatalogResponseButtonViewModelTests: XCTestCase {
             catalogItem: makeCatalogItem(id: "item-1"),
             layoutState: layoutState,
             eventService: eventService,
-            isPartnerManagedPurchase: false
+            transactionData: makeTransactionData(isPartnerManagedPurchase: false)
         )
 
         sut.cartItemInstantPurchase(position: 0)
@@ -161,7 +160,6 @@ final class CatalogResponseButtonViewModelTests: XCTestCase {
         catalogItem: CatalogItem? = nil,
         layoutState: MockLayoutState = MockLayoutState(),
         eventService: MockEventService = MockEventService(),
-        isPartnerManagedPurchase: Bool = true,
         transactionData: TransactionData? = nil
     ) -> CatalogResponseButtonViewModel {
         CatalogResponseButtonViewModel(
@@ -173,8 +171,20 @@ final class CatalogResponseButtonViewModelTests: XCTestCase {
             pressedStyle: nil,
             hoveredStyle: nil,
             disabledStyle: nil,
-            isPartnerManagedPurchase: isPartnerManagedPurchase,
             transactionData: transactionData
+        )
+    }
+
+    private func makeTransactionData(isPartnerManagedPurchase: Bool) -> TransactionData {
+        TransactionData(
+            shippingAddress: nil,
+            billingAddress: nil,
+            paymentType: nil,
+            supportedPaymentMethods: nil,
+            isPartnerManagedPurchase: isPartnerManagedPurchase,
+            partnerPaymentReference: nil,
+            confirmationRef: nil,
+            metadata: [:]
         )
     }
 

--- a/Tests/RoktUXHelperTests/UI/ViewModel/CatalogResponseButtonViewModelTests.swift
+++ b/Tests/RoktUXHelperTests/UI/ViewModel/CatalogResponseButtonViewModelTests.swift
@@ -33,33 +33,12 @@ final class CatalogResponseButtonViewModelTests: XCTestCase {
         XCTAssertTrue(closeInvoked)
     }
 
-    func test_cartItemInstantPurchase_forwardPayment_callsForwardPaymentWithReference() {
+    func test_cartItemInstantPurchase_forwardPayment_forwardsTransactionData() {
         let eventService = MockEventService()
         let layoutState = MockLayoutState()
         var closeInvoked = false
         layoutState.actionCollection[.close] = { _ in closeInvoked = true }
 
-        let catalogItem = makeCatalogItem(id: "item-1")
-        let sut = makeSUT(
-            catalogItem: catalogItem,
-            layoutState: layoutState,
-            eventService: eventService,
-            isPartnerManagedPurchase: false,
-            partnerPaymentReference: "ref-xyz"
-        )
-
-        sut.cartItemInstantPurchase(position: nil)
-
-        XCTAssertTrue(eventService.cartItemForwardPaymentCalled)
-        XCTAssertFalse(eventService.cartItemInstantPurchaseCalled)
-        XCTAssertFalse(eventService.dismissalEventCalled)
-        XCTAssertFalse(closeInvoked)
-        XCTAssertEqual(eventService.lastForwardPaymentReference, "ref-xyz")
-        XCTAssertEqual(eventService.lastForwardPaymentCatalogItem?.catalogItemId, "item-1")
-    }
-
-    func test_cartItemInstantPurchase_forwardPayment_forwardsTransactionData() {
-        let eventService = MockEventService()
         let transactionData = TransactionData(
             shippingAddress: Address(
                 name: "",
@@ -82,15 +61,19 @@ final class CatalogResponseButtonViewModelTests: XCTestCase {
         )
         let sut = makeSUT(
             catalogItem: makeCatalogItem(id: "item-1"),
+            layoutState: layoutState,
             eventService: eventService,
             isPartnerManagedPurchase: false,
-            partnerPaymentReference: "ref-xyz",
             transactionData: transactionData
         )
 
         sut.cartItemInstantPurchase(position: nil)
 
         XCTAssertTrue(eventService.cartItemForwardPaymentCalled)
+        XCTAssertFalse(eventService.cartItemInstantPurchaseCalled)
+        XCTAssertFalse(eventService.dismissalEventCalled)
+        XCTAssertFalse(closeInvoked)
+        XCTAssertEqual(eventService.lastForwardPaymentCatalogItem?.catalogItemId, "item-1")
         XCTAssertEqual(eventService.lastForwardPaymentTransactionData?.shippingAddress?.address1, "123 Main St")
         XCTAssertEqual(eventService.lastForwardPaymentTransactionData?.shippingAddress?.zip, "10001")
         XCTAssertEqual(eventService.lastForwardPaymentTransactionData?.partnerPaymentReference, "ref-xyz")
@@ -179,7 +162,6 @@ final class CatalogResponseButtonViewModelTests: XCTestCase {
         layoutState: MockLayoutState = MockLayoutState(),
         eventService: MockEventService = MockEventService(),
         isPartnerManagedPurchase: Bool = true,
-        partnerPaymentReference: String? = nil,
         transactionData: TransactionData? = nil
     ) -> CatalogResponseButtonViewModel {
         CatalogResponseButtonViewModel(
@@ -192,7 +174,6 @@ final class CatalogResponseButtonViewModelTests: XCTestCase {
             hoveredStyle: nil,
             disabledStyle: nil,
             isPartnerManagedPurchase: isPartnerManagedPurchase,
-            partnerPaymentReference: partnerPaymentReference,
             transactionData: transactionData
         )
     }

--- a/Tests/RoktUXHelperTests/UI/ViewModel/Mocks/MockEventService.swift
+++ b/Tests/RoktUXHelperTests/UI/ViewModel/Mocks/MockEventService.swift
@@ -41,7 +41,6 @@ class MockEventService: EventDiagnosticServicing {
     var cartItemForwardPaymentCalled = false
     var cartItemForwardPaymentSuccessCalled = false
     var cartItemForwardPaymentFailureCalled = false
-    var lastForwardPaymentReference: String?
     var lastForwardPaymentCatalogItem: CatalogItem?
     var lastForwardPaymentFailureReason: String?
     var lastForwardPaymentTransactionData: TransactionData?
@@ -147,13 +146,11 @@ class MockEventService: EventDiagnosticServicing {
 
     func cartItemForwardPayment(
         catalogItem: CatalogItem,
-        partnerPaymentReference: String?,
         transactionData: TransactionData?,
         completion: @escaping (ForwardPaymentStatus) -> Void
     ) {
         cartItemForwardPaymentCalled = true
         lastForwardPaymentCatalogItem = catalogItem
-        lastForwardPaymentReference = partnerPaymentReference
         lastForwardPaymentTransactionData = transactionData
         cartItemForwardPaymentCompletionCallback = completion
     }
@@ -206,7 +203,6 @@ class MockEventService: EventDiagnosticServicing {
         cartItemForwardPaymentCalled = false
         cartItemForwardPaymentSuccessCalled = false
         cartItemForwardPaymentFailureCalled = false
-        lastForwardPaymentReference = nil
         lastForwardPaymentCatalogItem = nil
         lastForwardPaymentFailureReason = nil
         lastForwardPaymentTransactionData = nil

--- a/Tests/RoktUXHelperTests/UI/ViewModel/Mocks/MockEventService.swift
+++ b/Tests/RoktUXHelperTests/UI/ViewModel/Mocks/MockEventService.swift
@@ -44,6 +44,7 @@ class MockEventService: EventDiagnosticServicing {
     var lastForwardPaymentReference: String?
     var lastForwardPaymentCatalogItem: CatalogItem?
     var lastForwardPaymentFailureReason: String?
+    var lastForwardPaymentTransactionData: TransactionData?
 
     // MARK: - Protocol Properties
 
@@ -147,11 +148,13 @@ class MockEventService: EventDiagnosticServicing {
     func cartItemForwardPayment(
         catalogItem: CatalogItem,
         partnerPaymentReference: String?,
+        transactionData: TransactionData?,
         completion: @escaping (ForwardPaymentStatus) -> Void
     ) {
         cartItemForwardPaymentCalled = true
         lastForwardPaymentCatalogItem = catalogItem
         lastForwardPaymentReference = partnerPaymentReference
+        lastForwardPaymentTransactionData = transactionData
         cartItemForwardPaymentCompletionCallback = completion
     }
 
@@ -206,6 +209,7 @@ class MockEventService: EventDiagnosticServicing {
         lastForwardPaymentReference = nil
         lastForwardPaymentCatalogItem = nil
         lastForwardPaymentFailureReason = nil
+        lastForwardPaymentTransactionData = nil
         dismissOption = nil
     }
 }


### PR DESCRIPTION
## Summary
- Forward-payment initiate-purchase path was dropping the offer's shipping data, so `/purchase` calls were missing `fulfillmentDetails.shippingAttributes` and failing. Mirrors the [#255](https://github.com/ROKT/rokt-ux-helper-ios/pull/255) plumbing to thread `TransactionData?` from the catalog response button all the way onto the public `CartItemForwardPayment` event so the host SDK can build the shipping payload.
- Bumps DcuiSchema 2.5.0 → 2.6.0.
- Jira: [UTYP-1406](https://rokt.atlassian.net/browse/UTYP-1406)

## Follow-up (host SDK, separate repo)
Host iOS SDK needs to consume `CartItemForwardPayment.transactionData.shippingAddress` and map it into `fulfillmentDetails.shippingAttributes` on the `/purchase` call (including `zip` → `postalCode`).

## Test plan
- [x] `swift package resolve` picks up DcuiSchema 2.6.0
- [x] `xcodebuild … build` succeeds
- [x] `CatalogResponseButtonViewModelTests` pass (incl. new `test_cartItemInstantPurchase_forwardPayment_forwardsTransactionData`)
- [x] `CatalogDevicePayButtonViewModelTests`, `TestLayoutTransformer`, `TransactionDataTests` still pass
- [ ] Host SDK side picks up and forwards shippingAddress on `/purchase`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[UTYP-1406]: https://rokt.atlassian.net/browse/UTYP-1406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ