### PR TITLE
fix(gallery): improve image carousel swiping in sheets

### DIFF
--- a/Sources/RoktUXHelper/UI/Components/CatalogImageGalleryComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/CatalogImageGalleryComponent.swift
@@ -5,7 +5,6 @@ import DcuiSchema
 
 /// UIKit gesture layer that disambiguates horizontal pan from vertical scroll,
 /// allowing the gallery swipe to coexist with a parent ScrollView(.vertical).
-@available(iOS 15, *)
 struct GalleryGestureView: UIViewRepresentable {
     var onTap: (CGPoint) -> Void
     var onPanChanged: ((CGFloat) -> Void)?
@@ -102,25 +101,21 @@ struct GalleryGestureView: UIViewRepresentable {
 
 // MARK: - GallerySwipePolicy
 
-@available(iOS 15, *)
 enum GalleryPanAxis: Equatable {
     case horizontal
     case vertical
 }
 
-@available(iOS 15, *)
 enum GallerySwipeDirection: Equatable {
     case backward
     case forward
 }
 
-@available(iOS 15, *)
 struct GallerySwipeResolution: Equatable {
     let page: Int
     let direction: GallerySwipeDirection?
 }
 
-@available(iOS 15, *)
 enum GallerySwipePolicy {
     private static let thresholdRatio: CGFloat = 0.22
     private static let minimumThreshold: CGFloat = 44
@@ -192,7 +187,6 @@ enum GallerySwipePolicy {
 // MARK: - CatalogHSPageView
 
 /// Horizontal pager that tracks drag offset for interactive swipe animation.
-@available(iOS 15, *)
 struct CatalogHSPageView<Content: View>: View {
     @Binding var page: Int
     let pages: Int
@@ -277,7 +271,6 @@ struct CatalogHSPageView<Content: View>: View {
 
 // MARK: - CatalogImageGalleryComponent
 
-@available(iOS 15, *)
 struct CatalogImageGalleryComponent: View {
     @SwiftUI.Environment(\.colorScheme) var colorScheme
     @EnvironmentObject var globalScreenSize: GlobalScreenSize

--- a/Sources/RoktUXHelper/UI/Components/CatalogImageGalleryComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/CatalogImageGalleryComponent.swift
@@ -126,7 +126,7 @@ enum GallerySwipePolicy {
     private static let minimumThreshold: CGFloat = 44
     private static let maximumThreshold: CGFloat = 90
     private static let flickVelocity: CGFloat = 500
-    private static let horizontalIntentRatio: CGFloat = 0.75
+    private static let horizontalDominanceRatio: CGFloat = 1
     private static let axisLockMinimumDistance: CGFloat = 8
 
     static func shouldBeginPan(translation: CGPoint = .zero, velocity: CGPoint) -> Bool {
@@ -143,7 +143,7 @@ enum GallerySwipePolicy {
 
     private static func axis(horizontal: CGFloat, vertical: CGFloat, minimum: CGFloat) -> GalleryPanAxis? {
         guard max(horizontal, vertical) > minimum else { return nil }
-        return horizontal >= vertical * horizontalIntentRatio ? .horizontal : .vertical
+        return horizontal > vertical * horizontalDominanceRatio ? .horizontal : .vertical
     }
 
     static func threshold(for width: CGFloat) -> CGFloat {

--- a/Sources/RoktUXHelper/UI/Components/CatalogImageGalleryComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/CatalogImageGalleryComponent.swift
@@ -9,7 +9,7 @@ import DcuiSchema
 struct GalleryGestureView: UIViewRepresentable {
     var onTap: (CGPoint) -> Void
     var onPanChanged: ((CGFloat) -> Void)?
-    var onPanEnded: ((CGFloat) -> Void)?
+    var onPanEnded: ((CGFloat, CGFloat) -> Void)?
 
     func makeUIView(context: Context) -> UIView {
         let view = UIView()
@@ -44,12 +44,13 @@ struct GalleryGestureView: UIViewRepresentable {
     class Coordinator: NSObject, UIGestureRecognizerDelegate {
         var onTap: (CGPoint) -> Void
         var onPanChanged: ((CGFloat) -> Void)?
-        var onPanEnded: ((CGFloat) -> Void)?
+        var onPanEnded: ((CGFloat, CGFloat) -> Void)?
+        private var lockedAxis: GalleryPanAxis?
 
         init(
             onTap: @escaping (CGPoint) -> Void,
             onPanChanged: ((CGFloat) -> Void)?,
-            onPanEnded: ((CGFloat) -> Void)?
+            onPanEnded: ((CGFloat, CGFloat) -> Void)?
         ) {
             self.onTap = onTap
             self.onPanChanged = onPanChanged
@@ -62,12 +63,20 @@ struct GalleryGestureView: UIViewRepresentable {
         }
 
         @objc func handlePan(_ sender: UIPanGestureRecognizer) {
-            let translation = sender.translation(in: sender.view).x
+            let translation = sender.translation(in: sender.view)
+            let velocity = sender.velocity(in: sender.view)
+            if lockedAxis == nil {
+                lockedAxis = GallerySwipePolicy.lockedAxis(translation: translation, velocity: velocity)
+            }
+
             switch sender.state {
             case .changed:
-                onPanChanged?(translation)
-            case .ended, .cancelled:
-                onPanEnded?(translation)
+                guard lockedAxis == .horizontal else { return }
+                onPanChanged?(translation.x)
+            case .ended, .cancelled, .failed:
+                defer { lockedAxis = nil }
+                guard lockedAxis == .horizontal else { return }
+                onPanEnded?(translation.x, velocity.x)
             default:
                 break
             }
@@ -75,16 +84,108 @@ struct GalleryGestureView: UIViewRepresentable {
 
         func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
             guard let pan = gestureRecognizer as? UIPanGestureRecognizer else { return true }
+            let translation = pan.translation(in: pan.view)
             let velocity = pan.velocity(in: pan.view)
-            return abs(velocity.x) > abs(velocity.y)
+            lockedAxis = GallerySwipePolicy.lockedAxis(translation: translation, velocity: velocity)
+            return lockedAxis == .horizontal
         }
 
         func gestureRecognizer(
-            _: UIGestureRecognizer,
+            _ gestureRecognizer: UIGestureRecognizer,
             shouldRecognizeSimultaneouslyWith _: UIGestureRecognizer
         ) -> Bool {
-            true
+            guard gestureRecognizer is UIPanGestureRecognizer else { return true }
+            return lockedAxis != .horizontal
         }
+    }
+}
+
+// MARK: - GallerySwipePolicy
+
+@available(iOS 15, *)
+enum GalleryPanAxis: Equatable {
+    case horizontal
+    case vertical
+}
+
+@available(iOS 15, *)
+enum GallerySwipeDirection: Equatable {
+    case backward
+    case forward
+}
+
+@available(iOS 15, *)
+struct GallerySwipeResolution: Equatable {
+    let page: Int
+    let direction: GallerySwipeDirection?
+}
+
+@available(iOS 15, *)
+enum GallerySwipePolicy {
+    private static let thresholdRatio: CGFloat = 0.22
+    private static let minimumThreshold: CGFloat = 44
+    private static let maximumThreshold: CGFloat = 90
+    private static let flickVelocity: CGFloat = 500
+    private static let horizontalIntentRatio: CGFloat = 0.75
+    private static let axisLockMinimumDistance: CGFloat = 8
+
+    static func shouldBeginPan(translation: CGPoint = .zero, velocity: CGPoint) -> Bool {
+        lockedAxis(translation: translation, velocity: velocity) == .horizontal
+    }
+
+    static func lockedAxis(translation: CGPoint = .zero, velocity: CGPoint) -> GalleryPanAxis? {
+        if let axis = axis(horizontal: abs(translation.x), vertical: abs(translation.y), minimum: axisLockMinimumDistance) {
+            return axis
+        }
+
+        return axis(horizontal: abs(velocity.x), vertical: abs(velocity.y), minimum: 0)
+    }
+
+    private static func axis(horizontal: CGFloat, vertical: CGFloat, minimum: CGFloat) -> GalleryPanAxis? {
+        guard max(horizontal, vertical) > minimum else { return nil }
+        return horizontal >= vertical * horizontalIntentRatio ? .horizontal : .vertical
+    }
+
+    static func threshold(for width: CGFloat) -> CGFloat {
+        min(max(max(width, 0) * thresholdRatio, minimumThreshold), maximumThreshold)
+    }
+
+    static func targetPage(
+        currentPage: Int,
+        pages: Int,
+        width: CGFloat,
+        translation: CGFloat,
+        velocity: CGFloat
+    ) -> GallerySwipeResolution {
+        guard pages > 0 else {
+            return GallerySwipeResolution(page: 0, direction: nil)
+        }
+
+        let currentPage = max(min(currentPage, pages - 1), 0)
+        guard let direction = direction(width: width, translation: translation, velocity: velocity) else {
+            return GallerySwipeResolution(page: currentPage, direction: nil)
+        }
+
+        let nextPage = switch direction {
+        case .forward:
+            min(currentPage + 1, pages - 1)
+        case .backward:
+            max(currentPage - 1, 0)
+        }
+
+        return GallerySwipeResolution(page: nextPage, direction: direction)
+    }
+
+    private static func direction(width: CGFloat, translation: CGFloat, velocity: CGFloat) -> GallerySwipeDirection? {
+        if abs(translation) >= threshold(for: width) {
+            return translation < 0 ? .forward : .backward
+        }
+
+        if abs(velocity) >= flickVelocity {
+            return velocity < 0 ? .forward : .backward
+        }
+
+        return nil
     }
 }
 
@@ -136,27 +237,25 @@ struct CatalogHSPageView<Content: View>: View {
                 onPanChanged: { translation in
                     dragOffset = translation
                 },
-                onPanEnded: { translation in
-                    let threshold = geo.size.width/2
-                    var newPage = page
-                    var swipeDirection: Bool?
+                onPanEnded: { translation, velocity in
+                    let resolution = GallerySwipePolicy.targetPage(
+                        currentPage: page,
+                        pages: pages,
+                        width: geo.size.width,
+                        translation: translation,
+                        velocity: velocity
+                    )
 
-                    if translation < -threshold {
-                        newPage += 1
-                        swipeDirection = true
-                    } else if translation > threshold {
-                        newPage -= 1
-                        swipeDirection = false
-                    }
-
-                    if let direction = swipeDirection {
-                        onSwipe?(direction)
+                    if let direction = resolution.direction {
+                        onSwipe?(direction == .forward)
                     }
 
                     dragOffset = 0
-                    page = max(min(newPage, pages - 1), 0)
+                    page = resolution.page
                 }
             )
+            .frame(width: geo.size.width, height: geo.size.height)
+            .contentShape(Rectangle())
         }
     }
 

--- a/Tests/RoktUXHelperTests/UI/Components/TestCatalogImageGalleryComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestCatalogImageGalleryComponent.swift
@@ -18,7 +18,6 @@ import DcuiSchema
 
 // MARK: - Component Tests
 
-@available(iOS 15.0, *)
 final class TestCatalogImageGalleryComponent: XCTestCase {
 
     // MARK: - Rendering
@@ -468,7 +467,6 @@ private class MockPanGestureRecognizer: UIPanGestureRecognizer {
 
 // MARK: - Factory Helpers
 
-@available(iOS 15.0, *)
 private extension TestCatalogImageGalleryComponent {
 
     func makeCatalogImageGalleryViewModel(
@@ -644,7 +642,6 @@ private extension TestCatalogImageGalleryComponent {
 
 // MARK: - LayoutSchemaViewModel Factory
 
-@available(iOS 15.0, *)
 extension LayoutSchemaViewModel {
     static func makeCatalogImageGallery(
         layoutState: LayoutState,

--- a/Tests/RoktUXHelperTests/UI/Components/TestCatalogImageGalleryComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestCatalogImageGalleryComponent.swift
@@ -331,6 +331,19 @@ final class GalleryGestureViewTests: XCTestCase {
 
         XCTAssertFalse(coordinator.gestureRecognizerShouldBegin(pan))
     }
+
+    func test_coordinator_verticalDominantDiagonalPanDoesNotBeginGalleryGesture() {
+        let coordinator = GalleryGestureView.Coordinator(onTap: { _ in }, onPanChanged: nil, onPanEnded: nil)
+        let pan = MockPanGestureRecognizer(
+            target: coordinator,
+            action: #selector(GalleryGestureView.Coordinator.handlePan(_:))
+        )
+        pan.mockTranslation = CGPoint(x: 80, y: 100)
+        pan.mockVelocity = CGPoint(x: 80, y: 100)
+
+        XCTAssertFalse(coordinator.gestureRecognizerShouldBegin(pan))
+        XCTAssertTrue(coordinator.gestureRecognizer(pan, shouldRecognizeSimultaneouslyWith: UIPanGestureRecognizer()))
+    }
 }
 
 // MARK: - GallerySwipePolicy Tests
@@ -398,12 +411,16 @@ final class GallerySwipePolicyTests: XCTestCase {
         XCTAssertEqual(backwardAtStart.direction, .backward)
     }
 
-    func test_mostlyHorizontalDiagonalPan_canBegin() {
-        XCTAssertTrue(GallerySwipePolicy.shouldBeginPan(velocity: CGPoint(x: 90, y: 100)))
+    func test_horizontalDominantDiagonalPan_canBegin() {
+        XCTAssertTrue(GallerySwipePolicy.shouldBeginPan(velocity: CGPoint(x: 120, y: 100)))
     }
 
-    func test_verticalDiagonalPan_doesNotBegin() {
-        XCTAssertFalse(GallerySwipePolicy.shouldBeginPan(velocity: CGPoint(x: 80, y: 200)))
+    func test_verticalDominantDiagonalPan_doesNotBegin() {
+        XCTAssertFalse(GallerySwipePolicy.shouldBeginPan(velocity: CGPoint(x: 80, y: 100)))
+    }
+
+    func test_equalDiagonalPan_prioritizesVerticalScroll() {
+        XCTAssertFalse(GallerySwipePolicy.shouldBeginPan(velocity: CGPoint(x: 100, y: 100)))
     }
 
     func test_axisLock_usesInitialHorizontalTranslationBeforeVerticalVelocity() {

--- a/Tests/RoktUXHelperTests/UI/Components/TestCatalogImageGalleryComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestCatalogImageGalleryComponent.swift
@@ -306,6 +306,123 @@ final class GalleryGestureViewTests: XCTestCase {
         XCTAssertNotNil(coordinator)
         XCTAssertNotNil(coordinator)
     }
+
+    func test_coordinator_horizontalPanLocksOutSimultaneousScroll() {
+        let coordinator = GalleryGestureView.Coordinator(onTap: { _ in }, onPanChanged: nil, onPanEnded: nil)
+        let pan = MockPanGestureRecognizer(
+            target: coordinator,
+            action: #selector(GalleryGestureView.Coordinator.handlePan(_:))
+        )
+        pan.mockTranslation = CGPoint(x: 40, y: 5)
+        pan.mockVelocity = CGPoint(x: 300, y: 40)
+
+        XCTAssertTrue(coordinator.gestureRecognizerShouldBegin(pan))
+        XCTAssertFalse(coordinator.gestureRecognizer(pan, shouldRecognizeSimultaneouslyWith: UIPanGestureRecognizer()))
+    }
+
+    func test_coordinator_verticalPanDoesNotBeginGalleryGesture() {
+        let coordinator = GalleryGestureView.Coordinator(onTap: { _ in }, onPanChanged: nil, onPanEnded: nil)
+        let pan = MockPanGestureRecognizer(
+            target: coordinator,
+            action: #selector(GalleryGestureView.Coordinator.handlePan(_:))
+        )
+        pan.mockTranslation = CGPoint(x: 5, y: 40)
+        pan.mockVelocity = CGPoint(x: 40, y: 300)
+
+        XCTAssertFalse(coordinator.gestureRecognizerShouldBegin(pan))
+    }
+}
+
+// MARK: - GallerySwipePolicy Tests
+
+final class GallerySwipePolicyTests: XCTestCase {
+
+    func test_shortSwipe_doesNotChangePage() {
+        let resolution = GallerySwipePolicy.targetPage(
+            currentPage: 1,
+            pages: 3,
+            width: 390,
+            translation: -30,
+            velocity: -120
+        )
+
+        XCTAssertEqual(resolution.page, 1)
+        XCTAssertNil(resolution.direction)
+    }
+
+    func test_naturalImageSwipe_advancesPage() {
+        let resolution = GallerySwipePolicy.targetPage(
+            currentPage: 0,
+            pages: 3,
+            width: 390,
+            translation: -100,
+            velocity: -120
+        )
+
+        XCTAssertEqual(resolution.page, 1)
+        XCTAssertEqual(resolution.direction, .forward)
+    }
+
+    func test_fastFlick_advancesPageWithShortTranslation() {
+        let resolution = GallerySwipePolicy.targetPage(
+            currentPage: 0,
+            pages: 3,
+            width: 390,
+            translation: -20,
+            velocity: -650
+        )
+
+        XCTAssertEqual(resolution.page, 1)
+        XCTAssertEqual(resolution.direction, .forward)
+    }
+
+    func test_swipeAtBounds_clampsPage() {
+        let forwardAtEnd = GallerySwipePolicy.targetPage(
+            currentPage: 2,
+            pages: 3,
+            width: 390,
+            translation: -100,
+            velocity: -120
+        )
+        let backwardAtStart = GallerySwipePolicy.targetPage(
+            currentPage: 0,
+            pages: 3,
+            width: 390,
+            translation: 100,
+            velocity: 120
+        )
+
+        XCTAssertEqual(forwardAtEnd.page, 2)
+        XCTAssertEqual(forwardAtEnd.direction, .forward)
+        XCTAssertEqual(backwardAtStart.page, 0)
+        XCTAssertEqual(backwardAtStart.direction, .backward)
+    }
+
+    func test_mostlyHorizontalDiagonalPan_canBegin() {
+        XCTAssertTrue(GallerySwipePolicy.shouldBeginPan(velocity: CGPoint(x: 90, y: 100)))
+    }
+
+    func test_verticalDiagonalPan_doesNotBegin() {
+        XCTAssertFalse(GallerySwipePolicy.shouldBeginPan(velocity: CGPoint(x: 80, y: 200)))
+    }
+
+    func test_axisLock_usesInitialHorizontalTranslationBeforeVerticalVelocity() {
+        let axis = GallerySwipePolicy.lockedAxis(
+            translation: CGPoint(x: 40, y: 5),
+            velocity: CGPoint(x: 20, y: 500)
+        )
+
+        XCTAssertEqual(axis, .horizontal)
+    }
+
+    func test_axisLock_usesInitialVerticalTranslationBeforeHorizontalVelocity() {
+        let axis = GallerySwipePolicy.lockedAxis(
+            translation: CGPoint(x: 5, y: 40),
+            velocity: CGPoint(x: 500, y: 20)
+        )
+
+        XCTAssertEqual(axis, .vertical)
+    }
 }
 
 // MARK: - Mock Helpers
@@ -316,6 +433,19 @@ private class MockTapGestureRecognizer: UITapGestureRecognizer {
 
     override func location(in view: UIView?) -> CGPoint {
         return mockLocation
+    }
+}
+
+private class MockPanGestureRecognizer: UIPanGestureRecognizer {
+    var mockTranslation: CGPoint = .zero
+    var mockVelocity: CGPoint = .zero
+
+    override func translation(in view: UIView?) -> CGPoint {
+        return mockTranslation
+    }
+
+    override func velocity(in view: UIView?) -> CGPoint {
+        return mockVelocity
     }
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- Catalog image galleries inside dynamic bottom sheets were difficult to swipe because horizontal image gestures competed with the bottom sheet's vertical scroll gesture.
- Users had to start swiping from the screen edge instead of directly on the image area, which made the carousel feel unnatural after expanding details.

## What Has Changed

- Adds a private gallery swipe policy that locks each pan to its initial horizontal or vertical direction until the gesture ends.
- Allows horizontal image-area swipes and fast flicks to page the carousel with a smaller bounded threshold.
- Lets vertical drags fall through to the parent bottom-sheet scroll view.
- Expands the gallery gesture layer to cover the image area.
- Adds unit tests for swipe decisions, bounds clamping, flick paging, diagonal gesture handling, and direction locking.

## Screenshots/Video

https://github.com/user-attachments/assets/a28e491a-2637-4fa8-8b8d-3abd541843d7

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Verified locally with focused gallery tests, the full `RoktUXHelper` iOS test target, `trunk check --ci`, and the Example UIKit flow on simulator.
