### PR TITLE
feat(image): support image scale styles

### DIFF
--- a/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "3a0630ca74ba1fae726a1fa82e0e4b8ac3ab913595800bd5b21db72a879bfc0f",
+  "originHash" : "76dfd71c4977dba3d21b217714aa06d90676a280846f4cb16698ae1acf6c4e31",
   "pins" : [
     {
       "identity" : "dcui-swift-schema",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ROKT/dcui-swift-schema.git",
       "state" : {
-        "revision" : "94e2913c91af7c9c49da0e86424f1e4d260a1b6c",
-        "version" : "2.7.0"
+        "revision" : "4f7a71eca08710d8f3a5d624b7fffe3bf1a265c6",
+        "version" : "2.8.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ROKT/dcui-swift-schema.git",
       "state" : {
-        "revision" : "94e2913c91af7c9c49da0e86424f1e4d260a1b6c",
-        "version" : "2.7.0"
+        "revision" : "4f7a71eca08710d8f3a5d624b7fffe3bf1a265c6",
+        "version" : "2.8.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/ROKT/dcui-swift-schema.git", exact: "2.7.0"),
+        .package(url: "https://github.com/ROKT/dcui-swift-schema.git", exact: "2.8.0"),
         .package(url: "https://github.com/nalexn/ViewInspector.git", exact: "0.10.3"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", exact: "1.19.2")
     ],

--- a/RoktUXHelper.podspec
+++ b/RoktUXHelper.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.resource_bundles = { 'RoktUXHelper' => ['Sources/RoktUXHelper/PrivacyInfo.xcprivacy'] }
   s.frameworks       = 'Foundation', 'UIKit', 'SwiftUI', 'Combine'
 
-  s.dependency 'DcuiSchema', '~> 2.6'
+  s.dependency 'DcuiSchema', '~> 2.8'
 end

--- a/RoktUXHelper.podspec
+++ b/RoktUXHelper.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.resource_bundles = { 'RoktUXHelper' => ['Sources/RoktUXHelper/PrivacyInfo.xcprivacy'] }
   s.frameworks       = 'Foundation', 'UIKit', 'SwiftUI', 'Combine'
 
-  s.dependency 'DcuiSchema', '~> 2.8'
+  s.dependency 'DcuiSchema', '2.8.0'
 end

--- a/Sources/RoktUXHelper/Data/Model/RoktIntegrationInfoDetails.swift
+++ b/Sources/RoktUXHelper/Data/Model/RoktIntegrationInfoDetails.swift
@@ -4,7 +4,7 @@ import UIKit
 private enum Constants {
     static let framework: String = "Swift"
     static let kBundleShort: String = "CFBundleShortVersionString"
-    static let layoutSchemaVersion: String = "2.7.0"
+    static let layoutSchemaVersion: String = "2.8.0"
     static let name: String = "UX Helper iOS"
     static let platform: String = "iOS"
     static let version: String = "0.1.0"

--- a/Sources/RoktUXHelper/Data/Model/Styles/BaseStyles.swift
+++ b/Sources/RoktUXHelper/Data/Model/Styles/BaseStyles.swift
@@ -7,6 +7,7 @@ struct BaseStyles: Codable, Hashable {
     let container: ContainerStylingProperties?
     let dimension: DimensionStylingProperties?
     let flexChild: FlexChildStylingProperties?
+    let image: ImageStylingProperties?
     let spacing: SpacingStylingProperties?
     let text: TextStylingProperties?
 
@@ -16,6 +17,7 @@ struct BaseStyles: Codable, Hashable {
         container: ContainerStylingProperties? = nil,
         dimension: DimensionStylingProperties? = nil,
         flexChild: FlexChildStylingProperties? = nil,
+        image: ImageStylingProperties? = nil,
         spacing: SpacingStylingProperties? = nil,
         text: TextStylingProperties? = nil
     ) {
@@ -24,6 +26,7 @@ struct BaseStyles: Codable, Hashable {
         self.container = container
         self.dimension = dimension
         self.flexChild = flexChild
+        self.image = image
         self.spacing = spacing
         self.text = text
     }
@@ -40,6 +43,7 @@ extension BaseStyles {
             container: try? StyleTransformer.updatedContainer(style?.container, newStyle: diff.container),
             dimension: StyleTransformer.updatedDimension(style?.dimension, newStyle: diff.dimension),
             flexChild: StyleTransformer.updatedFlexChild(style?.flexChild, newStyle: diff.flexChild),
+            image: StyleTransformer.updatedImage(style?.image, newStyle: diff.image),
             spacing: StyleTransformer.updatedSpacing(style?.spacing, newStyle: diff.spacing),
             text: try? StyleTransformer.updatedText(style?.text, newStyle: diff.text)
         )
@@ -54,6 +58,7 @@ extension BaseStyles {
             border: style.border,
             dimension: style.dimension,
             flexChild: style.flexChild,
+            image: style.image,
             spacing: style.spacing
         )
     }
@@ -121,6 +126,7 @@ extension CatalogImageGalleryStyles {
             background: background,
             border: border,
             dimension: dimension,
+            image: nil,
             flexChild: flexChild,
             spacing: spacing
         )

--- a/Sources/RoktUXHelper/Services/LayoutTransformer/StyleTransformer.swift
+++ b/Sources/RoktUXHelper/Services/LayoutTransformer/StyleTransformer.swift
@@ -445,6 +445,8 @@ struct StyleTransformer {
                                                            newStyle: newStyle?.border),
                                  dimension: updatedDimension(defaultStyle?.dimension,
                                                              newStyle: newStyle?.dimension),
+                                 image: updatedImage(defaultStyle?.image,
+                                                     newStyle: newStyle?.image),
                                  flexChild: updatedFlexChild(defaultStyle?.flexChild,
                                                              newStyle: newStyle?.flexChild),
                                  spacing: updatedSpacing(defaultStyle?.spacing,
@@ -459,6 +461,8 @@ struct StyleTransformer {
                                                          newStyle: newStyle?.border),
                                dimension: updatedDimension(defaultStyle?.dimension,
                                                            newStyle: newStyle?.dimension),
+                               image: updatedImage(defaultStyle?.image,
+                                                   newStyle: newStyle?.image),
                                flexChild: updatedFlexChild(defaultStyle?.flexChild,
                                                            newStyle: newStyle?.flexChild),
                                spacing: updatedSpacing(defaultStyle?.spacing,
@@ -721,6 +725,12 @@ struct StyleTransformer {
         return SpacingStylingProperties(padding: newStyle?.padding ?? defaultStyle?.padding,
                                         margin: newStyle?.margin ?? defaultStyle?.margin,
                                         offset: newStyle?.offset ?? defaultStyle?.offset)
+    }
+
+    static func updatedImage(_ defaultStyle: ImageStylingProperties?,
+                             newStyle: ImageStylingProperties?) -> ImageStylingProperties? {
+        guard defaultStyle != nil || newStyle != nil else { return nil }
+        return ImageStylingProperties(scale: newStyle?.scale ?? defaultStyle?.scale)
     }
 
     static func updatedBorder(_ defaultStyle: BorderStylingProperties?,

--- a/Sources/RoktUXHelper/UI/Components/Common/Image/AsyncImageView.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/Image/AsyncImageView.swift
@@ -7,7 +7,7 @@ struct AsyncImageView: View {
     @SwiftUI.Environment(\.colorScheme) var colorScheme
 
     let imageUrl: ThemeUrl?
-    let scale: BackgroundImageScale?
+    let scale: ImageRenderScale?
     var alt: String?
     var imageLoader: RoktUXImageLoader?
 

--- a/Sources/RoktUXHelper/UI/Components/Common/Image/Base64Image.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/Image/Base64Image.swift
@@ -4,7 +4,7 @@ import DcuiSchema
 
 @available(iOS 15, *)
 struct Base64Image: View {
-    let scale: BackgroundImageScale?
+    let scale: ImageRenderScale?
     let altString: String
     let base64Image: UIImage
 

--- a/Sources/RoktUXHelper/UI/Components/Common/Image/ExternalAsyncImage.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/Image/ExternalAsyncImage.swift
@@ -5,11 +5,11 @@ import DcuiSchema
 @available(iOS 15.0, *)
 struct ExternalAsyncImage: View {
     @ObservedObject var imageDownloader: ImageDownloader
-    let scale: BackgroundImageScale?
+    let scale: ImageRenderScale?
     let altString: String
     @State private var image: UIImage?
 
-    init(urlString: String, scale: BackgroundImageScale?, altString: String, loader: RoktUXImageLoader) {
+    init(urlString: String, scale: ImageRenderScale?, altString: String, loader: RoktUXImageLoader) {
         self.imageDownloader = ImageDownloader(urlString: urlString, loader: loader)
         self.scale = scale
         self.altString = altString

--- a/Sources/RoktUXHelper/UI/Components/Common/Image/Image+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/Image/Image+Extension.swift
@@ -1,16 +1,22 @@
 import SwiftUI
-import DcuiSchema
 
 @available(iOS 15.0, *)
 extension Image {
-    func scaleIfNeeded(scale: BackgroundImageScale?) -> some View {
-        switch scale {
+    func scaleIfNeeded(scale: ImageRenderScale?) -> some View {
+        let imageScale = scale ?? .fit
+
+        switch imageScale {
         case .crop:
             return AnyView(self) // No resizing or scaling
-        default:
+        case .fill:
             return AnyView(self
                 .resizable()
-                .aspectRatio(contentMode: scale?.getScale() ?? .fit))
+                .aspectRatio(contentMode: imageScale.contentMode)
+                .clipped())
+        case .fit:
+            return AnyView(self
+                .resizable()
+                .aspectRatio(contentMode: imageScale.contentMode))
         }
     }
 }

--- a/Sources/RoktUXHelper/UI/Components/Common/Image/ImageScale.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/Image/ImageScale.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+import DcuiSchema
+
+@available(iOS 15.0, *)
+enum ImageRenderScale: Equatable {
+    case crop
+    case fit
+    case fill
+
+    var contentMode: ContentMode {
+        switch self {
+        case .fill:
+            return .fill
+        case .crop, .fit:
+            return .fit
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+extension BackgroundImageScale {
+    var asImageRenderScale: ImageRenderScale {
+        switch self {
+        case .crop:
+            return .crop
+        case .fill:
+            return .fill
+        case .fit:
+            return .fit
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+extension DcuiSchema.ImageScale {
+    var asImageRenderScale: ImageRenderScale {
+        switch self {
+        case .crop:
+            return .crop
+        case .fill:
+            return .fill
+        case .fit:
+            return .fit
+        }
+    }
+}

--- a/Sources/RoktUXHelper/UI/Components/Common/View+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/View+Extension.swift
@@ -77,6 +77,14 @@ extension View {
             self
         }
     }
+
+    @ViewBuilder func clipToBounds(_ shouldClip: Bool, borderRadius: Float?) -> some View {
+        if shouldClip {
+            clipShape(RoundedRectangle(cornerRadius: CGFloat(borderRadius ?? 0)))
+        } else {
+            self
+        }
+    }
 }
 
 private struct SizePreferenceKey: PreferenceKey {

--- a/Sources/RoktUXHelper/UI/Components/DataImageComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/DataImageComponent.swift
@@ -28,6 +28,7 @@ struct DataImageViewComponent: View {
     var spacingStyle: SpacingStylingProperties? { style?.spacing }
     var backgroundStyle: BackgroundStylingProperties? { style?.background }
     var imageScale: ImageRenderScale { style?.image?.scale?.asImageRenderScale ?? .fit }
+    var clipsToBounds: Bool { imageScale != .fit || (borderStyle?.borderRadius ?? 0) > 0 }
 
     let config: ComponentConfig
     let model: DataImageViewModel
@@ -70,6 +71,7 @@ struct DataImageViewComponent: View {
                     defaultHeight: .wrapContent,
                     defaultWidth: .wrapContent,
                     expandsToContainerOnSelfAlign: expandsToContainerOnSelfAlign,
+                    clipsToBounds: clipsToBounds,
                     imageLoader: model.imageLoader
                 )
                 .onChange(of: globalScreenSize.width) { newSize in

--- a/Sources/RoktUXHelper/UI/Components/DataImageComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/DataImageComponent.swift
@@ -28,6 +28,7 @@ struct DataImageViewComponent: View {
     var spacingStyle: SpacingStylingProperties? { style?.spacing }
     var backgroundStyle: BackgroundStylingProperties? { style?.background }
     var imageScale: ImageRenderScale { style?.image?.scale?.asImageRenderScale ?? .fit }
+    var defaultWidth: WidthFitProperty { imageScale == .fit ? .wrapContent : .fitWidth }
     var clipsToBounds: Bool { imageScale != .fit || (borderStyle?.borderRadius ?? 0) > 0 }
 
     let config: ComponentConfig
@@ -69,7 +70,7 @@ struct DataImageViewComponent: View {
                     parentHeight: $parentHeight,
                     parentOverride: parentOverride,
                     defaultHeight: .wrapContent,
-                    defaultWidth: .wrapContent,
+                    defaultWidth: defaultWidth,
                     expandsToContainerOnSelfAlign: expandsToContainerOnSelfAlign,
                     clipsToBounds: clipsToBounds,
                     imageLoader: model.imageLoader

--- a/Sources/RoktUXHelper/UI/Components/DataImageComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/DataImageComponent.swift
@@ -27,6 +27,7 @@ struct DataImageViewComponent: View {
     var borderStyle: BorderStylingProperties? { style?.border }
     var spacingStyle: SpacingStylingProperties? { style?.spacing }
     var backgroundStyle: BackgroundStylingProperties? { style?.background }
+    var imageScale: ImageRenderScale { style?.image?.scale?.asImageRenderScale ?? .fit }
 
     let config: ComponentConfig
     let model: DataImageViewModel
@@ -83,7 +84,7 @@ struct DataImageViewComponent: View {
     func build() -> some View {
         AsyncImageView(imageUrl: ThemeUrl(light: model.image?.light ?? "",
                                           dark: model.image?.dark ?? ""),
-                       scale: .fit,
+                       scale: imageScale,
                        alt: model.image?.accessibilityAltText,
                        imageLoader: model.imageLoader,
                        isImageValid: $isImageValid)

--- a/Sources/RoktUXHelper/UI/Components/StaticImageViewComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/StaticImageViewComponent.swift
@@ -28,6 +28,7 @@ struct StaticImageViewComponent: View {
     var spacingStyle: SpacingStylingProperties? { style?.spacing }
     var backgroundStyle: BackgroundStylingProperties? { style?.background }
     var imageScale: ImageRenderScale { style?.image?.scale?.asImageRenderScale ?? .fit }
+    var defaultWidth: WidthFitProperty { imageScale == .fit ? .wrapContent : .fitWidth }
     var clipsToBounds: Bool { imageScale != .fit || (borderStyle?.borderRadius ?? 0) > 0 }
 
     let config: ComponentConfig
@@ -66,7 +67,7 @@ struct StaticImageViewComponent: View {
                     parentHeight: $parentHeight,
                     parentOverride: parentOverride,
                     defaultHeight: .wrapContent,
-                    defaultWidth: .wrapContent,
+                    defaultWidth: defaultWidth,
                     expandsToContainerOnSelfAlign: expandsToContainerOnSelfAlign,
                     clipsToBounds: clipsToBounds,
                     imageLoader: model.imageLoader

--- a/Sources/RoktUXHelper/UI/Components/StaticImageViewComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/StaticImageViewComponent.swift
@@ -27,6 +27,7 @@ struct StaticImageViewComponent: View {
     var borderStyle: BorderStylingProperties? { style?.border }
     var spacingStyle: SpacingStylingProperties? { style?.spacing }
     var backgroundStyle: BackgroundStylingProperties? { style?.background }
+    var imageScale: ImageRenderScale { style?.image?.scale?.asImageRenderScale ?? .fit }
 
     let config: ComponentConfig
     let model: StaticImageViewModel
@@ -81,7 +82,7 @@ struct StaticImageViewComponent: View {
     func build() -> some View {
         AsyncImageView(
             imageUrl: toThemeUrl(model.url),
-            scale: .fit,
+            scale: imageScale,
             alt: model.alt,
             imageLoader: model.imageLoader,
             isImageValid: $isImageValid

--- a/Sources/RoktUXHelper/UI/Components/StaticImageViewComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/StaticImageViewComponent.swift
@@ -28,6 +28,7 @@ struct StaticImageViewComponent: View {
     var spacingStyle: SpacingStylingProperties? { style?.spacing }
     var backgroundStyle: BackgroundStylingProperties? { style?.background }
     var imageScale: ImageRenderScale { style?.image?.scale?.asImageRenderScale ?? .fit }
+    var clipsToBounds: Bool { imageScale != .fit || (borderStyle?.borderRadius ?? 0) > 0 }
 
     let config: ComponentConfig
     let model: StaticImageViewModel
@@ -67,6 +68,7 @@ struct StaticImageViewComponent: View {
                     defaultHeight: .wrapContent,
                     defaultWidth: .wrapContent,
                     expandsToContainerOnSelfAlign: expandsToContainerOnSelfAlign,
+                    clipsToBounds: clipsToBounds,
                     imageLoader: model.imageLoader
                 )
                 .onChange(of: globalScreenSize.width) { newSize in

--- a/Sources/RoktUXHelper/UI/Components/Style/BackgroundModifier.swift
+++ b/Sources/RoktUXHelper/UI/Components/Style/BackgroundModifier.swift
@@ -53,7 +53,7 @@ struct BackgroundImageModifier: ViewModifier {
         content.background(alignment: bgAlignment) {
             hasBackgroundImage ?
                 AnyView(AsyncImageView(imageUrl: backgroundImage?.url,
-                                       scale: backgroundImage?.scale,
+                                       scale: backgroundImage?.scale?.asImageRenderScale,
                                        imageLoader: imageLoader,
                                        isImageValid: $isImageValid)) :
                 AnyView(EmptyView())

--- a/Sources/RoktUXHelper/UI/Components/Style/LayoutSchemaModifier.swift
+++ b/Sources/RoktUXHelper/UI/Components/Style/LayoutSchemaModifier.swift
@@ -32,6 +32,7 @@ struct LayoutSchemaModifier: ViewModifier, SpacingStyleable {
     let applyAlignSelf: Bool
     let applyMargin: Bool
     @Binding var frameChangeIndex: Int
+    let clipsToBounds: Bool
     let imageLoader: RoktUXImageLoader?
 
     func body(content: Content) -> some View {
@@ -51,6 +52,7 @@ struct LayoutSchemaModifier: ViewModifier, SpacingStyleable {
                    parentOverride: parentOverride,
                    margin: getMargin())
             .background(backgroundStyle: background, imageLoader: imageLoader)
+            .clipToBounds(clipsToBounds, borderRadius: border?.borderRadius)
             .border(
                 borderRadius: border?.borderRadius,
                 borderColor: border?.borderColor,
@@ -117,6 +119,7 @@ internal extension View {
         applyAlignSelf: Bool = true,
         applyMargin: Bool = true,
         frameChangeIndex: Binding<Int> = .constant(0),
+        clipsToBounds: Bool = false,
         imageLoader: RoktUXImageLoader?
     ) -> some View {
         modifier(LayoutSchemaModifier(
@@ -142,6 +145,7 @@ internal extension View {
             applyAlignSelf: applyAlignSelf,
             applyMargin: applyMargin,
             frameChangeIndex: frameChangeIndex,
+            clipsToBounds: clipsToBounds,
             imageLoader: imageLoader
         ))
     }

--- a/Tests/RoktUXHelperTests/Services/LayoutTransformer/TestStyleTransformer.swift
+++ b/Tests/RoktUXHelperTests/Services/LayoutTransformer/TestStyleTransformer.swift
@@ -183,13 +183,18 @@ final class TestStyleTransformer: XCTestCase {
                                                                                  maxHeight: nil,
                                                                                  height: nil, 
                                                                                  rotateZ: nil),
+                                           image: ImageStylingProperties(scale: .fit),
                                            flexChild: FlexChildStylingProperties(weight: 0, order: 0, alignSelf: nil),
                                            spacing: nil)
         
         let pressed = DataImageStyles(background: BackgroundStylingProperties(backgroundColor: ThemeColor(light: "#000000",
                                                                                                           dark: nil),
                                                                               backgroundImage: nil),
-                                      border: nil, dimension: nil, flexChild: nil, spacing: nil)
+                                      border: nil,
+                                      dimension: nil,
+                                      image: ImageStylingProperties(scale: .fill),
+                                      flexChild: nil,
+                                      spacing: nil)
         
         let expectedStyle = DataImageStyles(background: BackgroundStylingProperties(backgroundColor: ThemeColor(light: "#000000",
                                                                                                                 dark: nil),
@@ -202,6 +207,7 @@ final class TestStyleTransformer: XCTestCase {
                                                                                   maxHeight: nil,
                                                                                   height: nil,
                                                                                   rotateZ: nil),
+                                            image: ImageStylingProperties(scale: .fill),
                                             flexChild: FlexChildStylingProperties(weight: 0, order: 0, alignSelf: nil),
                                             spacing: nil)
         
@@ -214,6 +220,7 @@ final class TestStyleTransformer: XCTestCase {
         XCTAssertEqual(transformedStyle.flexChild, expectedStyle.flexChild)
         XCTAssertEqual(transformedStyle.spacing, expectedStyle.spacing)
         XCTAssertEqual(transformedStyle.border, expectedStyle.border)
+        XCTAssertEqual(transformedStyle.image, expectedStyle.image)
     }
     
     func test_get_updated_style_static_image() throws {
@@ -227,13 +234,18 @@ final class TestStyleTransformer: XCTestCase {
                                                                                    maxHeight: nil,
                                                                                    height: nil, 
                                                                                  rotateZ: nil),
+                                             image: ImageStylingProperties(scale: .fit),
                                              flexChild: FlexChildStylingProperties(weight: 0, order: 0, alignSelf: nil),
                                              spacing: nil)
         
         let pressed = StaticImageStyles(background: BackgroundStylingProperties(backgroundColor: ThemeColor(light: "#000000",
                                                                                                             dark: nil),
                                                                                 backgroundImage: nil),
-                                        border: nil, dimension: nil, flexChild: nil, spacing: nil)
+                                        border: nil,
+                                        dimension: nil,
+                                        image: ImageStylingProperties(scale: .fill),
+                                        flexChild: nil,
+                                        spacing: nil)
         
         let expectedStyle =
             StaticImageStyles(background: BackgroundStylingProperties(backgroundColor: ThemeColor(light: "#000000",
@@ -247,6 +259,7 @@ final class TestStyleTransformer: XCTestCase {
                                                                     maxHeight: nil,
                                                                     height: nil, 
                                                                                   rotateZ: nil),
+                              image: ImageStylingProperties(scale: .fill),
                               flexChild: FlexChildStylingProperties(weight: 0, order: 0, alignSelf: nil),
                               spacing: nil)
         
@@ -259,6 +272,7 @@ final class TestStyleTransformer: XCTestCase {
         XCTAssertEqual(transformedStyle?.flexChild, expectedStyle.flexChild)
         XCTAssertEqual(transformedStyle?.spacing, expectedStyle.spacing)
         XCTAssertEqual(transformedStyle?.border, expectedStyle.border)
+        XCTAssertEqual(transformedStyle?.image, expectedStyle.image)
     }
     
     func test_get_updated_style_static_image_with_breakpoints() throws {
@@ -272,13 +286,18 @@ final class TestStyleTransformer: XCTestCase {
                                                                                    maxHeight: nil,
                                                                                    height: nil, 
                                                                                  rotateZ: nil),
+                                             image: ImageStylingProperties(scale: .fit),
                                              flexChild: FlexChildStylingProperties(weight: 0, order: 0, alignSelf: nil),
                                              spacing: nil)
         
         let pressed = StaticImageStyles(background: BackgroundStylingProperties(backgroundColor: ThemeColor(light: "#000000",
                                                                                                             dark: nil),
                                                                                 backgroundImage: nil),
-                                        border: nil, dimension: nil, flexChild: nil, spacing: nil)
+                                        border: nil,
+                                        dimension: nil,
+                                        image: ImageStylingProperties(scale: .fill),
+                                        flexChild: nil,
+                                        spacing: nil)
         
         let expectedStyle =
             StaticImageStyles(background: BackgroundStylingProperties(backgroundColor: ThemeColor(light: "#000000",
@@ -292,6 +311,7 @@ final class TestStyleTransformer: XCTestCase {
                                                                     maxHeight: nil,
                                                                     height: nil, 
                                                                                   rotateZ: nil),
+                              image: ImageStylingProperties(scale: .fill),
                               flexChild: FlexChildStylingProperties(weight: 0, order: 0, alignSelf: nil),
                               spacing: nil)
         let styles = [BasicStateStylingBlock<StaticImageStyles>(default: defaultStyle,
@@ -314,12 +334,14 @@ final class TestStyleTransformer: XCTestCase {
         XCTAssertEqual(transformedStyle.first?.default.flexChild, defaultStyle.flexChild)
         XCTAssertEqual(transformedStyle.first?.default.spacing, defaultStyle.spacing)
         XCTAssertEqual(transformedStyle.first?.default.border, defaultStyle.border)
+        XCTAssertEqual(transformedStyle.first?.default.image, defaultStyle.image)
         // The pressed styles should be the same as default
         XCTAssertEqual(transformedStyle.first?.pressed?.background, defaultStyle.background)
         XCTAssertEqual(transformedStyle.first?.pressed?.dimension, defaultStyle.dimension)
         XCTAssertEqual(transformedStyle.first?.pressed?.flexChild, defaultStyle.flexChild)
         XCTAssertEqual(transformedStyle.first?.pressed?.spacing, defaultStyle.spacing)
         XCTAssertEqual(transformedStyle.first?.pressed?.border, defaultStyle.border)
+        XCTAssertEqual(transformedStyle.first?.pressed?.image, defaultStyle.image)
         
         // Check the second bereakpoint
         XCTAssertEqual(transformedStyle[1].default.background, defaultStyle.background)
@@ -327,12 +349,14 @@ final class TestStyleTransformer: XCTestCase {
         XCTAssertEqual(transformedStyle[1].default.flexChild, defaultStyle.flexChild)
         XCTAssertEqual(transformedStyle[1].default.spacing, defaultStyle.spacing)
         XCTAssertEqual(transformedStyle[1].default.border, defaultStyle.border)
+        XCTAssertEqual(transformedStyle[1].default.image, defaultStyle.image)
         // Check the pressed style on the second bereakpoint 
         XCTAssertEqual(transformedStyle[1].pressed?.background, expectedStyle.background)
         XCTAssertEqual(transformedStyle[1].pressed?.dimension, expectedStyle.dimension)
         XCTAssertEqual(transformedStyle[1].pressed?.flexChild, expectedStyle.flexChild)
         XCTAssertEqual(transformedStyle[1].pressed?.spacing, expectedStyle.spacing)
         XCTAssertEqual(transformedStyle[1].pressed?.border, expectedStyle.border)
+        XCTAssertEqual(transformedStyle[1].pressed?.image, expectedStyle.image)
     }
     
     func test_get_updated_style_progress_indicator() throws {

--- a/Tests/RoktUXHelperTests/UI/Components/TestDataImageComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestDataImageComponent.swift
@@ -108,6 +108,16 @@ final class TestDataImageComponent: XCTestCase {
                        ))
     }
 
+    func test_dataImageScale_defaultsToFit() throws {
+        XCTAssertEqual(try get_async_image_scale(for: nil), .fit)
+    }
+
+    func test_dataImageScale_usesConfiguredScale() throws {
+        XCTAssertEqual(try get_async_image_scale(for: .fit), .fit)
+        XCTAssertEqual(try get_async_image_scale(for: .fill), .fill)
+        XCTAssertEqual(try get_async_image_scale(for: .crop), .crop)
+    }
+
     func get_model(isValid: Bool = true, isFallback: Bool = false) throws -> DataImageViewModel {
         let validImage = "https://docs.rokt.com/assets/images/embedded-placement-1-5ab04a718fe7dda94ac24aa7b89aac92.png"
         let invalidImage = ""
@@ -142,5 +152,45 @@ final class TestDataImageComponent: XCTestCase {
                                            transactionData: nil),
                          layoutVariant: nil,
                          jwtToken: "slot-token")
+    }
+
+    func get_async_image_scale(for scale: DcuiSchema.ImageScale?) throws -> ImageRenderScale? {
+        let view = TestPlaceHolder(layout: LayoutSchemaViewModel.dataImage(get_model(scale: scale)))
+
+        return try view.inspect().view(TestPlaceHolder.self)
+            .view(EmbeddedComponent.self)
+            .vStack()[0]
+            .view(LayoutSchemaComponent.self)
+            .view(DataImageViewComponent.self)
+            .actualView()
+            .inspect()
+            .find(AsyncImageView.self)
+            .actualView()
+            .scale
+    }
+
+    func get_model(scale: DcuiSchema.ImageScale?) -> DataImageViewModel {
+        DataImageViewModel(
+            image: CreativeImage(
+                light: "https://docs.rokt.com/assets/images/embedded-placement-1-5ab04a718fe7dda94ac24aa7b89aac92.png",
+                dark: nil,
+                alt: "",
+                title: nil
+            ),
+            defaultStyle: [
+                DataImageStyles(
+                    background: nil,
+                    border: nil,
+                    dimension: nil,
+                    image: scale.map { ImageStylingProperties(scale: $0) },
+                    flexChild: nil,
+                    spacing: nil
+                )
+            ],
+            pressedStyle: nil,
+            hoveredStyle: nil,
+            disabledStyle: nil,
+            layoutState: nil
+        )
     }
 }

--- a/Tests/RoktUXHelperTests/UI/Components/TestDataImageComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestDataImageComponent.swift
@@ -118,6 +118,18 @@ final class TestDataImageComponent: XCTestCase {
         XCTAssertEqual(try get_async_image_scale(for: .crop), .crop)
     }
 
+    func test_dataImageClipsToBounds_forFillScale() throws {
+        XCTAssertTrue(try get_data_image_component(for: .fill).clipsToBounds)
+    }
+
+    func test_dataImageClipsToBounds_forBorderRadius() throws {
+        XCTAssertTrue(try get_data_image_component(for: nil, borderRadius: 16).clipsToBounds)
+    }
+
+    func test_dataImageClipsToBounds_defaultsToFalse() throws {
+        XCTAssertFalse(try get_data_image_component(for: nil).clipsToBounds)
+    }
+
     func get_model(isValid: Bool = true, isFallback: Bool = false) throws -> DataImageViewModel {
         let validImage = "https://docs.rokt.com/assets/images/embedded-placement-1-5ab04a718fe7dda94ac24aa7b89aac92.png"
         let invalidImage = ""
@@ -155,7 +167,20 @@ final class TestDataImageComponent: XCTestCase {
     }
 
     func get_async_image_scale(for scale: DcuiSchema.ImageScale?) throws -> ImageRenderScale? {
-        let view = TestPlaceHolder(layout: LayoutSchemaViewModel.dataImage(get_model(scale: scale)))
+        try get_data_image_component(for: scale)
+            .inspect()
+            .find(AsyncImageView.self)
+            .actualView()
+            .scale
+    }
+
+    func get_data_image_component(
+        for scale: DcuiSchema.ImageScale?,
+        borderRadius: Float? = nil
+    ) throws -> DataImageViewComponent {
+        let view = TestPlaceHolder(layout: LayoutSchemaViewModel.dataImage(
+            get_model(scale: scale, borderRadius: borderRadius)
+        ))
 
         return try view.inspect().view(TestPlaceHolder.self)
             .view(EmbeddedComponent.self)
@@ -163,13 +188,9 @@ final class TestDataImageComponent: XCTestCase {
             .view(LayoutSchemaComponent.self)
             .view(DataImageViewComponent.self)
             .actualView()
-            .inspect()
-            .find(AsyncImageView.self)
-            .actualView()
-            .scale
     }
 
-    func get_model(scale: DcuiSchema.ImageScale?) -> DataImageViewModel {
+    func get_model(scale: DcuiSchema.ImageScale?, borderRadius: Float? = nil) -> DataImageViewModel {
         DataImageViewModel(
             image: CreativeImage(
                 light: "https://docs.rokt.com/assets/images/embedded-placement-1-5ab04a718fe7dda94ac24aa7b89aac92.png",
@@ -180,7 +201,12 @@ final class TestDataImageComponent: XCTestCase {
             defaultStyle: [
                 DataImageStyles(
                     background: nil,
-                    border: nil,
+                    border: borderRadius.map {
+                        BorderStylingProperties(borderRadius: $0,
+                                                borderColor: nil,
+                                                borderWidth: nil,
+                                                borderStyle: nil)
+                    },
                     dimension: nil,
                     image: scale.map { ImageStylingProperties(scale: $0) },
                     flexChild: nil,

--- a/Tests/RoktUXHelperTests/UI/Components/TestDataImageComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestDataImageComponent.swift
@@ -130,6 +130,18 @@ final class TestDataImageComponent: XCTestCase {
         XCTAssertFalse(try get_data_image_component(for: nil).clipsToBounds)
     }
 
+    func test_dataImageDefaultWidth_defaultsToWrapContentForFitScale() throws {
+        XCTAssertEqual(try get_data_image_component(for: .fit).defaultWidth, .wrapContent)
+    }
+
+    func test_dataImageDefaultWidth_usesFitWidthForFillScale() throws {
+        XCTAssertEqual(try get_data_image_component(for: .fill).defaultWidth, .fitWidth)
+    }
+
+    func test_dataImageDefaultWidth_usesFitWidthForCropScale() throws {
+        XCTAssertEqual(try get_data_image_component(for: .crop).defaultWidth, .fitWidth)
+    }
+
     func get_model(isValid: Bool = true, isFallback: Bool = false) throws -> DataImageViewModel {
         let validImage = "https://docs.rokt.com/assets/images/embedded-placement-1-5ab04a718fe7dda94ac24aa7b89aac92.png"
         let invalidImage = ""

--- a/Tests/RoktUXHelperTests/UI/Components/TestStaticImageComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestStaticImageComponent.swift
@@ -82,6 +82,18 @@ final class TestStaticImageComponent: XCTestCase {
         XCTAssertEqual(try get_async_image_scale(for: .fill), .fill)
         XCTAssertEqual(try get_async_image_scale(for: .crop), .crop)
     }
+
+    func test_staticImageClipsToBounds_forFillScale() throws {
+        XCTAssertTrue(try get_static_image_component(for: .fill).clipsToBounds)
+    }
+
+    func test_staticImageClipsToBounds_forBorderRadius() throws {
+        XCTAssertTrue(try get_static_image_component(for: nil, borderRadius: 16).clipsToBounds)
+    }
+
+    func test_staticImageClipsToBounds_defaultsToFalse() throws {
+        XCTAssertFalse(try get_static_image_component(for: nil).clipsToBounds)
+    }
     
     func get_model(_ layoutName: LayoutName) throws -> StaticImageViewModel {
         let transformer = LayoutTransformer(layoutPlugin: get_mock_layout_plugin())
@@ -97,7 +109,20 @@ final class TestStaticImageComponent: XCTestCase {
     }
 
     func get_async_image_scale(for scale: DcuiSchema.ImageScale?) throws -> ImageRenderScale? {
-        let view = TestPlaceHolder(layout: LayoutSchemaViewModel.staticImage(get_model(scale: scale)))
+        try get_static_image_component(for: scale)
+            .inspect()
+            .find(AsyncImageView.self)
+            .actualView()
+            .scale
+    }
+
+    func get_static_image_component(
+        for scale: DcuiSchema.ImageScale?,
+        borderRadius: Float? = nil
+    ) throws -> StaticImageViewComponent {
+        let view = TestPlaceHolder(layout: LayoutSchemaViewModel.staticImage(
+            get_model(scale: scale, borderRadius: borderRadius)
+        ))
 
         return try view.inspect().view(TestPlaceHolder.self)
             .view(EmbeddedComponent.self)
@@ -105,13 +130,9 @@ final class TestStaticImageComponent: XCTestCase {
             .view(LayoutSchemaComponent.self)
             .view(StaticImageViewComponent.self)
             .actualView()
-            .inspect()
-            .find(AsyncImageView.self)
-            .actualView()
-            .scale
     }
 
-    func get_model(scale: DcuiSchema.ImageScale?) -> StaticImageViewModel {
+    func get_model(scale: DcuiSchema.ImageScale?, borderRadius: Float? = nil) -> StaticImageViewModel {
         StaticImageViewModel(
             url: StaticImageUrl(
                 light: "https://docs.rokt.com/assets/images/embedded-placement-1-5ab04a718fe7dda94ac24aa7b89aac92.png",
@@ -120,7 +141,15 @@ final class TestStaticImageComponent: XCTestCase {
             alt: "",
             stylingProperties: [
                 BasicStateStylingBlock<BaseStyles>(
-                    default: BaseStyles(image: scale.map { ImageStylingProperties(scale: $0) }),
+                    default: BaseStyles(
+                        border: borderRadius.map {
+                            BorderStylingProperties(borderRadius: $0,
+                                                    borderColor: nil,
+                                                    borderWidth: nil,
+                                                    borderStyle: nil)
+                        },
+                        image: scale.map { ImageStylingProperties(scale: $0) }
+                    ),
                     pressed: nil,
                     hovered: nil,
                     focussed: nil,

--- a/Tests/RoktUXHelperTests/UI/Components/TestStaticImageComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestStaticImageComponent.swift
@@ -94,6 +94,18 @@ final class TestStaticImageComponent: XCTestCase {
     func test_staticImageClipsToBounds_defaultsToFalse() throws {
         XCTAssertFalse(try get_static_image_component(for: nil).clipsToBounds)
     }
+
+    func test_staticImageDefaultWidth_defaultsToWrapContentForFitScale() throws {
+        XCTAssertEqual(try get_static_image_component(for: .fit).defaultWidth, .wrapContent)
+    }
+
+    func test_staticImageDefaultWidth_usesFitWidthForFillScale() throws {
+        XCTAssertEqual(try get_static_image_component(for: .fill).defaultWidth, .fitWidth)
+    }
+
+    func test_staticImageDefaultWidth_usesFitWidthForCropScale() throws {
+        XCTAssertEqual(try get_static_image_component(for: .crop).defaultWidth, .fitWidth)
+    }
     
     func get_model(_ layoutName: LayoutName) throws -> StaticImageViewModel {
         let transformer = LayoutTransformer(layoutPlugin: get_mock_layout_plugin())

--- a/Tests/RoktUXHelperTests/UI/Components/TestStaticImageComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestStaticImageComponent.swift
@@ -1,6 +1,7 @@
 import XCTest
 import SwiftUI
 import ViewInspector
+import DcuiSchema
 @testable import RoktUXHelper
 import SnapshotTesting
 
@@ -71,6 +72,16 @@ final class TestStaticImageComponent: XCTestCase {
         XCTAssertEqual(try image.accessibilityLabel().string(), "image")
         XCTAssertEqual(try image.accessibilityHidden(), false)
     }
+
+    func test_staticImageScale_defaultsToFit() throws {
+        XCTAssertEqual(try get_async_image_scale(for: nil), .fit)
+    }
+
+    func test_staticImageScale_usesConfiguredScale() throws {
+        XCTAssertEqual(try get_async_image_scale(for: .fit), .fit)
+        XCTAssertEqual(try get_async_image_scale(for: .fill), .fill)
+        XCTAssertEqual(try get_async_image_scale(for: .crop), .crop)
+    }
     
     func get_model(_ layoutName: LayoutName) throws -> StaticImageViewModel {
         let transformer = LayoutTransformer(layoutPlugin: get_mock_layout_plugin())
@@ -83,5 +94,40 @@ final class TestStaticImageComponent: XCTestCase {
         case .withAlt:
             return try transformer.getStaticImage(ModelTestData.StaticImageData.withAlt())
         }
+    }
+
+    func get_async_image_scale(for scale: DcuiSchema.ImageScale?) throws -> ImageRenderScale? {
+        let view = TestPlaceHolder(layout: LayoutSchemaViewModel.staticImage(get_model(scale: scale)))
+
+        return try view.inspect().view(TestPlaceHolder.self)
+            .view(EmbeddedComponent.self)
+            .vStack()[0]
+            .view(LayoutSchemaComponent.self)
+            .view(StaticImageViewComponent.self)
+            .actualView()
+            .inspect()
+            .find(AsyncImageView.self)
+            .actualView()
+            .scale
+    }
+
+    func get_model(scale: DcuiSchema.ImageScale?) -> StaticImageViewModel {
+        StaticImageViewModel(
+            url: StaticImageUrl(
+                light: "https://docs.rokt.com/assets/images/embedded-placement-1-5ab04a718fe7dda94ac24aa7b89aac92.png",
+                dark: nil
+            ),
+            alt: "",
+            stylingProperties: [
+                BasicStateStylingBlock<BaseStyles>(
+                    default: BaseStyles(image: scale.map { ImageStylingProperties(scale: $0) }),
+                    pressed: nil,
+                    hovered: nil,
+                    focussed: nil,
+                    disabled: nil
+                )
+            ],
+            layoutState: nil
+        )
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- DcuiSchema 2.8.0 adds image style scale data that RoktUXHelper needs to preserve when rendering image components. Without this support, static and data image components always render with the default fit behavior even when layout styles request fill or crop.

## What Has Changed

- Updated DcuiSchema package and podspec dependency versions to 2.8.0 and aligned `Constants.layoutSchemaVersion`.
- Added image style storage and merge support to shared styles and image component style transformers.
- Introduced shared `ImageRenderScale` mapping for background, static, and data image rendering.
- Wired static and data image components to honor configured `fit`, `fill`, and `crop` image scales.
- Added tests for image style transformation and component scale propagation.

## Screenshots/Video

- UI rendering behavior changed for image scaling. Please add screenshots or video showing `fit`, `fill`, and `crop` behavior before review.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Example JSON resource edits are intentionally excluded from this PR.