### PR TITLE
docs(agents): add public-repo confidentiality guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,17 @@ Instructions for AI coding agents (Claude Code, Codex, etc.) working in this rep
 
 `RoktUXHelper` is a Swift package that renders Rokt experiences inside partner iOS apps (SwiftUI + UIKit). It is distributed via SPM and CocoaPods. The library targets **iOS 15.0+**. See [README.md](./README.md) for the architecture diagram and a description of the core components (`RoktUX`, `LayoutTransformer`, `CreativeSyntaxMapper`, `LayoutSchemaViewModel`, `LayoutState`).
 
+## Confidentiality — this is a public repository
+
+This repository is public, and everything committed to it is permanent and world-readable: code, comments, commit messages, branch names, PR titles/descriptions (PR titles also become public release-note entries), and test names. Never include internal-only information:
+
+- Partner, client, customer, or advertiser names or identifiers — or any detail that could identify one (account/tenant/campaign IDs, deal terms, integration specifics). Keep examples generic and anonymized.
+- Internal service/system names, internal contract/class names, or their field layouts.
+- Backend or infrastructure implementation details: serializer libraries and versions, server-side validation/deserialization behavior, datastore/infra specifics, or anything describing how a payload is checked server-side.
+- Links to private repos, internal tickets/PRs, or internal dashboards.
+
+Describe client-side behavior only — what the SDK sends and receives and why, in partner-facing terms. When a change is driven by a server contract, refer to it generically (e.g. "to match the server contract") without naming internal types, versions, or server behavior. Keep internal rationale in non-public channels.
+
 ## Repository layout
 
 - `Sources/RoktUXHelper/` — library source.


### PR DESCRIPTION
## Background

- AGENTS.md didn't state this repository is public or what must be kept out of publicly visible text. This adds explicit confidentiality guidance so contributors/agents don't leak confidential or internal information into permanent repo history.

## What Has Changed

- Added a "Confidentiality — this is a public repository" section to AGENTS.md covering partner/client names, internal system/backend details, and private links.

## Screenshots/Video

- N/A — documentation-only change.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes

- Documentation-only; markdown lint clean. No tests apply.