### PR TITLE
fix: sync layoutSchemaVersion with dcui-swift-schema and guard drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Sync `Constants.layoutSchemaVersion` (was stuck at `2.5.0`) with the `dcui-swift-schema` package version (`2.7.0`) and add `SchemaVersionConsistencyTests` to fail the build on future drift
+
 ## [0.10.6] - 2026-04-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ For a detailed guide on adding new snapshots, see [TESTING.md](./TESTING.md).
 1. Ensure the Swift version of SSOT has been released in [DCUI-Schema-Repo](https://github.com/ROKT/dcui-layout-schema)
 2. Update dcui-swift-schema dependency version in package.swift to the latest version
    `.package(url: "https://github.com/ROKT/dcui-swift-schema.git", exact: "x.y.z"),`
-3. Verify `schema.swift` is updated
+3. Update `Constants.layoutSchemaVersion` in `Sources/RoktUXHelper/Data/Model/RoktIntegrationInfoDetails.swift` to match the same `x.y.z`. `SchemaVersionConsistencyTests` fails the build if these two values drift.
+4. Verify `schema.swift` is updated
 
 ## Example App
 

--- a/Sources/RoktUXHelper/Data/Model/RoktIntegrationInfoDetails.swift
+++ b/Sources/RoktUXHelper/Data/Model/RoktIntegrationInfoDetails.swift
@@ -4,7 +4,7 @@ import UIKit
 private enum Constants {
     static let framework: String = "Swift"
     static let kBundleShort: String = "CFBundleShortVersionString"
-    static let layoutSchemaVersion: String = "2.5.0"
+    static let layoutSchemaVersion: String = "2.7.0"
     static let name: String = "UX Helper iOS"
     static let platform: String = "iOS"
     static let version: String = "0.1.0"

--- a/Tests/RoktUXHelperTests/Data/Model/SchemaVersionConsistencyTests.swift
+++ b/Tests/RoktUXHelperTests/Data/Model/SchemaVersionConsistencyTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import RoktUXHelper
+
+final class SchemaVersionConsistencyTests: XCTestCase {
+
+    // Guards against drift between the dcui-swift-schema package version
+    // pinned in Package.swift and Constants.layoutSchemaVersion reported in
+    // RoktIntegrationInfo. Bumping one without the other has historically
+    // gone unnoticed; this test forces both to move together.
+    func test_layoutSchemaVersion_matches_dcuiSwiftSchemaPackageVersion() throws {
+        let packageVersion = try readDcuiSwiftSchemaPinnedVersion()
+        let reportedVersion = RoktIntegrationInfoDetails().layoutSchemaVersion
+
+        XCTAssertEqual(
+            reportedVersion,
+            packageVersion,
+            """
+            Constants.layoutSchemaVersion (\(reportedVersion)) is out of sync with the \
+            dcui-swift-schema version pinned in Package.swift (\(packageVersion)). \
+            Update Constants.layoutSchemaVersion in RoktIntegrationInfoDetails.swift to match.
+            """
+        )
+    }
+
+    private func readDcuiSwiftSchemaPinnedVersion(file: StaticString = #filePath) throws -> String {
+        let repoRoot = "\(file)".replacingOccurrences(
+            of: #"/Tests/.*$"#,
+            with: "",
+            options: .regularExpression
+        )
+        let packageURL = URL(fileURLWithPath: repoRoot + "/Package.swift")
+
+        let contents = try String(contentsOf: packageURL, encoding: .utf8)
+        let pattern = #"dcui-swift-schema\.git",\s*exact:\s*"([^"]+)""#
+        let regex = try NSRegularExpression(pattern: pattern)
+        let range = NSRange(contents.startIndex..., in: contents)
+
+        guard
+            let match = regex.firstMatch(in: contents, range: range),
+            let versionRange = Range(match.range(at: 1), in: contents)
+        else {
+            throw SchemaVersionLookupError.notFoundInPackageManifest(path: packageURL.path)
+        }
+
+        return String(contents[versionRange])
+    }
+
+    private enum SchemaVersionLookupError: Error, CustomStringConvertible {
+        case notFoundInPackageManifest(path: String)
+
+        var description: String {
+            switch self {
+            case .notFoundInPackageManifest(let path):
+                return "Could not find dcui-swift-schema exact version in \(path)"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Background

- The SDK reports `Constants.layoutSchemaVersion` to Rokt's platform as part of its integration metadata (`RoktIntegrationInfo`). It had drifted to `2.5.0` while `Package.swift` pins `dcui-swift-schema` at `2.7.0` (last bumped in #267). The drift went unnoticed because the constant lives in a separate file from the dependency pin and there was no automated check linking the two.
- `git log -S "layoutSchemaVersion: String ="` confirms the constant has not been touched since the initial commit, so every recent schema bump (2.0 → 2.7) silently misadvertised the SDK's supported version.

## What Has Changed

- Bumped `Constants.layoutSchemaVersion` from `2.5.0` to `2.7.0` to match the currently pinned `dcui-swift-schema` package version (`Sources/RoktUXHelper/Data/Model/RoktIntegrationInfoDetails.swift`).
- Added `SchemaVersionConsistencyTests`, a new unit test that parses the `dcui-swift-schema` exact version from `Package.swift` and asserts it equals `Constants.layoutSchemaVersion`. Future PRs that bump one without the other will fail in CI with a message pointing at the constant to update.
- Updated `README.md`'s "How to Update the Layouts Schema File" section with the new step (and a reference to the guard test).
- Added a `Fixed` entry under `[Unreleased]` in `CHANGELOG.md`.

## Screenshots/Video

- N/A — no UI changes.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Verified locally with `xcodebuild -scheme RoktUXHelper -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.1' test -only-testing:RoktUXHelperTests/SchemaVersionConsistencyTests` — passes.
- The test reads `Package.swift` via `#filePath`, stripping everything from `/Tests/` onward to locate the repo root. This works under both `swift test` and `xcodebuild test`.
- Considered reading `Package.resolved` (structured JSON) instead of regexing `Package.swift`, but kept the manifest as the source of truth since that's the file engineers actually edit when bumping.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- N/A — internal cleanup.