### PR TITLE
fix: avoid stale presenters for overlay layouts

### DIFF
--- a/Sources/RoktUXHelper/RoktUX.swift
+++ b/Sources/RoktUXHelper/RoktUX.swift
@@ -479,9 +479,25 @@ public class RoktUX: UXEventsDelegate {
                                             eventService: EventService?,
                                             onLoad: @escaping (() -> Void),
                                             onUnload: @escaping (() -> Void),
+                                            presentationAttempt: Int = 0,
                                             @ViewBuilder builder: @escaping (((CGFloat) -> Void)?) -> Content) {
         DispatchQueue.main.async {
             if let viewController = self.getTopViewController() {
+                if let transitionCoordinator = viewController.transitionCoordinator,
+                   presentationAttempt < 3 {
+                    transitionCoordinator.animate(alongsideTransition: nil) { _ in
+                        self.showOverlay(placementType: placementType,
+                                         bottomSheetUIModel: bottomSheetUIModel,
+                                         layoutState: layoutState,
+                                         eventService: eventService,
+                                         onLoad: onLoad,
+                                         onUnload: onUnload,
+                                         presentationAttempt: presentationAttempt + 1,
+                                         builder: builder)
+                    }
+                    return
+                }
+
                 viewController.present(placementType: placementType,
                                        bottomSheetUIModel: bottomSheetUIModel,
                                        layoutState: layoutState,
@@ -494,15 +510,9 @@ public class RoktUX: UXEventsDelegate {
     }
 
     private func getTopViewController() -> UIViewController? {
-        let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
+        let keyWindow = RoktUXPresentationResolver.keyWindow()
 
-        if var topController = keyWindow?.rootViewController {
-            while let presentedViewController = topController.presentedViewController {
-                topController = presentedViewController
-            }
-            return topController
-        }
-        return nil
+        return RoktUXPresentationResolver.stableTopViewController(startingAt: keyWindow?.rootViewController)
     }
 
     private func sendPageIntialEvents(

--- a/Sources/RoktUXHelper/UI/Components/Common/RoktUXPresentationResolver.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/RoktUXPresentationResolver.swift
@@ -1,0 +1,37 @@
+import UIKit
+
+@available(iOS 15.0, *)
+enum RoktUXPresentationResolver {
+    static func keyWindow() -> UIWindow? {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .filter { $0.activationState == .foregroundActive || $0.activationState == .foregroundInactive }
+            .flatMap(\.windows)
+            .first { $0.isKeyWindow }
+    }
+
+    static func stableTopViewController(
+        startingAt controller: UIViewController?,
+        isPresenterUsable: (UIViewController) -> Bool = defaultIsPresenterUsable
+    ) -> UIViewController? {
+        guard let controller, isPresenterUsable(controller) else {
+            return nil
+        }
+
+        var topController = controller
+        while let presentedViewController = topController.presentedViewController {
+            guard isPresenterUsable(presentedViewController) else {
+                break
+            }
+            topController = presentedViewController
+        }
+
+        return topController
+    }
+
+    private static func defaultIsPresenterUsable(_ controller: UIViewController) -> Bool {
+        controller.viewIfLoaded?.window != nil &&
+        !controller.isBeingDismissed &&
+        !controller.isMovingFromParent
+    }
+}

--- a/Tests/RoktUXHelperTests/UI/Components/Common/TestRoktUXPresentationResolver.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/Common/TestRoktUXPresentationResolver.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import RoktUXHelper
+
+@available(iOS 15.0, *)
+final class TestRoktUXPresentationResolver: XCTestCase {
+    func testStableTopViewControllerSkipsUnusablePresentedController() {
+        let root = StubPresentedViewController()
+        let stalePresented = StubPresentedViewController()
+        root.stubPresentedViewController = stalePresented
+
+        let presenter = RoktUXPresentationResolver.stableTopViewController(
+            startingAt: root,
+            isPresenterUsable: { $0 === root }
+        )
+
+        XCTAssertTrue(presenter === root)
+    }
+
+    func testStableTopViewControllerReturnsDeepestUsablePresentedController() {
+        let root = StubPresentedViewController()
+        let firstPresented = StubPresentedViewController()
+        let secondPresented = StubPresentedViewController()
+        root.stubPresentedViewController = firstPresented
+        firstPresented.stubPresentedViewController = secondPresented
+
+        let presenter = RoktUXPresentationResolver.stableTopViewController(
+            startingAt: root,
+            isPresenterUsable: { _ in true }
+        )
+
+        XCTAssertTrue(presenter === secondPresented)
+    }
+
+    func testStableTopViewControllerReturnsNilWhenRootIsUnusable() {
+        let root = StubPresentedViewController()
+
+        let presenter = RoktUXPresentationResolver.stableTopViewController(
+            startingAt: root,
+            isPresenterUsable: { _ in false }
+        )
+
+        XCTAssertNil(presenter)
+    }
+}
+
+private final class StubPresentedViewController: UIViewController {
+    var stubPresentedViewController: UIViewController?
+
+    override var presentedViewController: UIViewController? {
+        stubPresentedViewController
+    }
+}


### PR DESCRIPTION
## Background

- Overlay and bottom sheet layouts can be requested while UIKit is still completing a previous presentation transition. Resolving the top view controller during that window can select a presented controller that is no longer safe to present from.

## What Has Changed

- Resolve the presenter from the active foreground scene instead of deprecated global windows.
- Skip presented view controllers that are being dismissed, moving from parent, or detached from a window.
- Defer overlay presentation until the current transition coordinator completes, with a bounded retry.
- Add unit coverage for stable presenter resolution.

## Screenshots/Video

- N/A — no visual appearance changes.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes

- Local validation: `trunk check --ci`
- Local validation: `xcodebuild test -scheme RoktUXHelper -destination 'platform=iOS Simulator,id=2728398F-F3D7-42B5-BBCF-C7AD35ED7425' -only-testing:RoktUXHelperTests/TestRoktUXPresentationResolver`