### PR TITLE
docs: add AGENTS.md and clarify CHANGELOG is auto-generated

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# Agent Guide
+
+Instructions for AI coding agents (Claude Code, Codex, etc.) working in this repository. Human contributors should still read [README.md](./README.md), [TESTING.md](./TESTING.md), and [RELEASING.md](./RELEASING.md).
+
+## Project overview
+
+`RoktUXHelper` is a Swift package that renders Rokt experiences inside partner iOS apps (SwiftUI + UIKit). It is distributed via SPM and CocoaPods. The library targets **iOS 15.0+**. See [README.md](./README.md) for the architecture diagram and a description of the core components (`RoktUX`, `LayoutTransformer`, `CreativeSyntaxMapper`, `LayoutSchemaViewModel`, `LayoutState`).
+
+## Repository layout
+
+- `Sources/RoktUXHelper/` — library source.
+- `Tests/RoktUXHelperTests/` — unit and snapshot tests. Snapshot references live alongside the tests in `__Snapshots__/`.
+- `Example/` — example host app demonstrating SwiftUI and UIKit integration.
+- `.github/workflows/` — CI (pull request checks) and release automation.
+- `tools/` — local tooling and scripts.
+
+## Working on a feature branch
+
+1. **Branch naming and commits** — use conventional commit style for both branch names and PR titles (e.g. `feat(richtext): support <p> tag`, `fix(catalog-device-pay): prevent duplicate taps`). The release-draft workflow parses PR titles to generate the changelog, so accurate type/scope matters.
+2. **Tests** — open `Package.swift` in Xcode and run `⌘U`, or run tests via `swift test` / `xcodebuild test`. Add tests for new behaviour. See [TESTING.md](./TESTING.md) for the snapshot workflow.
+3. **Schema bumps** — if you change the `DcuiSchema` dependency, also bump `Constants.layoutSchemaVersion` in `Sources/RoktUXHelper/Data/Model/RoktIntegrationInfoDetails.swift` so `SchemaVersionConsistencyTests` passes. README has the full steps.
+4. **Public API changes** — update [MIGRATING.md](./MIGRATING.md) when you rename or remove public symbols.
+5. **PR template** — fill in the sections in `.github/pull_request_template.md` (background, what changed, screenshots if UI, checklist).
+
+## CHANGELOG.md is auto-generated — do not edit it
+
+`CHANGELOG.md` is produced automatically by the [`Release – Draft`](https://github.com/ROKT/rokt-ux-helper-ios/actions/workflows/release-draft.yml) GitHub Actions workflow, which calls `ROKT/rokt-workflows/actions/generate-changelog` and builds entries from the git history (conventional commit PR titles).
+
+**Do not modify `CHANGELOG.md` on feature branches.** Any manual edits will be overwritten when the next release PR is drafted. If you want your change to appear in the release notes:
+
+- Write a clear, conventional commit-style **PR title** (e.g. `feat(richtext): support <ul>, <ol>, <li>`).
+- That title becomes the changelog entry at release time — no further action needed.
+
+See [RELEASING.md](./RELEASING.md) for the full release flow.
+
+## Files you generally should not touch
+
+- `CHANGELOG.md` — auto-generated (see above).
+- `VERSION` — bumped by the `Release – Draft` workflow.
+- `RoktUXHelper.podspec` version field — also bumped by the release workflow.
+- `Package.resolved` — only changes when dependency versions change.
+- `Tests/.../__Snapshots__/*.png` — only regenerate intentionally; see [TESTING.md](./TESTING.md).
+
+## Verification before opening a PR
+
+- Build and run the unit + snapshot tests locally.
+- If you changed UI rendering, inspect snapshot diffs (delete the relevant `__Snapshots__/*.png`, re-run to re-record, eyeball the output, commit the new PNGs).
+- Confirm the example app in `Example/` still builds against your changes.
+
+## Releases
+
+Releases are driven entirely by the `Release – Draft` → merge → `Release – Publish` workflow chain. Agents should not create release commits, edit `CHANGELOG.md`, or bump `VERSION` directly. See [RELEASING.md](./RELEASING.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,10 +17,20 @@ Instructions for AI coding agents (Claude Code, Codex, etc.) working in this rep
 ## Working on a feature branch
 
 1. **Branch naming and commits** — use conventional commit style for both branch names and PR titles (e.g. `feat(richtext): support <p> tag`, `fix(catalog-device-pay): prevent duplicate taps`). The release-draft workflow parses PR titles to generate the changelog, so accurate type/scope matters.
-2. **Tests** — open `Package.swift` in Xcode and run `⌘U`, or run tests via `swift test` / `xcodebuild test`. Add tests for new behaviour. See [TESTING.md](./TESTING.md) for the snapshot workflow.
-3. **Schema bumps** — if you change the `DcuiSchema` dependency, also bump `Constants.layoutSchemaVersion` in `Sources/RoktUXHelper/Data/Model/RoktIntegrationInfoDetails.swift` so `SchemaVersionConsistencyTests` passes. README has the full steps.
-4. **Public API changes** — update [MIGRATING.md](./MIGRATING.md) when you rename or remove public symbols.
-5. **PR template** — fill in the sections in `.github/pull_request_template.md` (background, what changed, screenshots if UI, checklist).
+2. **Tests** — open `Package.swift` in Xcode and run `⌘U`, or from the CLI:
+
+   ```bash
+   set -o pipefail && xcodebuild -skipPackagePluginValidation -scheme RoktUXHelper \
+     -destination 'platform=iOS Simulator,name=iPhone 16' \
+     -derivedDataPath DerivedData test | xcbeautify
+   ```
+
+   Do **not** use `swift test` — the library imports `UIKit`, which is unavailable in the host SPM build and the command will fail. To scope to a single suite, append `-only-testing:RoktUXHelperTests/TestRowComponent`. Add tests for new behaviour.
+
+3. **Snapshot tests** — visual regressions are caught by `swift-snapshot-testing`; reference PNGs live next to each test in `__Snapshots__/`. To intentionally update a snapshot, either delete the offending PNG and re-run the test (it re-records on first run), or set `isRecording = true` in the test's `setUp()`, re-run, then **remove the flag before committing** (never commit `isRecording = true`). On CI failure, download the `snapshot-failures` artifact for actual-vs-expected diffs. See [TESTING.md](./TESTING.md) for the full workflow and coverage matrix.
+4. **Schema bumps** — if you change the `DcuiSchema` dependency, also bump `Constants.layoutSchemaVersion` in `Sources/RoktUXHelper/Data/Model/RoktIntegrationInfoDetails.swift` so `SchemaVersionConsistencyTests` passes. README has the full steps.
+5. **Public API changes** — update [MIGRATING.md](./MIGRATING.md) when you rename or remove public symbols.
+6. **PR template** — fill in the sections in `.github/pull_request_template.md` (background, what changed, screenshots if UI, checklist).
 
 ## CHANGELOG.md is auto-generated — do not edit it
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+<!-- markdownlint-disable MD041 -->
+
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -176,4 +176,4 @@ This workflow will:
 - Auto-generate changelog from git history (conventional commit PR titles)
 
 > [!NOTE]
-> The "Release – Draft" workflow maintains the `VERSION` file automatically. No manual changes to the `VERSION` file are needed.
+> The "Release – Draft" workflow maintains the `VERSION` file and `CHANGELOG.md` automatically. **Do not edit `CHANGELOG.md` in feature branches** — entries are generated from conventional commit PR titles at release time and any manual edits will be overwritten. See [RELEASING.md](./RELEASING.md) for details.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,3 +5,7 @@ To create a new release you will first create a pull request using the Github Ac
 This will oepn a pull request where you need to validate that the correct files have been updated. These should be documented in the body of the pull request, your job is to validate these have updated correctly and that the release notes look correct for client consumption.
 
 If everything checks out, and tests pass you can merge this pull request which will automatically trigger the [Release – Publish](https://github.com/ROKT/rokt-ux-helper-ios/actions/workflows/release-publish.yml) workflow.
+
+## CHANGELOG.md
+
+`CHANGELOG.md` is generated automatically by the `Release – Draft` workflow from the git history (conventional commit PR titles). **Do not edit `CHANGELOG.md` in feature branches** — any manual entries will be overwritten when the release PR is drafted. Write clear, conventional commit-style PR titles (e.g. `feat(richtext): support <p> tag`) and the changelog entry will be produced for you at release time.


### PR DESCRIPTION
## Background

- The repo had no agent-facing guide, and `CHANGELOG.md` was being edited manually in feature branches even though the `Release – Draft` workflow regenerates it from conventional commit PR titles.

## What Has Changed

- Added `AGENTS.md` with project-specific guidance for AI coding agents (layout, branch/test workflow, files not to touch).
- Added `CLAUDE.md` that `@`-references `AGENTS.md` so Claude Code picks up the same guidance without duplication.
- Updated `RELEASING.md` and `README.md` to call out that `CHANGELOG.md` is auto-generated and should not be edited on feature branches.

## Screenshots/Video

- N/A — docs only.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works. _(docs-only)_
- [x] I have tested this locally.

## Additional Notes

- No source or test changes; this is documentation only.