### PR TITLE
feat(catalog): resolve nested image fields in catalog placeholders

### DIFF
--- a/Sources/RoktUXHelper/Data/Expansion/Extractor/CatalogDataExtractor.swift
+++ b/Sources/RoktUXHelper/Data/Expansion/Extractor/CatalogDataExtractor.swift
@@ -123,6 +123,15 @@ struct CatalogDataExtractor<Validator: DataValidating>: DataExtracting where Val
             return decimalValue as! U
         }
 
+        // Last resort: if the caller wants a String but the value is something
+        // we can't stringify (e.g. a struct like CreativeImage reached when a
+        // placeholder path stops short of a leaf field), surface as empty so
+        // downstream placeholder logic treats it as "not present" rather than
+        // crashing on the trailing as! cast.
+        if type == String.self {
+            return "" as! U
+        }
+
         return value as! U
     }
 

--- a/Sources/RoktUXHelper/Data/Expansion/Extractor/DataReflector.swift
+++ b/Sources/RoktUXHelper/Data/Expansion/Extractor/DataReflector.swift
@@ -33,7 +33,21 @@ struct DataReflector: DataReflecting {
                 let remainingKeys = Array(keys.dropFirst())
                 let remainingKeysAsString = remainingKeys.joined(separator: BNFSeparator.namespace.rawValue)
 
-                targetProperty = valueDict[remainingKeysAsString]
+                if let directValue = valueDict[remainingKeysAsString] {
+                    // existing path: dict key contains the full dotted name
+                    // (e.g. copy["provider.discountPercent"])
+                    targetProperty = directValue
+                } else if remainingKeys.count > 1,
+                          let nestedValue = valueDict[remainingKeys[0]] {
+                    // dict value is itself a struct/object — recurse into it
+                    // with the leftover keys, so e.g. images["catalogItemImage2"].light
+                    // resolves through CreativeImage.light.
+                    let nestedMirror = Mirror(reflecting: nestedValue)
+                    targetProperty = getReflectedValue(
+                        data: nestedMirror,
+                        keys: Array(remainingKeys.dropFirst())
+                    )
+                }
 
                 break
             } else {

--- a/Tests/RoktUXHelperTests/Data/Expansion/Extractor/CatalogDataExtractorTests.swift
+++ b/Tests/RoktUXHelperTests/Data/Expansion/Extractor/CatalogDataExtractorTests.swift
@@ -168,13 +168,75 @@ final class CatalogDataExtractorTests: XCTestCase {
         )
     }
 
+    func test_extractDataRepresentedBy_usingImageLeafField_returnsLightURL() {
+        // Validates the DataReflector dict-of-struct recursion end-to-end
+        // through the catalog extractor. This is the placeholder shape that
+        // the new layout uses to drive its When predicates:
+        //   %^DATA.catalogItem.images.catalogItemImage2.light^%
+        let catalogItem = makeCatalogItem(images: [
+            "catalogItemImage0": CreativeImage(light: "url0", dark: nil, alt: nil, title: nil),
+            "catalogItemImage2": CreativeImage(light: "url2", dark: nil, alt: nil, title: nil)
+        ])
+
+        XCTAssertEqual(
+            try sut?.extractDataRepresentedBy(
+                String.self,
+                propertyChain: "DATA.catalogItem.images.catalogItemImage2.light",
+                responseKey: nil,
+                from: catalogItem
+            ),
+            .value("url2")
+        )
+    }
+
+    func test_extractDataRepresentedBy_usingImageLeafField_missingKey_returnsEmptyString() {
+        // Missing dict key → resolveValue returns nil → mandatoryKeyEmpty is
+        // thrown when there's no `| default`. PlaceholderPredicateResolver
+        // turns that into nil for the caller (covered separately in
+        // PlaceholderPredicateResolverTests).
+        let catalogItem = makeCatalogItem(images: [
+            "catalogItemImage0": CreativeImage(light: "url0", dark: nil, alt: nil, title: nil)
+        ])
+
+        // Add `|` trailing default to suppress mandatoryKeyEmpty so we can
+        // observe the empty-string surface from the extractor directly.
+        XCTAssertEqual(
+            try sut?.extractDataRepresentedBy(
+                String.self,
+                propertyChain: "DATA.catalogItem.images.catalogItemImage2.light|",
+                responseKey: nil,
+                from: catalogItem
+            ),
+            .value("")
+        )
+    }
+
+    func test_extractDataRepresentedBy_usingImagePathStoppingAtStruct_returnsEmptyString() {
+        // If a placeholder stops at the struct level instead of a leaf field,
+        // coerce(String.self) now returns "" instead of crashing on `as! U`.
+        let catalogItem = makeCatalogItem(images: [
+            "catalogItemImage2": CreativeImage(light: "url2", dark: nil, alt: nil, title: nil)
+        ])
+
+        XCTAssertEqual(
+            try sut?.extractDataRepresentedBy(
+                String.self,
+                propertyChain: "DATA.catalogItem.images.catalogItemImage2",
+                responseKey: nil,
+                from: catalogItem
+            ),
+            .value("")
+        )
+    }
+
     private func makeCatalogItem(
         copy: [String: String]? = nil,
         price: Decimal? = 14.99,
-        minItemCount: Int? = nil
+        minItemCount: Int? = nil,
+        images: [String: CreativeImage] = [:]
     ) -> CatalogItem {
         .init(
-            images: [:],
+            images: images,
             catalogItemId: "catalog-item-id",
             cartItemId: "cart-item-id",
             instanceGuid: "instance-guid",

--- a/Tests/RoktUXHelperTests/Data/Expansion/Extractor/DataReflectorTests.swift
+++ b/Tests/RoktUXHelperTests/Data/Expansion/Extractor/DataReflectorTests.swift
@@ -40,6 +40,47 @@ final class DataReflectorTests: XCTestCase {
             14.99
         )
     }
+
+    func test_getReflectedValue_dictOfStructs_resolvesLeafField() {
+        // images is a [String: ReflectorTestImage] map. Resolving
+        // images.<key>.<field> must drill through the struct value, since the
+        // joined-key lookup ("catalogItemImage2.light") would otherwise miss.
+        let catalogMirror = Mirror(reflecting: ReflectorTestCatalog(images: [
+            "catalogItemImage0": ReflectorTestImage(light: "url0", dark: nil),
+            "catalogItemImage2": ReflectorTestImage(light: "url2", dark: "dark2")
+        ]))
+
+        XCTAssertEqual(
+            sut.getReflectedValue(data: catalogMirror, keys: ["images", "catalogItemImage2", "light"]) as? String,
+            "url2"
+        )
+        XCTAssertEqual(
+            sut.getReflectedValue(data: catalogMirror, keys: ["images", "catalogItemImage2", "dark"]) as? String,
+            "dark2"
+        )
+    }
+
+    func test_getReflectedValue_dictOfStructs_missingDictKey_returnsNil() {
+        let catalogMirror = Mirror(reflecting: ReflectorTestCatalog(images: [
+            "catalogItemImage0": ReflectorTestImage(light: "url0", dark: nil)
+        ]))
+
+        XCTAssertNil(
+            sut.getReflectedValue(data: catalogMirror, keys: ["images", "catalogItemImage2", "light"])
+        )
+    }
+
+    func test_getReflectedValue_dictOfStructs_missingLeafField_returnsNil() {
+        // Optional<String> with .none should surface as nil after the leaf lookup.
+        let catalogMirror = Mirror(reflecting: ReflectorTestCatalog(images: [
+            "catalogItemImage2": ReflectorTestImage(light: nil, dark: nil)
+        ]))
+
+        let result = sut.getReflectedValue(data: catalogMirror, keys: ["images", "catalogItemImage2", "light"])
+        // The reflector returns the raw Optional<String>.none here; callers
+        // (CatalogDataExtractor.unwrapOptional) collapse that to nil.
+        XCTAssertNil(result as? String)
+    }
 }
 
 struct Pet {
@@ -60,6 +101,15 @@ struct Suburb {
 
 struct ProductDetails {
     let copy: [String: Any]
+}
+
+struct ReflectorTestImage {
+    let light: String?
+    let dark: String?
+}
+
+struct ReflectorTestCatalog {
+    let images: [String: ReflectorTestImage]
 }
 
 let fakePet = Pet(name: "Ginger")

--- a/Tests/RoktUXHelperTests/Data/Expansion/PlaceholderPredicateResolverTests.swift
+++ b/Tests/RoktUXHelperTests/Data/Expansion/PlaceholderPredicateResolverTests.swift
@@ -38,4 +38,65 @@ final class PlaceholderPredicateResolverTests: XCTestCase {
         XCTAssertNotNil(resolved)
         XCTAssertEqual(resolved, "14.99")
     }
+
+    func test_resolveString_catalogItemImagePresent_returnsLeafLightURL() {
+        // Verifies the DataReflector dict-of-struct recursion lands a real URL
+        // when the placeholder targets a nested field on a struct dict value.
+        let images: [String: CreativeImage] = [
+            "catalogItemImage0": CreativeImage(light: "url0", dark: nil, alt: nil, title: nil),
+            "catalogItemImage2": CreativeImage(light: "url2", dark: nil, alt: nil, title: nil)
+        ]
+        let catalogItem = CatalogItem.mock(catalogItemId: "item1", images: images)
+        let context = PlaceholderResolutionContext(offers: [],
+                                                   currentOfferIndex: 0,
+                                                   activeCatalogItem: catalogItem)
+
+        let resolved = sut.resolveString(
+            placeholder: "%^DATA.catalogItem.images.catalogItemImage2.light^%",
+            context: context
+        )
+
+        XCTAssertEqual(resolved, "url2")
+    }
+
+    func test_resolveString_catalogItemImageAbsent_returnsNil() {
+        // Verifies that a missing dict key still surfaces as nil rather than
+        // resolving to the wrong image (the original bug was the layout
+        // falling back to a sibling image via a |-chain).
+        let images: [String: CreativeImage] = [
+            "catalogItemImage0": CreativeImage(light: "url0", dark: nil, alt: nil, title: nil)
+        ]
+        let catalogItem = CatalogItem.mock(catalogItemId: "item1", images: images)
+        let context = PlaceholderResolutionContext(offers: [],
+                                                   currentOfferIndex: 0,
+                                                   activeCatalogItem: catalogItem)
+
+        let resolved = sut.resolveString(
+            placeholder: "%^DATA.catalogItem.images.catalogItemImage2.light^%",
+            context: context
+        )
+
+        XCTAssertNil(resolved)
+    }
+
+    func test_resolveString_catalogItemImagePathToStruct_returnsEmptyString() {
+        // When a placeholder stops at the struct level instead of a leaf field,
+        // the extractor's coerce(String.self) fallback now returns "" instead
+        // of crashing on `as! U`. Empty string makes Placeholder TextValue
+        // `exists` evaluate to false (PredicateHandling treats empty as absent).
+        let images: [String: CreativeImage] = [
+            "catalogItemImage2": CreativeImage(light: "url2", dark: nil, alt: nil, title: nil)
+        ]
+        let catalogItem = CatalogItem.mock(catalogItemId: "item1", images: images)
+        let context = PlaceholderResolutionContext(offers: [],
+                                                   currentOfferIndex: 0,
+                                                   activeCatalogItem: catalogItem)
+
+        let resolved = sut.resolveString(
+            placeholder: "%^DATA.catalogItem.images.catalogItemImage2^%",
+            context: context
+        )
+
+        XCTAssertEqual(resolved, "")
+    }
 }


### PR DESCRIPTION
## Background

- Catalog placeholders could not read a nested field inside a catalog dictionary. A path like `%^DATA.catalogItem.images.catalogItemImage2.light^%` failed because `DataReflector` only performed a single joined-key dictionary lookup and never recursed into the struct value held at the key. As a result, layouts had no reliable way to ask "does this catalog item have a third image?" and fell back to workarounds (e.g. `|`-chained image keys that silently duplicate a sibling image, or a separate count flag in `copy`).
- A secondary issue: requesting a `String` for a value the extractor could not stringify (a placeholder that stops at the struct level) hit a force-cast and crashed.

## What Has Changed

- **`DataReflector`** — when the joined-key lookup inside a `[String: Any]` dictionary misses and keys remain, it now recurses into the value's mirror with the leftover keys. This lets `images.<key>.<field>` resolve through the image map into the `CreativeImage` field. The existing dotted-dict-key path (e.g. `copy["provider.discountPercent"]`) is tried first and is unchanged, so existing placeholders behave exactly as before.
- **`CatalogDataExtractor.coerce`** — returns an empty string when a `String` is requested for a value it cannot stringify, instead of crashing on the trailing force-cast. Empty string is treated as "not present" by downstream `Placeholder` logic, which is the desired behavior.
- **Tests** — added coverage for the reflector recursion (present / missing dict key / missing leaf field), the resolver happy-path and missing-key path, and the `coerce` fallback.

This enables layouts to drive conditional rendering off the presence of a specific catalog image. For example, a `When` node can show a multi-image variant only when a third image exists:

```json
"predicates": [
  {
    "type": "Placeholder",
    "predicate": {
      "type": "TextValue",
      "content": {
        "condition": "exists",
        "input": "%^DATA.catalogItem.images.catalogItemImage2.light^%",
        "value": ""
      }
    }
  }
]
```

The mirror predicate with `"condition": "not-exists"` selects the single-image variant. A missing key resolves to `nil` (so `exists` is false) rather than falling back to a sibling image.

## Screenshots/Video

- No UI in this PR — it is a data-layer/SDK change. The rendering behavior it enables is configured in layout JSON (not included here) and is covered by the unit tests above.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- The change is additive: the new recursion only runs when the existing joined-key lookup misses and keys remain, so no current placeholder resolution path is altered.
- Targeted suites pass locally: `DataReflectorTests`, `CatalogDataExtractorTests`, `PlaceholderPredicateResolverTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
