### PR TITLE
feat(model): add v2 init response models

### DIFF
--- a/Sources/RoktUXHelper/Data/Model/InitResponse/TxnInitResponse.swift
+++ b/Sources/RoktUXHelper/Data/Model/InitResponse/TxnInitResponse.swift
@@ -1,0 +1,161 @@
+import Foundation
+
+public struct TxnInitResponse: Decodable, Equatable {
+    public let sessionId: String
+    public let sessionToken: TxnSessionToken
+    public let featureFlags: TxnFeatureFlags
+    public let fonts: [TxnFontItem]
+
+    enum CodingKeys: String, CodingKey {
+        case sessionId = "session_id"
+        case sessionToken = "session_token"
+        case featureFlags = "feature_flags"
+        case fonts
+    }
+
+    public init(
+        sessionId: String,
+        sessionToken: TxnSessionToken,
+        featureFlags: TxnFeatureFlags,
+        fonts: [TxnFontItem]
+    ) {
+        self.sessionId = sessionId
+        self.sessionToken = sessionToken
+        self.featureFlags = featureFlags
+        self.fonts = fonts
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        sessionId = try container.decode(String.self, forKey: .sessionId)
+        sessionToken = try container.decode(TxnSessionToken.self, forKey: .sessionToken)
+        // Tolerate absent feature_flags/fonts so a missing block doesn't fail init.
+        featureFlags = try container.decodeIfPresent(TxnFeatureFlags.self, forKey: .featureFlags)
+            ?? TxnFeatureFlags(flags: [:])
+        fonts = try container.decodeIfPresent([TxnFontItem].self, forKey: .fonts) ?? []
+    }
+}
+
+public struct TxnSessionToken: Decodable, Equatable {
+    public let token: String
+    public let expiresAt: Int64 // Unix epoch milliseconds
+
+    enum CodingKeys: String, CodingKey {
+        case token
+        case expiresAt = "expires_at"
+    }
+
+    public init(token: String, expiresAt: Int64) {
+        self.token = token
+        self.expiresAt = expiresAt
+    }
+
+    public var expiresAtDate: Date {
+        Date(timeIntervalSince1970: TimeInterval(expiresAt)/1000)
+    }
+}
+
+public struct TxnFontItem: Decodable, Equatable {
+    public let fontName: String
+    public let fontURL: String
+    public let fontStyle: String?
+    public let fontWeight: String?
+    public let fontPostScriptName: String?
+
+    enum CodingKeys: String, CodingKey {
+        case fontName = "font_name"
+        case fontURL = "font_url"
+        case fontStyle = "font_style"
+        case fontWeight = "font_weight"
+        case fontPostScriptName = "font_post_script_name"
+    }
+
+    public init(
+        fontName: String,
+        fontURL: String,
+        fontStyle: String? = nil,
+        fontWeight: String? = nil,
+        fontPostScriptName: String? = nil
+    ) {
+        self.fontName = fontName
+        self.fontURL = fontURL
+        self.fontStyle = fontStyle
+        self.fontWeight = fontWeight
+        self.fontPostScriptName = fontPostScriptName
+    }
+}
+
+public enum TxnFeatureFlagValue: Decodable, Equatable {
+    case bool(Bool)
+    case int(Int)
+    case double(Double)
+    case string(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        // Bool before the numeric kinds so JSON booleans aren't coerced into numbers.
+        if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .int(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unsupported feature flag value type"
+            )
+        }
+    }
+}
+
+public struct TxnFeatureFlags: Decodable, Equatable {
+    public let flags: [String: TxnFeatureFlagValue]
+
+    public init(flags: [String: TxnFeatureFlagValue]) {
+        self.flags = flags
+    }
+
+    public init(from decoder: Decoder) throws {
+        // Decode per-key and skip values whose type isn't modeled, so a single
+        // unknown/extensible server flag can't fail the whole init response.
+        let container = try decoder.container(keyedBy: DynamicCodingKey.self)
+        var decoded: [String: TxnFeatureFlagValue] = [:]
+        for key in container.allKeys {
+            if let value = try? container.decode(TxnFeatureFlagValue.self, forKey: key) {
+                decoded[key.stringValue] = value
+            }
+        }
+        flags = decoded
+    }
+
+    private struct DynamicCodingKey: CodingKey {
+        let stringValue: String
+        let intValue: Int? = nil
+
+        init(stringValue: String) {
+            self.stringValue = stringValue
+        }
+
+        init?(intValue: Int) {
+            return nil
+        }
+    }
+
+    public func bool(forKey key: String) -> Bool? {
+        if case .bool(let value) = flags[key] { return value }
+        return nil
+    }
+
+    public func int(forKey key: String) -> Int? {
+        if case .int(let value) = flags[key] { return value }
+        return nil
+    }
+
+    public func string(forKey key: String) -> String? {
+        if case .string(let value) = flags[key] { return value }
+        return nil
+    }
+}

--- a/Tests/RoktUXHelperTests/Data/Model/InitResponse/TestTxnInitResponse.swift
+++ b/Tests/RoktUXHelperTests/Data/Model/InitResponse/TestTxnInitResponse.swift
@@ -1,0 +1,172 @@
+import XCTest
+@testable import RoktUXHelper
+
+final class TestTxnInitResponse: XCTestCase {
+
+    private func decode(_ json: String) throws -> TxnInitResponse {
+        let data = Data(json.utf8)
+        return try JSONDecoder().decode(TxnInitResponse.self, from: data)
+    }
+
+    // Mirrors the happy-path body in the SDK's V2SessionsInitClientPactSpec.
+    private let happyPathJSON = """
+    {
+        "session_id": "550e8400-e29b-41d4-a716-446655440000",
+        "session_token": {
+            "token": "pact-stub-session-token",
+            "expires_at": 1774474053000
+        },
+        "feature_flags": {
+            "rokt-tracking-status": true,
+            "client-timeout-ms": 30000,
+            "ios-sdk-log-font-happy-path": true,
+            "ios-sdk-use-font-register-with-url": false,
+            "mobile-sdk-use-bounding-box": false,
+            "mobile-sdk-use-sdk-cache": false,
+            "is-post-purchase-enabled": true,
+            "minimum-post-purchase-schema": "2.3.0"
+        },
+        "fonts": []
+    }
+    """
+
+    // MARK: - Top-level decoding
+
+    func test_decode_happyPath_topLevelFields() throws {
+        let response = try decode(happyPathJSON)
+        XCTAssertEqual(response.sessionId, "550e8400-e29b-41d4-a716-446655440000")
+        XCTAssertEqual(response.sessionToken.token, "pact-stub-session-token")
+        XCTAssertEqual(response.sessionToken.expiresAt, 1_774_474_053_000)
+        XCTAssertEqual(response.fonts, [])
+    }
+
+    func test_init_memberwise_setsAllFields() {
+        let token = TxnSessionToken(token: "t", expiresAt: 1_774_474_053_000)
+        let flags = TxnFeatureFlags(flags: ["rokt-tracking-status": .bool(true)])
+        let response = TxnInitResponse(sessionId: "sid", sessionToken: token, featureFlags: flags, fonts: [])
+        XCTAssertEqual(response.sessionId, "sid")
+        XCTAssertEqual(response.sessionToken, token)
+        XCTAssertEqual(response.featureFlags, flags)
+        XCTAssertEqual(response.fonts, [])
+    }
+
+    // MARK: - Session token
+
+    func test_sessionToken_expiresAtDate_convertsFromMilliseconds() {
+        let token = TxnSessionToken(token: "t", expiresAt: 1_774_474_053_000)
+        XCTAssertEqual(token.expiresAtDate, Date(timeIntervalSince1970: 1_774_474_053))
+    }
+
+    // MARK: - Feature flag accessors
+
+    func test_featureFlags_typedAccessors() throws {
+        let flags = try decode(happyPathJSON).featureFlags
+        XCTAssertEqual(flags.bool(forKey: "rokt-tracking-status"), true)
+        XCTAssertEqual(flags.bool(forKey: "ios-sdk-use-font-register-with-url"), false)
+        XCTAssertEqual(flags.int(forKey: "client-timeout-ms"), 30000)
+        XCTAssertEqual(flags.string(forKey: "minimum-post-purchase-schema"), "2.3.0")
+    }
+
+    func test_featureFlags_accessor_typeMismatchReturnsNil() throws {
+        let flags = try decode(happyPathJSON).featureFlags
+        XCTAssertNil(flags.bool(forKey: "client-timeout-ms"))
+        XCTAssertNil(flags.int(forKey: "rokt-tracking-status"))
+        XCTAssertNil(flags.string(forKey: "is-post-purchase-enabled"))
+        XCTAssertNil(flags.bool(forKey: "does-not-exist"))
+    }
+
+    func test_featureFlagValue_decodesFractionalNumberAsDouble() throws {
+        let json = """
+        {
+            "session_id": "s",
+            "session_token": { "token": "t", "expires_at": 1 },
+            "feature_flags": { "some-ratio": 1.5 }
+        }
+        """
+        let flags = try decode(json).featureFlags
+        XCTAssertEqual(flags.flags["some-ratio"], .double(1.5))
+    }
+
+    func test_featureFlagValue_unsupportedType_isSkipped() throws {
+        let json = """
+        {
+            "session_id": "s",
+            "session_token": { "token": "t", "expires_at": 1 },
+            "feature_flags": { "weird": { "nested": 1 } }
+        }
+        """
+        let flags = try decode(json).featureFlags
+        XCTAssertTrue(flags.flags.isEmpty)
+    }
+
+    func test_featureFlags_unsupportedValue_keepsKnownFlags() throws {
+        let json = """
+        {
+            "session_id": "s",
+            "session_token": { "token": "t", "expires_at": 1 },
+            "feature_flags": {
+                "rokt-tracking-status": true,
+                "client-timeout-ms": 30000,
+                "future-array-flag": [1, 2, 3],
+                "future-object-flag": { "nested": true },
+                "future-null-flag": null
+            }
+        }
+        """
+        let flags = try decode(json).featureFlags
+        XCTAssertEqual(flags.bool(forKey: "rokt-tracking-status"), true)
+        XCTAssertEqual(flags.int(forKey: "client-timeout-ms"), 30000)
+        XCTAssertNil(flags.flags["future-array-flag"])
+        XCTAssertNil(flags.flags["future-object-flag"])
+        XCTAssertNil(flags.flags["future-null-flag"])
+        XCTAssertEqual(flags.flags.count, 2)
+    }
+
+    // MARK: - Fonts
+
+    func test_decode_fonts_populated() throws {
+        let json = """
+        {
+            "session_id": "s",
+            "session_token": { "token": "t", "expires_at": 1 },
+            "feature_flags": {},
+            "fonts": [
+                {
+                    "font_name": "Inter-Regular",
+                    "font_url": "https://example.test/inter.woff2",
+                    "font_style": "normal",
+                    "font_weight": "400",
+                    "font_post_script_name": "Inter-Regular"
+                }
+            ]
+        }
+        """
+        let font = try XCTUnwrap(try decode(json).fonts.first)
+        XCTAssertEqual(font.fontName, "Inter-Regular")
+        XCTAssertEqual(font.fontURL, "https://example.test/inter.woff2")
+        XCTAssertEqual(font.fontStyle, "normal")
+        XCTAssertEqual(font.fontWeight, "400")
+        XCTAssertEqual(font.fontPostScriptName, "Inter-Regular")
+    }
+
+    // MARK: - Resilience
+
+    func test_decode_missingFeatureFlagsAndFonts_defaultsToEmpty() throws {
+        let json = """
+        {
+            "session_id": "s",
+            "session_token": { "token": "t", "expires_at": 1 }
+        }
+        """
+        let response = try decode(json)
+        XCTAssertTrue(response.featureFlags.flags.isEmpty)
+        XCTAssertEqual(response.fonts, [])
+    }
+
+    func test_decode_missingSessionToken_throws() {
+        let json = """
+        { "session_id": "s", "feature_flags": {}, "fonts": [] }
+        """
+        XCTAssertThrowsError(try decode(json))
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

## Background

- We are adding support for the v2 init endpoint. This PR adds the response models for that endpoint to the shared ux-helper, so they can be reused across platforms.

## What Has Changed

- Added the v2 init response wire models as **public, additive** API: `TxnInitResponse`, `TxnSessionToken`, `TxnFontItem`, `TxnFeatureFlagValue`, and `TxnFeatureFlags`.
- Models are `Decodable` + `Equatable` with snake_case `CodingKeys`, tolerant decoding (absent `feature_flags`/`fonts` default to empty, unmodeled flag value types are skipped), public memberwise inits, and typed accessors (`bool/int/string(forKey:)`).
- Added unit tests covering decode, ms→`Date` expiry, typed accessors with type-mismatch handling, tolerant defaults, and the missing-`session_token` error path.

## Screenshots/Video

- {Include any screenshots or video demonstrating the new feature or fix, if applicable}

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- {Any additional information or context relevant to this PR}

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes [ticket](https://go/j/[ticket-number])
