### PR TITLE
fix: re-sync RichText colour to live colour scheme on appear

### DIFF
--- a/Sources/RoktUXHelper/UI/Components/RichTextComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/RichTextComponent.swift
@@ -151,9 +151,7 @@ struct RichTextComponent: View {
                     // (e.g. carousel navigation) while the host keeps a constant, forced appearance
                     // never re-syncs and can render with the wrong colour. Re-bake against the live
                     // SwiftUI environment on appear so RichText matches the rest of the layout.
-                    DispatchQueue.main.async {
-                        model.updateAttributedString(colorScheme)
-                    }
+                    model.updateAttributedString(colorScheme)
                 }
         }
     }

--- a/Sources/RoktUXHelper/UI/Components/RichTextComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/RichTextComponent.swift
@@ -145,6 +145,15 @@ struct RichTextComponent: View {
                 }
                 .onAppear {
                     model.onAppear(textStyle: style)
+                    // The attributed string colour is baked once at layout-transform time using
+                    // `UITraitCollection.current` (the device appearance). `onChange(of: colorScheme)`
+                    // only re-bakes when the scheme *changes*, so an offer that is revealed later
+                    // (e.g. carousel navigation) while the host keeps a constant, forced appearance
+                    // never re-syncs and can render with the wrong colour. Re-bake against the live
+                    // SwiftUI environment on appear so RichText matches the rest of the layout.
+                    DispatchQueue.main.async {
+                        model.updateAttributedString(colorScheme)
+                    }
                 }
         }
     }


### PR DESCRIPTION
## Summary

`RichText` renders with the wrong colour (e.g. white-on-white, invisible body/disclaimer text) for offers revealed after the first one, when a host app forces a UI appearance that differs from the device's system appearance and passes `colorMode = .system`.

### Root cause
- `RichText` bakes its text colour into an `NSAttributedString` **once** at layout-transform time (`AttributedStringTransformer.convertRichTextHTMLIfExists`), resolving `.system` against `UITraitCollection.current` (the **device** appearance).
- It only refreshes via `onChange(of: colorScheme)` / the width `onChange`, which fire only on a *change*.
- Every other component (`BasicText`, backgrounds, borders) resolves colour **live** from `@Environment(\.colorScheme)`.

When the host forces a constant appearance (e.g. light via the SwiftUI environment) different from the device (dark), the first/visible offer happens to be corrected by the initial width change, but offers revealed later via **carousel navigation** never get a change event — so they keep the stale device-trait colour while the rest of the layout uses the host appearance. Result: a mix of light and dark colours (white text on a white background).

This is a regression: the always-live colour derivation (originally added in the SDK as "richtext fix for dark mode") was dropped when colour resolution moved to an `onChange`-only model ("use SwiftUI color scheme").

### Fix
Re-bake the attributed string against the live SwiftUI `@Environment(\.colorScheme)` on `onAppear`, so every `RichText` (including carousel-navigated offers) stays consistent with the rest of the layout.

## Test plan
- [x] Reproduced in the UX Helper example: `colorMode(.system)` + light forced at the SwiftUI level + dark device + navigate past the first offer -> body/disclaimer render white-on-white.
- [x] With the fix, all carousel offers render with correct, consistent colours.
- [x] Existing `RichText` logical unit tests pass. (The pre-existing `testSnapshot` image mismatch reproduces on `main` without this change — environment/OS drift, unrelated.)

### Note on automated coverage
A focused unit/snapshot test for this specific case is awkward: a single hosted `RichText` self-corrects via the `onChange` handlers (the same reason the first offer looks fine), so it does not reproduce the bug without simulating carousel navigation to a later offer. Happy to add a carousel-navigation integration/snapshot test as a follow-up if desired.