### PR TITLE
fix: Ignore invalid alt text for images

### DIFF
--- a/Sources/RoktUXHelper/Data/Model/Constants.swift
+++ b/Sources/RoktUXHelper/Data/Model/Constants.swift
@@ -72,6 +72,21 @@ let kPageAnnouncement = "Page %d of %d"
 let kOneByOneAnnouncement = "Offer %d of %d"
 let kProgressIndicatorAnnouncement = "%d of %d"
 
+/// Generic `creative.images` alt strings from the backend that are not meaningful for VoiceOver.
+let kNonDescriptiveCreativeImageAltTexts: Set<String> = [
+    "image",
+    "img",
+    "photo",
+    "picture",
+    "1.91:1 image",
+    "transparent 1.91:1 image",
+    "logo image",
+    "1.91:1 logo image",
+    "transparent 1.91:1 logo image",
+    "transparent logo image",
+    "transparent image"
+]
+
 // MARK: Cart Item Instant purchase constants
 
 let kCartItemId = "cartItemId"

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/CreativeImage+Accessibility.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/CreativeImage+Accessibility.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension CreativeImage {
+    /// Alt text to expose to VoiceOver, or `nil` when `alt` is empty or a non-descriptive backend default.
+    var accessibilityAltText: String? {
+        guard let trimmed = alt?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty,
+              !kNonDescriptiveCreativeImageAltTexts.contains(trimmed.lowercased()) else {
+            return nil
+        }
+        return trimmed
+    }
+}

--- a/Sources/RoktUXHelper/UI/Components/DataImageCarouselComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/DataImageCarouselComponent.swift
@@ -236,7 +236,7 @@ struct DataImageCarouselComponent: View {
         AsyncImageView(
             imageUrl: ThemeUrl(light: image.light ?? "", dark: image.dark ?? ""),
             scale: .fit,
-            alt: image.alt,
+            alt: image.accessibilityAltText,
             imageLoader: model.imageLoader,
             isImageValid: .constant(true)
         )

--- a/Sources/RoktUXHelper/UI/Components/DataImageComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/DataImageComponent.swift
@@ -84,7 +84,7 @@ struct DataImageViewComponent: View {
         AsyncImageView(imageUrl: ThemeUrl(light: model.image?.light ?? "",
                                           dark: model.image?.dark ?? ""),
                        scale: .fit,
-                       alt: model.image?.alt,
+                       alt: model.image?.accessibilityAltText,
                        imageLoader: model.imageLoader,
                        isImageValid: $isImageValid)
     }

--- a/Sources/RoktUXHelper/UI/Components/Distribution/OneByOneDistributionComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/Distribution/OneByOneDistributionComponent.swift
@@ -33,7 +33,6 @@ struct OneByOneDistributionComponent: View {
     @State private var toggleTransition = false
     @State var customStateMap: RoktUXCustomStateMap?
 
-    @AccessibilityFocusState private var shouldFocusAccessibility: Bool
     var accessibilityAnnouncement: String {
         String(format: kOneByOneAnnouncement,
                currentOffer + 1,
@@ -116,13 +115,13 @@ struct OneByOneDistributionComponent: View {
                     registerActions()
                     toggleTransition = true
                     model.sendImpressionEvents(currentOffer: currentOffer)
-                    shouldFocusAccessibility = true
+                    UIAccessibility.post(notification: .announcement,
+                                         argument: accessibilityAnnouncement)
                 }
                 .onChange(of: currentOffer) { newValue in
                     model.layoutState?.capturePluginViewState(offerIndex: newValue, dismiss: false)
                     transitionIn()
                     model.sendImpressionEvents(currentOffer: newValue)
-                    shouldFocusAccessibility = true
                     UIAccessibility.post(notification: .announcement,
                                          argument: accessibilityAnnouncement)
                 }
@@ -144,9 +143,6 @@ struct OneByOneDistributionComponent: View {
                     model.sendCreativeViewedEvent(currentOffer: currentOffer)
                 }
             }
-            .accessibilityElement(children: .contain)
-            .accessibilityFocused($shouldFocusAccessibility)
-            .accessibilityLabel(accessibilityAnnouncement)
         }
     }
 

--- a/Tests/RoktUXHelperTests/Data/Model/TestCreativeImageAccessibility.swift
+++ b/Tests/RoktUXHelperTests/Data/Model/TestCreativeImageAccessibility.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import RoktUXHelper
+
+final class TestCreativeImageAccessibility: XCTestCase {
+
+    func test_accessibilityAltText_returnsNil_forEmptyOrGenericBackendValues() {
+        let genericAlts = [
+            "image",
+            "Image",
+            " IMAGE ",
+            "img",
+            "photo",
+            "picture",
+            "1.91:1 Image",
+            "Transparent 1.91:1 Image",
+            "Logo Image",
+            "1.91:1 Logo Image",
+            "Transparent 1.91:1 Logo Image",
+            "Transparent Logo Image",
+            "Transparent Image",
+            "",
+            "   ",
+            nil
+        ]
+        for alt in genericAlts {
+            let image = CreativeImage(light: "https://example.com/a.png", dark: nil, alt: alt, title: "image")
+            XCTAssertNil(image.accessibilityAltText, "Expected nil for alt: \(String(describing: alt))")
+        }
+    }
+
+    func test_accessibilityAltText_returnsTrimmedValue_forDescriptiveAlt() {
+        let image = CreativeImage(
+            light: "https://example.com/a.png",
+            dark: nil,
+            alt: "  Acme rewards logo  ",
+            title: nil
+        )
+        XCTAssertEqual(image.accessibilityAltText, "Acme rewards logo")
+    }
+}

--- a/Tests/RoktUXHelperTests/UI/Components/Distribution/TestOneByOneDistributionComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/Distribution/TestOneByOneDistributionComponent.swift
@@ -40,7 +40,8 @@ final class TestOneByOneDistributionComponent: XCTestCase {
         let padding = try oneByOne.padding()
         XCTAssertEqual(padding, EdgeInsets(top: 3.0, leading: 6.0, bottom: 5.0, trailing: 4.0))
 
-        XCTAssertEqual(try group.accessibilityLabel().string(), "Offer 1 of 1")
+        XCTAssertEqual(oneByOneComponent.accessibilityAnnouncement, "Offer 1 of 1")
+        XCTAssertThrowsError(try group.accessibilityLabel())
 
         oneByOneComponent.goToNextOffer()
         XCTAssertTrue(closeActionCalled)

--- a/Tests/RoktUXHelperTests/UI/Components/TestDataImageComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestDataImageComponent.swift
@@ -42,6 +42,30 @@ final class TestDataImageComponent: XCTestCase {
         XCTAssertNil(try? image.find(AsyncImageView.self))
     }
 
+    func test_data_image_withGenericBackendAlt_isHiddenFromAccessibility() throws {
+        let imageURL = "https://docs.rokt.com/assets/images/embedded-placement-1-5ab04a718fe7dda94ac24aa7b89aac92.png"
+        let slot = get_slot(image: imageURL, alt: "image")
+        let transformer = LayoutTransformer(layoutPlugin: get_mock_layout_plugin(slots: [slot]))
+        let model = try transformer.getDataImage(
+            ModelTestData.DataImageData.dataImage(),
+            context: .inner(.generic(slot.offer!))
+        )
+        let view = TestPlaceHolder(layout: LayoutSchemaViewModel.dataImage(model))
+
+        let asyncImage = try view.inspect().view(TestPlaceHolder.self)
+            .view(EmbeddedComponent.self)
+            .vStack()[0]
+            .view(LayoutSchemaComponent.self)
+            .view(DataImageViewComponent.self)
+            .actualView()
+            .inspect()
+            .find(AsyncImageView.self)
+            .asyncImage()
+
+        XCTAssertEqual(try asyncImage.accessibilityLabel().string(), "")
+        XCTAssertEqual(try asyncImage.accessibilityHidden(), true)
+    }
+
     func test_data_image_with_fallback() throws {
         let view = TestPlaceHolder(layout: LayoutSchemaViewModel.dataImage(try get_model(isValid: true, isFallback: true)))
 
@@ -96,7 +120,7 @@ final class TestDataImageComponent: XCTestCase {
         )
     }
 
-    func get_slot(image: String) -> SlotModel {
+    func get_slot(image: String, alt: String? = "") -> SlotModel {
         return SlotModel(instanceGuid: "",
                          offer: OfferModel(campaignId: "", creative:
                                             CreativeModel(referralCreativeId: "",
@@ -105,7 +129,8 @@ final class TestDataImageComponent: XCTestCase {
                                                           images: [
                                                               "creativeImage": CreativeImage(
                                                                   light: image,
-                                                                  dark: nil, alt: "",
+                                                                  dark: nil,
+                                                                  alt: alt,
                                                                   title: nil
                                                               )
                                                           ],


### PR DESCRIPTION
## Background

- Creative payloads often ship placeholder alt values (for example "Image", aspect-ratio labels, or “transparent” variants) that are not meaningful for VoiceOver and can sound like noise or duplicate the “image” role.
- The one-by-one offer container used .accessibilityElement(children: .contain) with an “Offer X of Y” label, so VoiceOver treated the whole card as a single group before you could reach headings, body copy, and buttons—hurting linear navigation even though children were still reachable via direct touch.

## What Has Changed

- Introduced CreativeImage.accessibilityAltText and a shared denylist kNonDescriptiveCreativeImageAltTexts (including generic terms and the Example experience.json placeholder alts). When alt matches (case-insensitive, trimmed), it is treated as empty for accessibility so DataImage / DataImageCarousel stay visually unchanged but are hidden from the accessibility tree like empty alt.
- Wired DataImageViewComponent and DataImageCarouselComponent to pass accessibilityAltText into AsyncImageView instead of raw alt.
- Adjusted OneByOneDistributionComponent by removing the grouped accessibility wrapper (.contain + label + focus on the offer wrapper). Offer index is still communicated via UIAccessibility.post(.announcement, …) on load and when the current offer changes, so users hear “Offer 2 of 3” without an extra group stop in the swipe order.
- Added/updated tests: TestCreativeImageAccessibility, TestDataImageComponent (generic backend alt), and TestOneByOneDistributionComponent (announcement string preserved; wrapper no longer exposes a group label).

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes [ticket](https://go/j/[ticket-number])
