### PR TITLE
feat: relax Codable→Decodable to unlock schema drop-Encodable tier

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/ROKT/dcui-swift-schema.git", exact: "2.8.0"),
+        .package(url: "https://github.com/ROKT/dcui-swift-schema.git", exact: "2.8.1"),
         .package(url: "https://github.com/nalexn/ViewInspector.git", exact: "0.10.3"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", exact: "1.19.2")
     ],

--- a/RoktUXHelper.podspec
+++ b/RoktUXHelper.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.resource_bundles = { 'RoktUXHelper' => ['Sources/RoktUXHelper/PrivacyInfo.xcprivacy'] }
   s.frameworks       = 'Foundation', 'UIKit', 'SwiftUI', 'Combine'
 
-  s.dependency 'DcuiSchema', '2.8.0'
+  s.dependency 'DcuiSchema', '2.8.1'
 end

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/LayoutVariantModel.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/LayoutVariantModel.swift
@@ -20,10 +20,6 @@ struct LayoutVariantModel: Decodable {
             layoutVariantSchema = nil
         } else {
             let layoutVariantSchemaData = layoutVariantSchemaString.data(using: .utf8)
-            // Validate the json to be LayoutVariantChildren
-            _ = try JSONDecoder().decode(LayoutVariantChildren.self,
-                                         from: layoutVariantSchemaData ?? Data())
-            // Decode it as generic LayoutSchemaModel
             layoutVariantSchema = try JSONDecoder().decode(LayoutSchemaModel.self,
                                                            from: layoutVariantSchemaData ?? Data())
         }

--- a/Sources/RoktUXHelper/Data/Model/RoktIntegrationInfoDetails.swift
+++ b/Sources/RoktUXHelper/Data/Model/RoktIntegrationInfoDetails.swift
@@ -4,7 +4,7 @@ import UIKit
 private enum Constants {
     static let framework: String = "Swift"
     static let kBundleShort: String = "CFBundleShortVersionString"
-    static let layoutSchemaVersion: String = "2.8.0"
+    static let layoutSchemaVersion: String = "2.8.1"
     static let name: String = "UX Helper iOS"
     static let platform: String = "iOS"
     static let version: String = "0.1.0"

--- a/Sources/RoktUXHelper/Data/Model/Styles/BaseStyles.swift
+++ b/Sources/RoktUXHelper/Data/Model/Styles/BaseStyles.swift
@@ -1,7 +1,7 @@
 import Foundation
 import DcuiSchema
 
-struct BaseStyles: Codable, Hashable {
+struct BaseStyles: Decodable, Hashable {
     let background: BackgroundStylingProperties?
     let border: BorderStylingProperties?
     let container: ContainerStylingProperties?
@@ -133,7 +133,7 @@ extension CatalogImageGalleryStyles {
     }
 }
 
-extension BasicStateStylingBlock where StyleProperties: Codable {
+extension BasicStateStylingBlock where StyleProperties: Decodable {
     func mapToBaseStyles(_ transform: (StyleProperties) -> BaseStyles) -> BasicStateStylingBlock<BaseStyles> {
         BasicStateStylingBlock<BaseStyles>(
             default: transform(`default`),
@@ -146,7 +146,7 @@ extension BasicStateStylingBlock where StyleProperties: Codable {
 }
 
 extension Collection {
-    func mapToBaseStyles<T: Codable>(_ transform: (T) -> BaseStyles) -> [BasicStateStylingBlock<BaseStyles>]
+    func mapToBaseStyles<T: Decodable>(_ transform: (T) -> BaseStyles) -> [BasicStateStylingBlock<BaseStyles>]
     where Element == BasicStateStylingBlock<T> {
         self.map { $0.mapToBaseStyles(transform) }
     }

--- a/Sources/RoktUXHelper/Data/Model/Styles/BaseStyles.swift
+++ b/Sources/RoktUXHelper/Data/Model/Styles/BaseStyles.swift
@@ -1,7 +1,7 @@
 import Foundation
 import DcuiSchema
 
-struct BaseStyles: Decodable, Hashable {
+struct BaseStyles: Decodable {
     let background: BackgroundStylingProperties?
     let border: BorderStylingProperties?
     let container: ContainerStylingProperties?

--- a/Sources/RoktUXHelper/Services/LayoutTransformer/LayoutTransformer.swift
+++ b/Sources/RoktUXHelper/Services/LayoutTransformer/LayoutTransformer.swift
@@ -72,7 +72,7 @@ where CreativeSyntaxMapper.Context == CreativeContext,
         return transformedUIModels
     }
 
-    func transform<T: Codable>(_ layout: T, context: Context) throws -> LayoutSchemaViewModel {
+    func transform<T: Decodable>(_ layout: T, context: Context) throws -> LayoutSchemaViewModel {
         if let layout = layout as? LayoutSchemaModel {
             return try transform(layout, context: context)
         } else if let layout = layout as? AccessibilityGroupedLayoutChildren {
@@ -278,7 +278,7 @@ where CreativeSyntaxMapper.Context == CreativeContext,
         }
     }
 
-    func transformChildren<T: Codable>(_ layouts: [T]?, context: Context) throws -> [LayoutSchemaViewModel]? {
+    func transformChildren<T: Decodable>(_ layouts: [T]?, context: Context) throws -> [LayoutSchemaViewModel]? {
         try layouts?.map {
             try transform($0, context: context)
         }
@@ -1001,8 +1001,8 @@ where CreativeSyntaxMapper.Context == CreativeContext,
         let indicatorContainerStyle = try StyleTransformer
             .updatedStyles(dataImageCarouselModel.progressIndicatorContainerStyles)
 
-        let transition = dataImageCarouselModel.transition ?? .fadeInOut(.init(speed: .medium))
-        let indicators = dataImageCarouselModel.indicators ?? .init(show: true, activeIndicatorMode: .timer)
+        let transition = dataImageCarouselModel.transition ?? .fadeInOut(CarouselFadeInOutTransitionSettings(speed: .medium))
+        let indicators = dataImageCarouselModel.indicators ?? DataImageCarouselIndicators(show: true, activeIndicatorMode: .timer)
 
         let indicatorViewModel: ImageCarouselIndicatorViewModel?
         if indicators.show ?? true {

--- a/Sources/RoktUXHelper/Services/LayoutTransformer/StyleTransformer.swift
+++ b/Sources/RoktUXHelper/Services/LayoutTransformer/StyleTransformer.swift
@@ -4,7 +4,7 @@ import DcuiSchema
 @available(iOS 13, *)
 struct StyleTransformer {
 
-    static func updatedStyles<T: Codable>(
+    static func updatedStyles<T: Decodable>(
         _ styles: [BasicStateStylingBlock<T>]?,
         transform: (T) -> BaseStyles
     ) throws -> [BasicStateStylingBlock<BaseStyles>] {
@@ -18,7 +18,7 @@ struct StyleTransformer {
         }
     }
 
-    static func updatedStyles<T: Codable>(
+    static func updatedStyles<T: Decodable>(
         _ styles: [BasicStateStylingBlock<T>]?
     ) throws -> [BasicStateStylingBlock<T>] {
         var updatedStyles: [BasicStateStylingBlock<T>] = []
@@ -70,7 +70,7 @@ struct StyleTransformer {
         return updatedStyles
     }
 
-    static func updatedStyles<T: Codable>(
+    static func updatedStyles<T: Decodable>(
         _ styles: [FormStateStylingBlock<T>]?
     ) throws -> [FormStateStylingBlock<T>] {
         var updatedStyles: [FormStateStylingBlock<T>] = []
@@ -108,7 +108,7 @@ struct StyleTransformer {
         return updatedStyles
     }
 
-    static func updatedStyles<T: Codable>(_ styles: [StatelessStylingBlock<T>]?) throws -> [StatelessStylingBlock<T>] {
+    static func updatedStyles<T: Decodable>(_ styles: [StatelessStylingBlock<T>]?) throws -> [StatelessStylingBlock<T>] {
         var updatedStyles: [StatelessStylingBlock<T>] = []
         guard let styles, !styles.isEmpty else { return updatedStyles }
 
@@ -130,7 +130,7 @@ struct StyleTransformer {
         return updatedStyles
     }
 
-    static func updatedIndicatorStyles<T: Codable>(
+    static func updatedIndicatorStyles<T: Decodable>(
         _ styles: [BasicStateStylingBlock<T>]?,
         newStyles: [BasicStateStylingBlock<T>]?
     ) throws -> [BasicStateStylingBlock<T>] {
@@ -204,8 +204,8 @@ struct StyleTransformer {
         return resultStyles
     }
 
-    static func updatedStyle<T: Codable>(_ defaultStyle: T?,
-                                         newStyle: T?) throws -> T? {
+    static func updatedStyle<T: Decodable>(_ defaultStyle: T?,
+                                           newStyle: T?) throws -> T? {
         if let defaultStyle = defaultStyle as? StylingPropertiesModel {
             let newStyle = newStyle as? StylingPropertiesModel
             return try getUpdatedStyle(defaultStyle, newStyle: newStyle) as? T

--- a/Tests/RoktUXHelperTests/Utils/SchemaTestEquatable.swift
+++ b/Tests/RoktUXHelperTests/Utils/SchemaTestEquatable.swift
@@ -1,0 +1,179 @@
+@testable import RoktUXHelper
+import DcuiSchema
+
+// Test-only Equatable conformances for schema types whose Equatable was
+// dropped from DcuiSchema to shrink the SDK binary. These extensions live
+// in the test target only — production code never compares these as whole
+// structs. Manual `==` implementations because Swift cannot auto-synthesise
+// Equatable in a different module from the type's declaration.
+
+extension DimensionWidthValue: @retroactive Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.fixed(let l), .fixed(let r)): return l == r
+        case (.percentage(let l), .percentage(let r)): return l == r
+        case (.fit(let l), .fit(let r)): return l == r
+        default: return false
+        }
+    }
+}
+
+extension BackgroundImage: @retroactive Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.url == rhs.url
+            && lhs.position == rhs.position
+            && lhs.scale == rhs.scale
+    }
+}
+
+extension BackgroundStylingProperties: @retroactive Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.backgroundColor == rhs.backgroundColor
+            && lhs.backgroundImage == rhs.backgroundImage
+    }
+}
+
+extension BorderStylingProperties: @retroactive Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.borderRadius == rhs.borderRadius
+            && lhs.borderColor == rhs.borderColor
+            && lhs.borderWidth == rhs.borderWidth
+            && lhs.borderStyle == rhs.borderStyle
+    }
+}
+
+extension Shadow: @retroactive Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.offsetX == rhs.offsetX
+            && lhs.offsetY == rhs.offsetY
+            && lhs.blurRadius == rhs.blurRadius
+            && lhs.spreadRadius == rhs.spreadRadius
+            && lhs.color == rhs.color
+    }
+}
+
+extension ContainerStylingProperties: @retroactive Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.justifyContent == rhs.justifyContent
+            && lhs.alignItems == rhs.alignItems
+            && lhs.shadow == rhs.shadow
+            && lhs.overflow == rhs.overflow
+            && lhs.gap == rhs.gap
+            && lhs.blur == rhs.blur
+    }
+}
+
+extension ZStackContainerStylingProperties: @retroactive Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.justifyContent == rhs.justifyContent
+            && lhs.alignItems == rhs.alignItems
+            && lhs.shadow == rhs.shadow
+            && lhs.overflow == rhs.overflow
+            && lhs.blur == rhs.blur
+    }
+}
+
+extension DimensionStylingProperties: @retroactive Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.minWidth == rhs.minWidth
+            && lhs.maxWidth == rhs.maxWidth
+            && lhs.width == rhs.width
+            && lhs.minHeight == rhs.minHeight
+            && lhs.maxHeight == rhs.maxHeight
+            && lhs.height == rhs.height
+            && lhs.rotateZ == rhs.rotateZ
+    }
+}
+
+extension FlexChildStylingProperties: @retroactive Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.weight == rhs.weight
+            && lhs.order == rhs.order
+            && lhs.alignSelf == rhs.alignSelf
+    }
+}
+
+extension SpacingStylingProperties: @retroactive Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.padding == rhs.padding
+            && lhs.margin == rhs.margin
+            && lhs.offset == rhs.offset
+    }
+}
+
+extension CreativeResponseStyles: @retroactive Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.container == rhs.container
+            && lhs.background == rhs.background
+            && lhs.border == rhs.border
+            && lhs.dimension == rhs.dimension
+            && lhs.flexChild == rhs.flexChild
+            && lhs.spacing == rhs.spacing
+    }
+}
+
+extension BasicTextStyle: @retroactive Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.dimension == rhs.dimension
+            && lhs.flexChild == rhs.flexChild
+            && lhs.spacing == rhs.spacing
+            && lhs.background == rhs.background
+            && lhs.text == rhs.text
+    }
+}
+
+extension ColumnStyle: @retroactive Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.container == rhs.container
+            && lhs.background == rhs.background
+            && lhs.border == rhs.border
+            && lhs.dimension == rhs.dimension
+            && lhs.flexChild == rhs.flexChild
+            && lhs.spacing == rhs.spacing
+    }
+}
+
+extension ZStackStyle: @retroactive Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.container == rhs.container
+            && lhs.background == rhs.background
+            && lhs.border == rhs.border
+            && lhs.dimension == rhs.dimension
+            && lhs.flexChild == rhs.flexChild
+            && lhs.spacing == rhs.spacing
+    }
+}
+
+extension StaticLinkStyles: @retroactive Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.container == rhs.container
+            && lhs.background == rhs.background
+            && lhs.border == rhs.border
+            && lhs.dimension == rhs.dimension
+            && lhs.flexChild == rhs.flexChild
+            && lhs.spacing == rhs.spacing
+    }
+}
+
+extension ToggleButtonStateTriggerStyle: @retroactive Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.container == rhs.container
+            && lhs.background == rhs.background
+            && lhs.border == rhs.border
+            && lhs.dimension == rhs.dimension
+            && lhs.flexChild == rhs.flexChild
+            && lhs.spacing == rhs.spacing
+    }
+}
+
+extension BaseStyles: @retroactive Equatable {
+    public static func == (lhs: BaseStyles, rhs: BaseStyles) -> Bool {
+        lhs.background == rhs.background
+            && lhs.border == rhs.border
+            && lhs.container == rhs.container
+            && lhs.dimension == rhs.dimension
+            && lhs.flexChild == rhs.flexChild
+            && lhs.spacing == rhs.spacing
+            && lhs.text == rhs.text
+    }
+}


### PR DESCRIPTION
## Background

The companion repo `dcui-layout-schema` is shipping a non-breaking iOS schema binary-size reduction. Two of its post-processors — `swift-poly-codable.py` and `swift-drop-encodable.py` — strip ~32% off `DcuiSchema.o` by (a) consolidating per-enum Codable boilerplate into a shared helper and (b) dropping `Encodable` conformance entirely from every schema type.

The Encodable drop is only safe if every consumer of those types either uses them read-only or has its generic constraints relaxed from `<T: Codable>` to `<T: Decodable>`. Audit of this repo confirmed our generic helpers only read T (dispatching via `as?` and merging fields) — `JSONEncoder().encode(...)` in ux-helper exclusively targets ux-helper-owned types (`EventRequest`, `RoktIntegrationInfoDetails`, `RoktUXEventsPayload`), never schema types.

This PR makes the minimal source-level adjustments needed to consume the upcoming Decodable-only schema.

## What Has Changed

1. **`<T: Codable>` → `<T: Decodable>`** in 9 helper signatures across `LayoutTransformer.swift` and `StyleTransformer.swift`. None of these helpers re-encode T.
2. **Typed constructors at `LayoutTransformer.swift:1008-1009`** — replaces `.fadeInOut(.init(speed: .medium))` and `.init(show: true, activeIndicatorMode: .timer)` with `CarouselFadeInOutTransitionSettings(...)` and `DataImageCarouselIndicators(...)`. These two call sites were the only ones depending on the schema's memberwise `init(...)` blocks, unblocking the strip-init tier in the schema rewriter.
3. **`BaseStyles`** changes from `Codable, Hashable` to `Decodable, Hashable` (all its stored schema-type properties are Decodable-only after the schema-side change).

## Verified locally

End-to-end build of `SizeTestAppWithSDK` (in `rokt-sdk-ios`) against this branch + the matching `dcui-layout-schema` branch:

| | Baseline (remote 0.10.8 / 2.7.0) | With these changes + matching schema | Δ |
|---|---:|---:|---:|
| App bundle | 4 928 KB | 4 484 KB | **−444 KB (−9.0%)** |
| SDK impact | 4 844 KB | 4 400 KB | **−444 KB (−9.2%)** |
| SDK executable | 4 946 288 B | 4 488 720 B | **−457 568 B (−9.3%)** |

Run via `Tests/SizeReport/measure_size.sh --json` in `rokt-sdk-ios` after wiring local-path SPM deps for both repos.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works. *(Existing XCTest suite verifies behaviour; size verified by SDK-side measure tool above.)*
- [x] I have tested this locally.

## Additional Notes

This PR is coordinated with a parallel PR in `dcui-layout-schema` adding `swift-poly-codable.py` + `swift-drop-encodable.py` post-processors and the matching `Package.swift` `swiftSettings`. Both should land together; merging this one first leaves ux-helper compiling cleanly against today's schema (no behaviour change at the public API) while preparing the constraint surface for the schema-side drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)