### PR TITLE
fix: Voiceover Accessibility Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- VoiceOver: pagination and dot indicators now announce `Offer X of Y` for consistent context; grouped distribution uses page count for the total; Rich Text wrapped in HTML `h1`–`h6` exposes the Heading trait (no extra spoken suffix); creative images and static images hide from VoiceOver when alt duplicates title-like offer copy (decorative brand/logo treatment).
+- VoiceOver: pagination and dot indicators now announce `Offer X of Y` for consistent context; grouped distribution uses page count for the total; Rich Text wrapped in HTML `h1`–`h6` exposes the Heading trait (no extra spoken suffix); creative images and static images hide from VoiceOver when alt duplicates title-like offer copy (decorative brand/logo treatment), comparing plain text after stripping DCUI HTML and decoding entities on creative copy.
 
 ## [0.10.7] - 2026-05-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- VoiceOver: pagination and dot indicators now announce `Offer X of Y` for consistent context; grouped distribution uses page count for the total; Rich Text wrapped in HTML `h1`–`h6` exposes the Heading trait (no extra spoken suffix); creative images and static images hide from VoiceOver when alt duplicates title-like offer copy (decorative brand/logo treatment).
+
 ## [0.10.7] - 2026-05-01
 
 ### Fixed

--- a/Sources/RoktUXHelper/Data/Model/Constants.swift
+++ b/Sources/RoktUXHelper/Data/Model/Constants.swift
@@ -67,9 +67,9 @@ let kSharedDataItemsQueueLabel = "com.rokt.shareddata.items.queue"
 
 // MARK: - Accessibility
 
-let kPageAnnouncement = "Page %d of %d"
+let kPageAnnouncement = "Offer %d of %d"
 let kOneByOneAnnouncement = "Offer %d of %d"
-let kProgressIndicatorAnnouncement = "%d of %d"
+let kProgressIndicatorAnnouncement = "Offer %d of %d"
 
 // MARK: Cart Item Instant purchase constants
 

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/OfferModel.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/OfferModel.swift
@@ -47,3 +47,48 @@ struct CreativeLink: Codable, Hashable {
     let url: String?
     let title: String?
 }
+
+extension OfferModel {
+    /// Returns true when image alt text matches title-like creative copy so the image can be hidden from VoiceOver as decorative.
+    func imageAltDuplicatesTitleLikeCopy(_ alt: String) -> Bool {
+        let normalizedAlt = Self.normalizeAccessibilityComparisonString(alt)
+        guard !normalizedAlt.isEmpty else { return false }
+
+        for (key, value) in creative.copy {
+            guard Self.isTitleLikeCopyField(key) else { continue }
+            if Self.normalizeAccessibilityComparisonString(value) == normalizedAlt {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Whether a creative image alt duplicates title-like copy on the active offer (VoiceOver hides redundant logo imagery).
+    static func decorativeAccessibilityDueToDuplicateOfferCopy(
+        alt: String?,
+        layoutState: (any LayoutStateRepresenting)?
+    ) -> Bool {
+        guard let alt else { return false }
+        guard let offer = layoutState?.items[LayoutState.fullOfferKey] as? OfferModel else { return false }
+        return offer.imageAltDuplicatesTitleLikeCopy(alt)
+    }
+
+    private static func isTitleLikeCopyField(_ key: String) -> Bool {
+        let k = key.lowercased()
+        if k.contains("subtitle") { return false }
+        if k == "title" || k == "headline" { return true }
+        if k.contains("headline") { return true }
+        if k.contains("brand") || k.contains("advertiser") { return true }
+        if k.hasSuffix("title") { return true }
+        return false
+    }
+
+    private static func normalizeAccessibilityComparisonString(_ string: String) -> String {
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+        return trimmed
+            .folding(options: .diacriticInsensitive, locale: .current)
+            .lowercased()
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+    }
+}

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/OfferModel.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/OfferModel.swift
@@ -48,6 +48,7 @@ struct CreativeLink: Codable, Hashable {
     let title: String?
 }
 
+@available(iOS 15, *)
 extension OfferModel {
     /// Returns true when image alt text matches title-like creative copy so the image can be hidden from VoiceOver as decorative.
     func imageAltDuplicatesTitleLikeCopy(_ alt: String) -> Bool {
@@ -56,7 +57,10 @@ extension OfferModel {
 
         for (key, value) in creative.copy {
             guard Self.isTitleLikeCopyField(key) else { continue }
-            if Self.normalizeAccessibilityComparisonString(value) == normalizedAlt {
+            let comparableCopy = Self.normalizeAccessibilityComparisonString(
+                Self.plainTextFromCreativeCopyForAccessibilityComparison(value)
+            )
+            if comparableCopy == normalizedAlt {
                 return true
             }
         }
@@ -71,6 +75,17 @@ extension OfferModel {
         guard let alt else { return false }
         guard let offer = layoutState?.items[LayoutState.fullOfferKey] as? OfferModel else { return false }
         return offer.imageAltDuplicatesTitleLikeCopy(alt)
+    }
+
+    /// Title-like copy may contain DCUI HTML (`<h2>…</h2>`) or entities (`&amp;`); alt is plain—parse to comparable text before matching.
+    private static func plainTextFromCreativeCopyForAccessibilityComparison(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+        guard trimmed.contains("<") || trimmed.contains("&") else {
+            return trimmed
+        }
+        let (parsed, _) = LightweightHTMLParser.parse(html: trimmed, baseFont: nil)
+        return parsed.string
     }
 
     private static func isTitleLikeCopyField(_ key: String) -> Bool {

--- a/Sources/RoktUXHelper/UI/Components/Common/Image/AsyncImageView.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/Image/AsyncImageView.swift
@@ -10,9 +10,15 @@ struct AsyncImageView: View {
     let scale: BackgroundImageScale?
     var alt: String?
     var imageLoader: RoktUXImageLoader?
+    /// When true, hides this image from VoiceOver because its alt duplicates title-like offer copy (decorative brand treatment).
+    var decorativeAccessibilityDuplicateOfOfferCopy: Bool = false
 
     private var altString: String {
         alt ?? ""
+    }
+
+    private var hideFromAccessibility: Bool {
+        altString.isEmpty || decorativeAccessibilityDuplicateOfOfferCopy
     }
 
     private var imgURL: String {
@@ -49,12 +55,14 @@ struct AsyncImageView: View {
                let base64Image = UIImage(data: base64Data) {
                 Base64Image(scale: scale,
                             altString: altString,
-                            base64Image: base64Image)
+                            base64Image: base64Image,
+                            decorativeAccessibilityDuplicateOfOfferCopy: decorativeAccessibilityDuplicateOfOfferCopy)
             } else if let imageLoader {
                 ExternalAsyncImage(urlString: imgURL,
                                    scale: scale,
                                    altString: altString,
-                                   loader: imageLoader)
+                                   loader: imageLoader,
+                                   decorativeAccessibilityDuplicateOfOfferCopy: decorativeAccessibilityDuplicateOfOfferCopy)
             } else {
                 AsyncImage(url: URL(string: imgURL)) { phase in
                     if let image = phase.image { // valid
@@ -67,7 +75,7 @@ struct AsyncImageView: View {
                     }
                 }
                 .accessibilityLabel(altString)
-                .accessibilityHidden(altString.isEmpty)
+                .accessibilityHidden(hideFromAccessibility)
             }
         } else {
             EmptyView()

--- a/Sources/RoktUXHelper/UI/Components/Common/Image/Base64Image.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/Image/Base64Image.swift
@@ -7,11 +7,16 @@ struct Base64Image: View {
     let scale: BackgroundImageScale?
     let altString: String
     let base64Image: UIImage
+    var decorativeAccessibilityDuplicateOfOfferCopy: Bool = false
+
+    private var hideFromAccessibility: Bool {
+        altString.isEmpty || decorativeAccessibilityDuplicateOfOfferCopy
+    }
 
     var body: some View {
         Image(uiImage: base64Image)
             .scaleIfNeeded(scale: scale)
             .accessibilityLabel(altString)
-            .accessibilityHidden(altString.isEmpty)
+            .accessibilityHidden(hideFromAccessibility)
     }
 }

--- a/Sources/RoktUXHelper/UI/Components/Common/Image/ExternalAsyncImage.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/Image/ExternalAsyncImage.swift
@@ -7,12 +7,19 @@ struct ExternalAsyncImage: View {
     @ObservedObject var imageDownloader: ImageDownloader
     let scale: BackgroundImageScale?
     let altString: String
+    var decorativeAccessibilityDuplicateOfOfferCopy: Bool = false
     @State private var image: UIImage?
 
-    init(urlString: String, scale: BackgroundImageScale?, altString: String, loader: RoktUXImageLoader) {
+    private var hideFromAccessibility: Bool {
+        altString.isEmpty || decorativeAccessibilityDuplicateOfOfferCopy
+    }
+
+    init(urlString: String, scale: BackgroundImageScale?, altString: String, loader: RoktUXImageLoader,
+         decorativeAccessibilityDuplicateOfOfferCopy: Bool = false) {
         self.imageDownloader = ImageDownloader(urlString: urlString, loader: loader)
         self.scale = scale
         self.altString = altString
+        self.decorativeAccessibilityDuplicateOfOfferCopy = decorativeAccessibilityDuplicateOfOfferCopy
     }
 
     var body: some View {
@@ -20,7 +27,7 @@ struct ExternalAsyncImage: View {
             Image(uiImage: image)
                 .scaleIfNeeded(scale: scale)
                 .accessibilityLabel(altString)
-                .accessibilityHidden(altString.isEmpty)
+                .accessibilityHidden(hideFromAccessibility)
                 .onReceive(imageDownloader.imageSubject) { newImage in
                     self.image = newImage
                 }

--- a/Sources/RoktUXHelper/UI/Components/Common/LightweightHTMLParser.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/LightweightHTMLParser.swift
@@ -4,7 +4,8 @@ import UIKit
 ///
 /// Supports the DCUI rich text tag surface:
 ///   `<b>`, `<strong>`, `<i>`, `<em>`, `<u>`, `<s>`, `<strike>`,
-///   `<a href="…" target="…">`, `<font color="…">`, `<br>`, `<br/>`
+///   `<a href="…" target="…">`, `<font color="…">`, `<br>`, `<br/>`,
+///   `<h1>`–`<h6>` (semantic heading only; VoiceOver trait applied by `RichTextComponent`)
 ///
 /// Also decodes common HTML entities (`&amp;`, `&lt;`, `&gt;`, `&quot;`,
 /// `&apos;`, `&nbsp;`, `&#NNN;`, `&#xHHH;`).
@@ -13,10 +14,11 @@ enum LightweightHTMLParser {
 
     // MARK: - Public API
 
-    static func parse(html: String, baseFont: UIFont?) -> NSMutableAttributedString {
+    static func parse(html: String, baseFont: UIFont?) -> (NSMutableAttributedString, Bool) {
         let result = NSMutableAttributedString()
         var index = html.startIndex
         var tagStack: [Tag] = []
+        var containsHeadingContent = false
 
         while index < html.endIndex {
             if html[index] == "<" {
@@ -33,13 +35,27 @@ enum LightweightHTMLParser {
                 index = nextIndex
                 let decoded = decodeHTMLEntities(text)
                 if !decoded.isEmpty {
+                    if tagStackContainsHeading(tagStack) {
+                        containsHeadingContent = true
+                    }
                     let attrs = buildAttributes(from: tagStack, baseFont: baseFont)
                     result.append(NSAttributedString(string: decoded, attributes: attrs))
                 }
             }
         }
 
-        return result
+        return (result, containsHeadingContent)
+    }
+
+    private static func tagStackContainsHeading(_ tagStack: [Tag]) -> Bool {
+        tagStack.contains { tag in
+            switch tag.name {
+            case "h1", "h2", "h3", "h4", "h5", "h6":
+                return true
+            default:
+                return false
+            }
+        }
     }
 
     // MARK: - Tag model

--- a/Sources/RoktUXHelper/UI/Components/Common/String+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/String+Extension.swift
@@ -10,15 +10,30 @@ internal extension StringProtocol {
         linkStyles: InlineTextStylingProperties?,
         colorScheme: ColorScheme
     ) -> NSAttributedString {
+        htmlToAttributedStringWithAccessibilitySemantics(
+            textColorHex: textColorHex,
+            uiFont: uiFont,
+            linkStyles: linkStyles,
+            colorScheme: colorScheme
+        ).attributedString
+    }
+
+    func htmlToAttributedStringWithAccessibilitySemantics(
+        textColorHex: String?,
+        uiFont: UIFont?,
+        linkStyles: InlineTextStylingProperties?,
+        colorScheme: ColorScheme
+    ) -> (attributedString: NSAttributedString, containsHeadingContent: Bool) {
         var convertedText = String(self)
 
         if let textColorHex {
             convertedText = "<font color=\(textColorHex)>" + self + "</font>"
         }
 
-        let parsed = LightweightHTMLParser.parse(html: convertedText, baseFont: uiFont)
+        let (parsed, containsHeadingContent) = LightweightHTMLParser.parse(html: convertedText, baseFont: uiFont)
 
-        return updateLinkStyles(linkStyles, attrStr: parsed, colorScheme: colorScheme)
+        let attributed = updateLinkStyles(linkStyles, attrStr: parsed, colorScheme: colorScheme)
+        return (attributed, containsHeadingContent)
     }
 
     private func updateLinkStyles(_ linkStyles: InlineTextStylingProperties?,

--- a/Sources/RoktUXHelper/UI/Components/DataImageCarouselComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/DataImageCarouselComponent.swift
@@ -238,6 +238,10 @@ struct DataImageCarouselComponent: View {
             scale: .fit,
             alt: image.alt,
             imageLoader: model.imageLoader,
+            decorativeAccessibilityDuplicateOfOfferCopy: OfferModel.decorativeAccessibilityDueToDuplicateOfferCopy(
+                alt: image.alt,
+                layoutState: model.layoutState
+            ),
             isImageValid: .constant(true)
         )
         .frame(maxWidth: .infinity)

--- a/Sources/RoktUXHelper/UI/Components/DataImageComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/DataImageComponent.swift
@@ -86,6 +86,10 @@ struct DataImageViewComponent: View {
                        scale: .fit,
                        alt: model.image?.alt,
                        imageLoader: model.imageLoader,
+                       decorativeAccessibilityDuplicateOfOfferCopy: OfferModel.decorativeAccessibilityDueToDuplicateOfferCopy(
+                           alt: model.image?.alt,
+                           layoutState: model.layoutState
+                       ),
                        isImageValid: $isImageValid)
     }
 

--- a/Sources/RoktUXHelper/UI/Components/Distribution/GroupedDistributionComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/Distribution/GroupedDistributionComponent.swift
@@ -39,7 +39,7 @@ struct GroupedDistributionComponent: View {
     var accessibilityAnnouncement: String {
         String(format: kPageAnnouncement,
                currentGroup + 1,
-               model.children?.count ?? 1)
+               totalPages)
     }
 
     let parentOverride: ComponentParentOverride?

--- a/Sources/RoktUXHelper/UI/Components/RichTextComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/RichTextComponent.swift
@@ -164,5 +164,6 @@ struct RichTextComponent: View {
             .scaledFont(textStyle: style?.text)
             .tint(Color(hex: style?.text?.textColor?.getAdaptiveColor(colorScheme)))
             .environment(\.openURL, OpenURLAction(handler: model.handleURL))
+            .accessibilityAddTraits(model.accessibilityUsesHeadingTrait ? [.isHeader] : [])
     }
 }

--- a/Sources/RoktUXHelper/UI/Components/StaticImageViewComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/StaticImageViewComponent.swift
@@ -84,6 +84,10 @@ struct StaticImageViewComponent: View {
             scale: .fit,
             alt: model.alt,
             imageLoader: model.imageLoader,
+            decorativeAccessibilityDuplicateOfOfferCopy: OfferModel.decorativeAccessibilityDueToDuplicateOfferCopy(
+                alt: model.alt,
+                layoutState: model.layoutState
+            ),
             isImageValid: $isImageValid
         )
     }

--- a/Sources/RoktUXHelper/UI/Components/ViewModel/RichTextViewModel.swift
+++ b/Sources/RoktUXHelper/UI/Components/ViewModel/RichTextViewModel.swift
@@ -24,6 +24,7 @@ class RichTextViewModel: Hashable, Identifiable, ObservableObject, ScreenSizeAda
     @LazyPublished var breakpointIndex = 0
     @LazyPublished var breakpointLinkIndex = 0
     @LazyPublished var attributedString = NSAttributedString("")
+    @LazyPublished var accessibilityUsesHeadingTrait = false
 
     var imageLoader: RoktUXImageLoader? {
         layoutState?.imageLoader
@@ -200,14 +201,16 @@ class RichTextViewModel: Hashable, Identifiable, ObservableObject, ScreenSizeAda
         let performTransformation = { [weak self] in
             guard let self else { return }
 
-            let htmlTransformedValue = valueToTransform.htmlToAttributedString(
-                textColorHex: breakpointDefaultStyle?.text?.textColor?.getAdaptiveColor(colorScheme),
-                uiFont: breakpointDefaultStyle?.text?.styledUIFont,
-                linkStyles: breakpointLinkStyle?.text,
-                colorScheme: colorScheme
-            )
+            let (htmlTransformedValue, containsHeadingContent) = valueToTransform
+                .htmlToAttributedStringWithAccessibilitySemantics(
+                    textColorHex: breakpointDefaultStyle?.text?.textColor?.getAdaptiveColor(colorScheme),
+                    uiFont: breakpointDefaultStyle?.text?.styledUIFont,
+                    linkStyles: breakpointLinkStyle?.text,
+                    colorScheme: colorScheme
+                )
 
             self.attributedString = htmlTransformedValue
+            self.accessibilityUsesHeadingTrait = containsHeadingContent
         }
 
         DispatchQueue.main.async {

--- a/Tests/RoktUXHelperTests/Data/Model/ExperienceResponse/TestOfferModelAccessibilityComparison.swift
+++ b/Tests/RoktUXHelperTests/Data/Model/ExperienceResponse/TestOfferModelAccessibilityComparison.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import RoktUXHelper
+
+@available(iOS 15, *)
+final class TestOfferModelAccessibilityComparison: XCTestCase {
+
+    func test_imageAltDuplicatesTitleLikeCopy_plainTitle_matches() {
+        let sut = OfferModel.mock(copy: ["title": "Acme Brand"])
+        XCTAssertTrue(sut.imageAltDuplicatesTitleLikeCopy("Acme Brand"))
+    }
+
+    func test_imageAltDuplicatesTitleLikeCopy_htmlWrappedTitle_matchesPlainAlt() {
+        let sut = OfferModel.mock(copy: ["title": "<h2>Acme Brand</h2>"])
+        XCTAssertTrue(sut.imageAltDuplicatesTitleLikeCopy("Acme Brand"))
+    }
+
+    func test_imageAltDuplicatesTitleLikeCopy_htmlEntities_matchDecodedAlt() {
+        let sut = OfferModel.mock(copy: ["title": "Tom &amp; Jerry"])
+        XCTAssertTrue(sut.imageAltDuplicatesTitleLikeCopy("Tom & Jerry"))
+    }
+
+    func test_imageAltDuplicatesTitleLikeCopy_mismatch_returnsFalse() {
+        let sut = OfferModel.mock(copy: ["title": "<h2>Acme</h2>"])
+        XCTAssertFalse(sut.imageAltDuplicatesTitleLikeCopy("Other Co"))
+    }
+
+    func test_imageAltDuplicatesTitleLikeCopy_subtitleKey_isIgnored() {
+        let sut = OfferModel.mock(copy: ["subtitle": "<b>Acme</b>"])
+        XCTAssertFalse(sut.imageAltDuplicatesTitleLikeCopy("Acme"))
+    }
+}

--- a/Tests/RoktUXHelperTests/UI/Components/Common/TestLightweightHTMLParser.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/Common/TestLightweightHTMLParser.swift
@@ -10,7 +10,7 @@ final class TestLightweightHTMLParser: XCTestCase {
     // MARK: - Plain text (no tags)
 
     func test_plain_text() {
-        let result = LightweightHTMLParser.parse(html: "Hello World", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "Hello World", baseFont: baseFont)
         XCTAssertEqual(result.string, "Hello World")
 
         let font = result.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
@@ -18,14 +18,14 @@ final class TestLightweightHTMLParser: XCTestCase {
     }
 
     func test_empty_string() {
-        let result = LightweightHTMLParser.parse(html: "", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "", baseFont: baseFont)
         XCTAssertEqual(result.string, "")
     }
 
     // MARK: - Bold
 
     func test_bold_b_tag() {
-        let result = LightweightHTMLParser.parse(html: "<b>Bold</b>", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "<b>Bold</b>", baseFont: baseFont)
         XCTAssertEqual(result.string, "Bold")
 
         let font = result.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
@@ -33,7 +33,7 @@ final class TestLightweightHTMLParser: XCTestCase {
     }
 
     func test_bold_strong_tag() {
-        let result = LightweightHTMLParser.parse(html: "<strong>Bold</strong>", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "<strong>Bold</strong>", baseFont: baseFont)
         XCTAssertEqual(result.string, "Bold")
 
         let font = result.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
@@ -43,7 +43,7 @@ final class TestLightweightHTMLParser: XCTestCase {
     // MARK: - Italic
 
     func test_italic_i_tag() {
-        let result = LightweightHTMLParser.parse(html: "<i>Italic</i>", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "<i>Italic</i>", baseFont: baseFont)
         XCTAssertEqual(result.string, "Italic")
 
         let font = result.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
@@ -51,7 +51,7 @@ final class TestLightweightHTMLParser: XCTestCase {
     }
 
     func test_italic_em_tag() {
-        let result = LightweightHTMLParser.parse(html: "<em>Italic</em>", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "<em>Italic</em>", baseFont: baseFont)
         XCTAssertEqual(result.string, "Italic")
 
         let font = result.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
@@ -61,7 +61,7 @@ final class TestLightweightHTMLParser: XCTestCase {
     // MARK: - Underline
 
     func test_underline() {
-        let result = LightweightHTMLParser.parse(html: "<u>Underlined</u>", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "<u>Underlined</u>", baseFont: baseFont)
         XCTAssertEqual(result.string, "Underlined")
 
         let underline = result.attribute(.underlineStyle, at: 0, effectiveRange: nil) as? Int
@@ -71,7 +71,7 @@ final class TestLightweightHTMLParser: XCTestCase {
     // MARK: - Strikethrough
 
     func test_strikethrough_s_tag() {
-        let result = LightweightHTMLParser.parse(html: "<s>Struck</s>", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "<s>Struck</s>", baseFont: baseFont)
         XCTAssertEqual(result.string, "Struck")
 
         let strike = result.attribute(.strikethroughStyle, at: 0, effectiveRange: nil) as? Int
@@ -79,7 +79,7 @@ final class TestLightweightHTMLParser: XCTestCase {
     }
 
     func test_strikethrough_strike_tag() {
-        let result = LightweightHTMLParser.parse(html: "<strike>Struck</strike>", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "<strike>Struck</strike>", baseFont: baseFont)
         XCTAssertEqual(result.string, "Struck")
 
         let strike = result.attribute(.strikethroughStyle, at: 0, effectiveRange: nil) as? Int
@@ -89,7 +89,7 @@ final class TestLightweightHTMLParser: XCTestCase {
     // MARK: - Links
 
     func test_link_with_href() {
-        let result = LightweightHTMLParser.parse(
+        let (result, _) = LightweightHTMLParser.parse(
             html: "<a href=\"https://rokt.com\">Rokt</a>",
             baseFont: baseFont
         )
@@ -100,7 +100,7 @@ final class TestLightweightHTMLParser: XCTestCase {
     }
 
     func test_link_with_target_attribute() {
-        let result = LightweightHTMLParser.parse(
+        let (result, _) = LightweightHTMLParser.parse(
             html: "<a href=\"https://rokt.com/privacy\" target=\"_blank\">Privacy</a>",
             baseFont: baseFont
         )
@@ -113,7 +113,7 @@ final class TestLightweightHTMLParser: XCTestCase {
     // MARK: - Font color
 
     func test_font_color_unquoted() {
-        let result = LightweightHTMLParser.parse(
+        let (result, _) = LightweightHTMLParser.parse(
             html: "<font color=#FF0000>Red</font>",
             baseFont: baseFont
         )
@@ -124,7 +124,7 @@ final class TestLightweightHTMLParser: XCTestCase {
     }
 
     func test_font_color_quoted() {
-        let result = LightweightHTMLParser.parse(
+        let (result, _) = LightweightHTMLParser.parse(
             html: "<font color=\"#00FF00\">Green</font>",
             baseFont: baseFont
         )
@@ -135,7 +135,7 @@ final class TestLightweightHTMLParser: XCTestCase {
     }
 
     func test_font_color_does_not_bleed_outside_tag() {
-        let result = LightweightHTMLParser.parse(
+        let (result, _) = LightweightHTMLParser.parse(
             html: "Before <font color=#FF0000>Red</font> After",
             baseFont: baseFont
         )
@@ -151,12 +151,12 @@ final class TestLightweightHTMLParser: XCTestCase {
     // MARK: - Line break
 
     func test_br_tag() {
-        let result = LightweightHTMLParser.parse(html: "Line1<br>Line2", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "Line1<br>Line2", baseFont: baseFont)
         XCTAssertEqual(result.string, "Line1\nLine2")
     }
 
     func test_self_closing_br_tag() {
-        let result = LightweightHTMLParser.parse(html: "Line1<br/>Line2", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "Line1<br/>Line2", baseFont: baseFont)
         XCTAssertEqual(result.string, "Line1\nLine2")
     }
 
@@ -164,7 +164,7 @@ final class TestLightweightHTMLParser: XCTestCase {
 
     func test_dcui_fixture_strong_em_u_s() {
         let html = "<strong><em><u>ORDER</u> <s>Number</s>: Uk171359906</em></strong>"
-        let result = LightweightHTMLParser.parse(html: html, baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: html, baseFont: baseFont)
 
         XCTAssertEqual(result.string, "ORDER Number: Uk171359906")
 
@@ -187,7 +187,7 @@ final class TestLightweightHTMLParser: XCTestCase {
 
     func test_dcui_fixture_with_font_color_wrapper() {
         let html = "<font color=#AABBCC><strong><em><u>ORDER</u> <s>Number</s>: Uk171359906</em></strong></font>"
-        let result = LightweightHTMLParser.parse(html: html, baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: html, baseFont: baseFont)
 
         XCTAssertEqual(result.string, "ORDER Number: Uk171359906")
 
@@ -199,7 +199,7 @@ final class TestLightweightHTMLParser: XCTestCase {
     // MARK: - Bold + Italic combined
 
     func test_bold_italic_combined() {
-        let result = LightweightHTMLParser.parse(html: "<b><i>BoldItalic</i></b>", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "<b><i>BoldItalic</i></b>", baseFont: baseFont)
         XCTAssertEqual(result.string, "BoldItalic")
 
         let font = result.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
@@ -210,7 +210,7 @@ final class TestLightweightHTMLParser: XCTestCase {
     // MARK: - Mixed styled and unstyled text
 
     func test_partial_bold() {
-        let result = LightweightHTMLParser.parse(html: "Get <b>20% off</b> today", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "Get <b>20% off</b> today", baseFont: baseFont)
         XCTAssertEqual(result.string, "Get 20% off today")
 
         let fontPlain = result.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
@@ -226,7 +226,7 @@ final class TestLightweightHTMLParser: XCTestCase {
     // MARK: - Nil base font (falls back to system font)
 
     func test_nil_base_font_still_applies_bold() {
-        let result = LightweightHTMLParser.parse(html: "<b>Bold</b>", baseFont: nil)
+        let (result, _) = LightweightHTMLParser.parse(html: "<b>Bold</b>", baseFont: nil)
         XCTAssertEqual(result.string, "Bold")
 
         let font = result.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
@@ -235,7 +235,7 @@ final class TestLightweightHTMLParser: XCTestCase {
     }
 
     func test_nil_base_font_still_applies_italic() {
-        let result = LightweightHTMLParser.parse(html: "<i>Italic</i>", baseFont: nil)
+        let (result, _) = LightweightHTMLParser.parse(html: "<i>Italic</i>", baseFont: nil)
         XCTAssertEqual(result.string, "Italic")
 
         let font = result.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
@@ -244,7 +244,7 @@ final class TestLightweightHTMLParser: XCTestCase {
     }
 
     func test_nil_base_font_uses_system_font_size() {
-        let result = LightweightHTMLParser.parse(html: "Plain", baseFont: nil)
+        let (result, _) = LightweightHTMLParser.parse(html: "Plain", baseFont: nil)
         XCTAssertEqual(result.string, "Plain")
 
         let font = result.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
@@ -255,39 +255,39 @@ final class TestLightweightHTMLParser: XCTestCase {
     // MARK: - HTML entities
 
     func test_html_entities_amp_lt_gt() {
-        let result = LightweightHTMLParser.parse(html: "A &amp; B &lt; C &gt; D", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "A &amp; B &lt; C &gt; D", baseFont: baseFont)
         XCTAssertEqual(result.string, "A & B < C > D")
     }
 
     func test_html_entities_quot_apos() {
-        let result = LightweightHTMLParser.parse(html: "&quot;hello&quot; &apos;world&apos;", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "&quot;hello&quot; &apos;world&apos;", baseFont: baseFont)
         XCTAssertEqual(result.string, "\"hello\" 'world'")
     }
 
     func test_html_entity_nbsp() {
-        let result = LightweightHTMLParser.parse(html: "no&nbsp;break", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "no&nbsp;break", baseFont: baseFont)
         XCTAssertEqual(result.string, "no\u{00A0}break")
     }
 
     func test_numeric_decimal_entity() {
-        let result = LightweightHTMLParser.parse(html: "&#65;&#66;&#67;", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "&#65;&#66;&#67;", baseFont: baseFont)
         XCTAssertEqual(result.string, "ABC")
     }
 
     func test_numeric_hex_entity() {
-        let result = LightweightHTMLParser.parse(html: "&#x41;&#x42;&#x43;", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "&#x41;&#x42;&#x43;", baseFont: baseFont)
         XCTAssertEqual(result.string, "ABC")
     }
 
     func test_unknown_entity_preserved() {
-        let result = LightweightHTMLParser.parse(html: "&unknown;", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "&unknown;", baseFont: baseFont)
         XCTAssertEqual(result.string, "&unknown;")
     }
 
     // MARK: - Case insensitivity
 
     func test_uppercase_tags() {
-        let result = LightweightHTMLParser.parse(html: "<B>Bold</B>", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "<B>Bold</B>", baseFont: baseFont)
         XCTAssertEqual(result.string, "Bold")
 
         let font = result.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
@@ -295,7 +295,7 @@ final class TestLightweightHTMLParser: XCTestCase {
     }
 
     func test_mixed_case_tags() {
-        let result = LightweightHTMLParser.parse(html: "<Strong>Bold</Strong>", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "<Strong>Bold</Strong>", baseFont: baseFont)
         XCTAssertEqual(result.string, "Bold")
 
         let font = result.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
@@ -305,7 +305,7 @@ final class TestLightweightHTMLParser: XCTestCase {
     // MARK: - Malformed HTML resilience
 
     func test_unclosed_tag_still_renders_text() {
-        let result = LightweightHTMLParser.parse(html: "<b>Bold text", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "<b>Bold text", baseFont: baseFont)
         XCTAssertEqual(result.string, "Bold text")
 
         let font = result.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
@@ -313,15 +313,23 @@ final class TestLightweightHTMLParser: XCTestCase {
     }
 
     func test_stray_less_than() {
-        let result = LightweightHTMLParser.parse(html: "A < B", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "A < B", baseFont: baseFont)
         XCTAssertTrue(result.string.contains("A"))
         XCTAssertTrue(result.string.contains("B"))
     }
 
     func test_empty_tag() {
-        let result = LightweightHTMLParser.parse(html: "Before<>After", baseFont: baseFont)
+        let (result, _) = LightweightHTMLParser.parse(html: "Before<>After", baseFont: baseFont)
         XCTAssertTrue(result.string.contains("Before"))
         XCTAssertTrue(result.string.contains("After"))
+    }
+
+    func test_heading_tags_set_semantic_heading_flag() {
+        let (_, hasHeading) = LightweightHTMLParser.parse(html: "<h2>Winter savings</h2>", baseFont: baseFont)
+        XCTAssertTrue(hasHeading)
+
+        let (_, noHeading) = LightweightHTMLParser.parse(html: "<b>Winter savings</b>", baseFont: baseFont)
+        XCTAssertFalse(noHeading)
     }
 
     // MARK: - Integration with htmlToAttributedString extension

--- a/Tests/RoktUXHelperTests/UI/Components/Distribution/TestCarouselDistributionComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/Distribution/TestCarouselDistributionComponent.swift
@@ -37,7 +37,7 @@ final class TestCarouselDistributionComponent: XCTestCase {
 
         // Test accessibility label on the carousel item (LayoutSchemaComponent)
         let carouselItem = try geometryReader.find(LayoutSchemaComponent.self)
-        XCTAssertEqual(try carouselItem.accessibilityLabel().string(), "Page 1 of 1")
+        XCTAssertEqual(try carouselItem.accessibilityLabel().string(), "Offer 1 of 1")
 
         carouselComponent.model.goToNextOffer(nil)
         XCTAssertTrue(closeActionCalled)

--- a/Tests/RoktUXHelperTests/UI/Components/Distribution/TestGroupedDistributionComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/Distribution/TestGroupedDistributionComponent.swift
@@ -41,7 +41,7 @@ final class TestGroupedDistributionComponent: XCTestCase {
         let padding = try grouped.padding()
         XCTAssertEqual(padding, EdgeInsets(top: 3.0, leading: 6.0, bottom: 5.0, trailing: 4.0))
         
-        XCTAssertEqual(try grouped.accessibilityLabel().string(), "Page 1 of 1")
+        XCTAssertEqual(try grouped.accessibilityLabel().string(), "Offer 1 of 1")
 
         groupedComponent.goToNextOffer()
         XCTAssertTrue(closeActionCalled)

--- a/Tests/RoktUXHelperTests/UI/Components/TestProgressIndicatorComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestProgressIndicatorComponent.swift
@@ -30,7 +30,7 @@ final class TestProgressIndicatorComponent: XCTestCase {
         let padding = try progressIndicator.padding()
         XCTAssertEqual(padding, EdgeInsets(top: 10.0, leading: 10.0, bottom: 10.0, trailing: 10.0))
         
-        XCTAssertEqual(try progressIndicator.accessibilityLabel().string(), "1 of 1")
+        XCTAssertEqual(try progressIndicator.accessibilityLabel().string(), "Offer 1 of 1")
         XCTAssertEqual(try progressIndicator.accessibilityHidden(), false)
     }
     


### PR DESCRIPTION
## Background

- A partner reported VoiceOver issues on the latest SDK: rich text that uses HTML heading tags did not expose an appropriate Heading role; brand/logo images duplicated spoken content when their alt matched adjacent title-style copy; and pagination / dot indicators announced bare counts (“2 of 4”) without enough context.
- The intent is to align with expected accessibility behavior—semantic headings via traits (not extra label suffixes), treat redundant brand imagery as decorative when it repeats title-like copy, and make position announcements explicitly refer to offers.

## What Has Changed

- Headings: LightweightHTMLParser recognizes <h1>–<h6> and surfaces whether the string contains heading content; RichTextViewModel / RichTextComponent apply AccessibilityTraits.header (SwiftUI .isHeader) when appropriate, without appending “heading” text to labels.
- Decorative brand images: OfferModel compares normalized image alt to title-like fields in creative.copy; when they match, image views (AsyncImageView, Base64Image, ExternalAsyncImage) hide from VoiceOver via accessibilityHidden, wired from data/static/carousel image components.
- Pagination copy: kPageAnnouncement, kOneByOneAnnouncement, and kProgressIndicatorAnnouncement now use Offer %d of %d so indicators announce e.g. “Offer 2 of 4”; distribution and progress-indicator tests were updated accordingly.
- CHANGELOG: Unreleased notes describe the VoiceOver fixes above.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes

- {Any additional information or context relevant to this PR}

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes [ticket](https://go/j/[ticket-number])
