### PR TITLE
feat(richtext): support <p> tag in HTML parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support `<p>` tag in RichText HTML parser. Paragraphs render with a line break and 8pt of spacing between them.
+
 ## [0.10.10] - 2026-05-19
 
 ### Fixed

--- a/Sources/RoktUXHelper/UI/Components/Common/LightweightHTMLParser.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/LightweightHTMLParser.swift
@@ -88,6 +88,21 @@ enum LightweightHTMLParser {
         } else if tag.isSelfClosing || tag.name == "br" {
             result.append(NSAttributedString(string: "\n"))
         } else if tag.name == "p" {
+            // If a previous <p> is still open (no explicit </p>), finalize it
+            // so its range is preserved instead of overwritten.
+            if let start = paragraphStart {
+                if !result.string.hasSuffix("\n") {
+                    result.append(NSAttributedString(string: "\n"))
+                }
+                let length = result.length - start
+                if length > 0 {
+                    paragraphRanges.append(NSRange(location: start, length: length))
+                }
+                paragraphStart = nil
+                if let openP = stack.lastIndex(where: { $0.name == "p" }) {
+                    stack.remove(at: openP)
+                }
+            }
             if result.length > 0, !result.string.hasSuffix("\n") {
                 result.append(NSAttributedString(string: "\n"))
             }

--- a/Sources/RoktUXHelper/UI/Components/Common/LightweightHTMLParser.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/LightweightHTMLParser.swift
@@ -4,7 +4,7 @@ import UIKit
 ///
 /// Supports the DCUI rich text tag surface:
 ///   `<b>`, `<strong>`, `<i>`, `<em>`, `<u>`, `<s>`, `<strike>`,
-///   `<a href="…" target="…">`, `<font color="…">`, `<br>`, `<br/>`
+///   `<a href="…" target="…">`, `<font color="…">`, `<br>`, `<br/>`, `<p>`
 ///
 /// Also decodes common HTML entities (`&amp;`, `&lt;`, `&gt;`, `&quot;`,
 /// `&apos;`, `&nbsp;`, `&#NNN;`, `&#xHHH;`).
@@ -17,12 +17,20 @@ enum LightweightHTMLParser {
         let result = NSMutableAttributedString()
         var index = html.startIndex
         var tagStack: [Tag] = []
+        var paragraphRanges: [NSRange] = []
+        var paragraphStart: Int?
 
         while index < html.endIndex {
             if html[index] == "<" {
                 if let (tag, nextIndex) = scanTag(in: html, from: index) {
                     index = nextIndex
-                    handleTag(tag, stack: &tagStack, result: result)
+                    handleTag(
+                        tag,
+                        stack: &tagStack,
+                        result: result,
+                        paragraphStart: &paragraphStart,
+                        paragraphRanges: &paragraphRanges
+                    )
                 } else {
                     let attrs = buildAttributes(from: tagStack, baseFont: baseFont)
                     result.append(NSAttributedString(string: "<", attributes: attrs))
@@ -39,6 +47,7 @@ enum LightweightHTMLParser {
             }
         }
 
+        applyParagraphSpacing(to: result, ranges: paragraphRanges)
         return result
     }
 
@@ -56,16 +65,55 @@ enum LightweightHTMLParser {
     private static func handleTag(
         _ tag: Tag,
         stack: inout [Tag],
-        result: NSMutableAttributedString
+        result: NSMutableAttributedString,
+        paragraphStart: inout Int?,
+        paragraphRanges: inout [NSRange]
     ) {
         if tag.isClosing {
+            if tag.name == "p" {
+                if let start = paragraphStart {
+                    if !result.string.hasSuffix("\n") {
+                        result.append(NSAttributedString(string: "\n"))
+                    }
+                    let length = result.length - start
+                    if length > 0 {
+                        paragraphRanges.append(NSRange(location: start, length: length))
+                    }
+                    paragraphStart = nil
+                }
+            }
             if let idx = stack.lastIndex(where: { $0.name == tag.name }) {
                 stack.remove(at: idx)
             }
         } else if tag.isSelfClosing || tag.name == "br" {
             result.append(NSAttributedString(string: "\n"))
+        } else if tag.name == "p" {
+            if result.length > 0, !result.string.hasSuffix("\n") {
+                result.append(NSAttributedString(string: "\n"))
+            }
+            paragraphStart = result.length
+            stack.append(tag)
         } else {
             stack.append(tag)
+        }
+    }
+
+    private static func applyParagraphSpacing(
+        to result: NSMutableAttributedString,
+        ranges: [NSRange]
+    ) {
+        guard !ranges.isEmpty else { return }
+
+        let style = NSMutableParagraphStyle()
+        style.paragraphSpacing = 8
+
+        for range in ranges {
+            let clamped = NSRange(
+                location: range.location,
+                length: min(range.length, result.length - range.location)
+            )
+            guard clamped.length > 0 else { continue }
+            result.addAttribute(.paragraphStyle, value: style, range: clamped)
         }
     }
 

--- a/Sources/RoktUXHelper/UI/Components/Common/LightweightHTMLParser.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/LightweightHTMLParser.swift
@@ -76,16 +76,12 @@ enum LightweightHTMLParser {
     ) {
         if tag.isClosing {
             if tag.name == paragraphTag {
-                if let start = paragraphStart {
-                    if !result.string.hasSuffix(newline) {
-                        result.append(NSAttributedString(string: newline))
-                    }
-                    let length = result.length - start
-                    if length > 0 {
-                        paragraphRanges.append(NSRange(location: start, length: length))
-                    }
-                    paragraphStart = nil
-                }
+                finalizeOpenParagraph(
+                    result: result,
+                    paragraphStart: &paragraphStart,
+                    stack: &stack,
+                    paragraphRanges: &paragraphRanges
+                )
             }
             if let idx = stack.lastIndex(where: { $0.name == tag.name }) {
                 stack.remove(at: idx)
@@ -95,22 +91,13 @@ enum LightweightHTMLParser {
         } else if tag.name == paragraphTag {
             // If a previous <p> is still open (no explicit </p>), finalize it
             // so its range is preserved instead of overwritten.
-            if let start = paragraphStart {
-                if !result.string.hasSuffix(newline) {
-                    result.append(NSAttributedString(string: newline))
-                }
-                let length = result.length - start
-                if length > 0 {
-                    paragraphRanges.append(NSRange(location: start, length: length))
-                }
-                paragraphStart = nil
-                if let openP = stack.lastIndex(where: { $0.name == paragraphTag }) {
-                    stack.remove(at: openP)
-                }
-            }
-            if result.length > 0, !result.string.hasSuffix(newline) {
-                result.append(NSAttributedString(string: newline))
-            }
+            finalizeOpenParagraph(
+                result: result,
+                paragraphStart: &paragraphStart,
+                stack: &stack,
+                paragraphRanges: &paragraphRanges
+            )
+            ensureTrailingNewline(in: result)
             paragraphStart = result.length
             stack.append(tag)
         } else {
@@ -118,22 +105,49 @@ enum LightweightHTMLParser {
         }
     }
 
+    // MARK: - Finalizers
+
+    private static func finalizeOpenParagraph(
+        result: NSMutableAttributedString,
+        paragraphStart: inout Int?,
+        stack: inout [Tag],
+        paragraphRanges: inout [NSRange]
+    ) {
+        guard let start = paragraphStart else { return }
+        ensureTrailingNewline(in: result)
+        let length = result.length - start
+        if length > 0 {
+            paragraphRanges.append(NSRange(location: start, length: length))
+        }
+        paragraphStart = nil
+        if let openP = stack.lastIndex(where: { $0.name == paragraphTag }) {
+            stack.remove(at: openP)
+        }
+    }
+
+    private static func ensureTrailingNewline(in result: NSMutableAttributedString) {
+        guard result.length > 0, !result.string.hasSuffix(newline) else { return }
+        result.append(NSAttributedString(string: newline))
+    }
+
+    private static let paragraphStyleForP: NSParagraphStyle = {
+        let style = NSMutableParagraphStyle()
+        style.paragraphSpacing = 8
+        return style
+    }()
+
     private static func applyParagraphSpacing(
         to result: NSMutableAttributedString,
         ranges: [NSRange]
     ) {
         guard !ranges.isEmpty else { return }
-
-        let style = NSMutableParagraphStyle()
-        style.paragraphSpacing = 8
-
         for range in ranges {
             let clamped = NSRange(
                 location: range.location,
                 length: min(range.length, result.length - range.location)
             )
             guard clamped.length > 0 else { continue }
-            result.addAttribute(.paragraphStyle, value: style, range: clamped)
+            result.addAttribute(.paragraphStyle, value: paragraphStyleForP, range: clamped)
         }
     }
 

--- a/Sources/RoktUXHelper/UI/Components/Common/LightweightHTMLParser.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/LightweightHTMLParser.swift
@@ -11,6 +11,11 @@ import UIKit
 @available(iOS 15, *)
 enum LightweightHTMLParser {
 
+    // MARK: - Constants
+
+    private static let paragraphTag = "p"
+    private static let newline = "\n"
+
     // MARK: - Public API
 
     static func parse(html: String, baseFont: UIFont?) -> NSMutableAttributedString {
@@ -70,10 +75,10 @@ enum LightweightHTMLParser {
         paragraphRanges: inout [NSRange]
     ) {
         if tag.isClosing {
-            if tag.name == "p" {
+            if tag.name == paragraphTag {
                 if let start = paragraphStart {
-                    if !result.string.hasSuffix("\n") {
-                        result.append(NSAttributedString(string: "\n"))
+                    if !result.string.hasSuffix(newline) {
+                        result.append(NSAttributedString(string: newline))
                     }
                     let length = result.length - start
                     if length > 0 {
@@ -86,25 +91,25 @@ enum LightweightHTMLParser {
                 stack.remove(at: idx)
             }
         } else if tag.isSelfClosing || tag.name == "br" {
-            result.append(NSAttributedString(string: "\n"))
-        } else if tag.name == "p" {
+            result.append(NSAttributedString(string: newline))
+        } else if tag.name == paragraphTag {
             // If a previous <p> is still open (no explicit </p>), finalize it
             // so its range is preserved instead of overwritten.
             if let start = paragraphStart {
-                if !result.string.hasSuffix("\n") {
-                    result.append(NSAttributedString(string: "\n"))
+                if !result.string.hasSuffix(newline) {
+                    result.append(NSAttributedString(string: newline))
                 }
                 let length = result.length - start
                 if length > 0 {
                     paragraphRanges.append(NSRange(location: start, length: length))
                 }
                 paragraphStart = nil
-                if let openP = stack.lastIndex(where: { $0.name == "p" }) {
+                if let openP = stack.lastIndex(where: { $0.name == paragraphTag }) {
                     stack.remove(at: openP)
                 }
             }
-            if result.length > 0, !result.string.hasSuffix("\n") {
-                result.append(NSAttributedString(string: "\n"))
+            if result.length > 0, !result.string.hasSuffix(newline) {
+                result.append(NSAttributedString(string: newline))
             }
             paragraphStart = result.length
             stack.append(tag)

--- a/Tests/RoktUXHelperTests/UI/Components/Common/TestLightweightHTMLParser.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/Common/TestLightweightHTMLParser.swift
@@ -202,6 +202,20 @@ final class TestLightweightHTMLParser: XCTestCase {
         XCTAssertEqual(result.string, "No close tag")
     }
 
+    func test_p_tag_implicit_close_preserves_previous_paragraph() {
+        // <p>First<p>Second</p> — second <p> implicitly closes the first.
+        // Both paragraphs must receive a paragraph style with spacing.
+        let result = LightweightHTMLParser.parse(html: "<p>First<p>Second</p>", baseFont: baseFont)
+        XCTAssertEqual(result.string, "First\nSecond\n")
+
+        let firstStyle = result.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        XCTAssertNotNil(firstStyle, "First paragraph must keep its paragraph style after implicit close")
+        XCTAssertGreaterThan(firstStyle?.paragraphSpacing ?? 0, 0)
+
+        let secondStyle = result.attribute(.paragraphStyle, at: 6, effectiveRange: nil) as? NSParagraphStyle
+        XCTAssertNotNil(secondStyle)
+    }
+
     func test_p_tag_paragraph_style_does_not_apply_to_text_outside() {
         let result = LightweightHTMLParser.parse(html: "Before <p>Inside</p> After", baseFont: baseFont)
         // Parsed string is "Before \nInside\n After"

--- a/Tests/RoktUXHelperTests/UI/Components/Common/TestLightweightHTMLParser.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/Common/TestLightweightHTMLParser.swift
@@ -160,6 +160,65 @@ final class TestLightweightHTMLParser: XCTestCase {
         XCTAssertEqual(result.string, "Line1\nLine2")
     }
 
+    // MARK: - Paragraph tag
+
+    func test_p_tag_single_paragraph() {
+        let result = LightweightHTMLParser.parse(html: "<p>Hello</p>", baseFont: baseFont)
+        XCTAssertEqual(result.string, "Hello\n")
+
+        let paragraphStyle = result.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        XCTAssertNotNil(paragraphStyle)
+        XCTAssertGreaterThan(paragraphStyle?.paragraphSpacing ?? 0, 0)
+    }
+
+    func test_p_tag_two_paragraphs_separated_by_newline() {
+        let result = LightweightHTMLParser.parse(html: "<p>First</p><p>Second</p>", baseFont: baseFont)
+        XCTAssertEqual(result.string, "First\nSecond\n")
+
+        let firstStyle = result.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        let secondStyle = result.attribute(.paragraphStyle, at: 6, effectiveRange: nil) as? NSParagraphStyle
+        XCTAssertNotNil(firstStyle)
+        XCTAssertNotNil(secondStyle)
+    }
+
+    func test_p_tag_after_inline_text_adds_break() {
+        let result = LightweightHTMLParser.parse(html: "Intro<p>Body</p>", baseFont: baseFont)
+        XCTAssertEqual(result.string, "Intro\nBody\n")
+    }
+
+    func test_p_tag_with_inline_formatting_inside() {
+        let result = LightweightHTMLParser.parse(html: "<p>Hello <b>bold</b> world</p>", baseFont: baseFont)
+        XCTAssertEqual(result.string, "Hello bold world\n")
+
+        let plainFont = result.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
+        XCTAssertEqual(plainFont?.fontDescriptor.symbolicTraits.contains(.traitBold), false)
+
+        let boldFont = result.attribute(.font, at: 6, effectiveRange: nil) as? UIFont
+        XCTAssertEqual(boldFont?.fontDescriptor.symbolicTraits.contains(.traitBold), true)
+    }
+
+    func test_p_tag_unclosed_still_renders() {
+        let result = LightweightHTMLParser.parse(html: "<p>No close tag", baseFont: baseFont)
+        XCTAssertEqual(result.string, "No close tag")
+    }
+
+    func test_p_tag_paragraph_style_does_not_apply_to_text_outside() {
+        let result = LightweightHTMLParser.parse(html: "Before <p>Inside</p> After", baseFont: baseFont)
+        // Parsed string is "Before \nInside\n After"
+        XCTAssertEqual(result.string, "Before \nInside\n After")
+
+        let outsideBefore = result.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        XCTAssertNil(outsideBefore)
+
+        // Index 8 is the first char of "Inside" — inside the <p> range.
+        let insideStyle = result.attribute(.paragraphStyle, at: 8, effectiveRange: nil) as? NSParagraphStyle
+        XCTAssertNotNil(insideStyle)
+
+        // Index 16 is the space before "After" — outside the <p> range.
+        let outsideAfter = result.attribute(.paragraphStyle, at: 16, effectiveRange: nil) as? NSParagraphStyle
+        XCTAssertNil(outsideAfter)
+    }
+
     // MARK: - Nested tags (DCUI fixture)
 
     func test_dcui_fixture_strong_em_u_s() {


### PR DESCRIPTION
## Background

- The DCUI rich text parser supported inline tags (`<b>`, `<i>`, `<a>`, `<font>`, `<br>`, etc.) but treated `<p>` as unknown, so paragraph-formatted server content rendered as one continuous run.

## What Has Changed

- `LightweightHTMLParser` now opens/closes `<p>` as a block: emits a newline at the boundaries and applies 8pt `NSParagraphStyle.paragraphSpacing` to each paragraph's range.
- Inline formatting inside `<p>` continues to work — the tag stack is untouched.

## Screenshots/Video

<img width="200" src="https://github.com/user-attachments/assets/78751207-6a0c-4722-9ee9-2fb1b29d5e59" />
<img width="200" src="https://github.com/user-attachments/assets/f5405255-4928-4ddd-8439-eb5472b7165a" />
<img width="200" src="https://github.com/user-attachments/assets/bfc1859f-adef-48ee-ad5f-003eb2629e5a" />


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation. (CHANGELOG)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- 6 new unit tests in `TestLightweightHTMLParser` (single/multi paragraph, inline mixing, unclosed, no-bleed guard). Existing `TestRichTextComponent` snapshots unchanged.
- Manual: rendered labelled multi-paragraph disclaimers in the example app (iPhone 16 / iOS 18.6 simulator) via the SwiftUI path. Sample experience.json edits used to validate are not included in this PR.