### PR TITLE
feat(parse): add pre-parsed experience rendering

### DIFF
--- a/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "76dfd71c4977dba3d21b217714aa06d90676a280846f4cb16698ae1acf6c4e31",
+  "originHash" : "5776a0a3a8ab92b75220f512aea8aeb25171c9ae7f7d323bc37fe03b05098f57",
   "pins" : [
     {
       "identity" : "dcui-swift-schema",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ROKT/dcui-swift-schema.git",
       "state" : {
-        "revision" : "4f7a71eca08710d8f3a5d624b7fffe3bf1a265c6",
-        "version" : "2.8.0"
+        "revision" : "1e69ee148840e67e658c57f001d8fa0017278f06",
+        "version" : "2.8.1"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ROKT/dcui-swift-schema.git",
       "state" : {
-        "revision" : "4f7a71eca08710d8f3a5d624b7fffe3bf1a265c6",
-        "version" : "2.8.0"
+        "revision" : "1e69ee148840e67e658c57f001d8fa0017278f06",
+        "version" : "2.8.1"
       }
     },
     {

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/RoktUXParseResult.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/RoktUXParseResult.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// The result of parsing an experience response via ``RoktUX/parseExperience(_:)``.
+///
+/// Carries the decoded page model alongside the parse window so hosts can reuse the
+/// model for rendering (avoiding a second decode) and report JSON parse timing metrics.
+public struct RoktUXParseResult {
+    /// The session identifier from the experience response. Available whenever the
+    /// response decodes successfully, even if it contains no renderable layouts.
+    public let sessionId: String
+    /// The page identifier from the experience response, when present.
+    public let pageId: String?
+    /// The decoded page model, ready to be rendered via `loadLayout(pageModel:)`.
+    /// `nil` when the response decodes but contains no renderable layouts.
+    public let pageModel: RoktUXPageModel?
+    /// The moment decoding of the experience response started.
+    public let parseStart: Date
+    /// The moment decoding of the experience response finished.
+    public let parseEnd: Date
+}

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/RoktUXParseResult.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/RoktUXParseResult.swift
@@ -1,9 +1,14 @@
 import Foundation
 
+/// Internal, for rokt-sdk-ios.
 /// The result of parsing an experience response via ``RoktUX/parseExperience(_:)``.
 ///
-/// Carries the decoded page model alongside the parse window so hosts can reuse the
-/// model for rendering (avoiding a second decode) and report JSON parse timing metrics.
+/// Carries the decoded page model alongside the parse window so the Rokt SDK can reuse
+/// the model for rendering (avoiding a second decode) and report JSON parse timing metrics.
+///
+/// > Important: This type is intended for use by the Rokt mobile SDK. It is `public` only
+/// > so the SDK can consume it across the module boundary; it is not a supported public
+/// > integration API and may change without notice.
 public struct RoktUXParseResult {
     /// The session identifier from the experience response. Available whenever the
     /// response decodes successfully, even if it contains no renderable layouts.

--- a/Sources/RoktUXHelper/RoktUX.swift
+++ b/Sources/RoktUXHelper/RoktUX.swift
@@ -233,13 +233,11 @@ public class RoktUX: UXEventsDelegate {
         RoktUXLogger.shared.verbose("loadLayout called with pre-parsed page model")
         let processor = EventProcessor(integrationType: .sdk,
                                        onRoktPlatformEvent: onRoktPlatformEvent)
-        let responseReceivedDate = Self.preParsedResponseReceivedDate(pageModel: pageModel,
-                                                                      startDate: startDate)
 
         sendPageIntialEvents(
             pageModel: pageModel,
             startDate: startDate,
-            responseReceivedDate: responseReceivedDate,
+            responseReceivedDate: pageModel.responseReceivedDate,
             processor: processor
         )
 
@@ -255,7 +253,6 @@ public class RoktUX: UXEventsDelegate {
             defaultLayoutLoader: defaultLayoutLoader,
             layoutLoaders: layoutLoaders,
             config: config,
-            responseReceivedDate: responseReceivedDate,
             onLoad: {},
             onUnload: {},
             onEmbeddedSizeChange: onEmbeddedSizeChange,
@@ -263,10 +260,6 @@ public class RoktUX: UXEventsDelegate {
             onPluginViewStateChange: onPluginViewStateChange,
             processor: processor
         )
-    }
-
-    static func preParsedResponseReceivedDate(pageModel: RoktUXPageModel, startDate: Date) -> Date {
-        max(pageModel.responseReceivedDate, startDate)
     }
 
     /**
@@ -394,7 +387,6 @@ public class RoktUX: UXEventsDelegate {
         defaultLayoutLoader: LayoutLoader?,
         layoutLoaders: [String: LayoutLoader?]?,
         config: RoktUXConfig?,
-        responseReceivedDate: Date? = nil,
         onLoad: @escaping (() -> Void),
         onUnload: @escaping (() -> Void),
         onEmbeddedSizeChange: @escaping (String, CGFloat) -> Void,
@@ -403,7 +395,6 @@ public class RoktUX: UXEventsDelegate {
         processor: EventProcessing
     ) {
         if let layoutPlugins = page.layoutPlugins {
-            let layoutResponseReceivedDate = responseReceivedDate ?? page.responseReceivedDate
             RoktUXLogger.shared.info("Processing \(layoutPlugins.count) layout plugin(s)")
             for layoutPlugin in layoutPlugins {
                 let layoutLoader = defaultLayoutLoader ?? layoutLoaders?
@@ -416,7 +407,7 @@ public class RoktUX: UXEventsDelegate {
                     layoutPlugin: layoutPlugin,
                     layoutPluginViewState: layoutPluginViewState,
                     startDate: startDate,
-                    responseReceivedDate: layoutResponseReceivedDate,
+                    responseReceivedDate: page.responseReceivedDate,
                     layoutLoader: layoutLoader,
                     config: config,
                     onLoad: onLoad,

--- a/Sources/RoktUXHelper/RoktUX.swift
+++ b/Sources/RoktUXHelper/RoktUX.swift
@@ -133,37 +133,20 @@ public class RoktUX: UXEventsDelegate {
                                                    experienceResponse: experienceResponse,
                                                    processor: processor)
 
-            if let layoutPlugins = layoutPage.layoutPlugins {
-                RoktUXLogger.shared.info("Processing \(layoutPlugins.count) layout plugin(s)")
-                for layoutPlugin in layoutPlugins {
-                    let layoutLoader = defaultLayoutLoader ?? layoutLoaders?
-                        .first { $0.key == layoutPlugin.targetElementSelector }?
-                        .value
-                    let layoutPluginViewState = layoutPluginViewStates?
-                        .first { viewState in viewState.pluginId == layoutPlugin.pluginId }
-                    displayLayout(
-                        page: layoutPage,
-                        layoutPlugin: layoutPlugin,
-                        layoutPluginViewState: layoutPluginViewState,
-                        startDate: startDate,
-                        responseReceivedDate: layoutPage.responseReceivedDate,
-                        layoutLoader: layoutLoader,
-                        config: config,
-                        onLoad: onLoad,
-                        onUnload: onUnload,
-                        onEmbeddedSizeChange: onEmbeddedSizeChange,
-                        onRoktUXEvent: onRoktUXEvent,
-                        onPluginViewStateChange: onPluginViewStateChange,
-                        processor: processor
-                    )
-                }
-            } else {
-                sendDiagnostics(code: kAPIExecuteErrorCode,
-                                callStack: kEmptyResponse,
-                                processor: processor)
-                RoktUXLogger.shared.warning("No layouts found in experience response")
-                onRoktUXEvent(RoktUXEvent.LayoutFailure(layoutId: nil))
-            }
+            displayLayoutPlugins(
+                page: layoutPage,
+                startDate: startDate,
+                layoutPluginViewStates: layoutPluginViewStates,
+                defaultLayoutLoader: defaultLayoutLoader,
+                layoutLoaders: layoutLoaders,
+                config: config,
+                onLoad: onLoad,
+                onUnload: onUnload,
+                onEmbeddedSizeChange: onEmbeddedSizeChange,
+                onRoktUXEvent: onRoktUXEvent,
+                onPluginViewStateChange: onPluginViewStateChange,
+                processor: processor
+            )
         } catch {
             sendDiagnostics(code: kValidationErrorCode,
                             callStack: error.localizedDescription,
@@ -171,6 +154,101 @@ public class RoktUX: UXEventsDelegate {
             RoktUXLogger.shared.error("Failed to parse experience response", error: error)
             onRoktUXEvent(RoktUXEvent.LayoutFailure(layoutId: nil))
         }
+    }
+
+    /**
+     Parses (and times) an SDK experience response exactly once.
+
+     Use together with ``loadLayout(startDate:pageModel:layoutPluginViewStates:defaultLayoutLoader:layoutLoaders:config:onLoad:onUnload:onEmbeddedSizeChange:onRoktUXEvent:onRoktPlatformEvent:onPluginViewStateChange:)``
+     to avoid decoding the experience response a second time when rendering.
+
+     - Parameter experienceResponse: The raw experience response JSON string.
+     - Returns: A ``RoktUXParseResult`` containing the session/page identifiers, the decoded
+       page model (`nil` when the response has no renderable layouts) and the parse
+       start/end timestamps, or `nil` if the response cannot be decoded.
+     */
+    public static func parseExperience(_ experienceResponse: String) -> RoktUXParseResult? {
+        let parseStart = Date()
+        guard let response = try? RoktDecoder()
+            .decode(RoktUXExperienceResponse.self, experienceResponse)
+        else {
+            return nil
+        }
+        let pageModel = response.getPageModel()
+        let parseEnd = Date()
+        return RoktUXParseResult(
+            sessionId: response.sessionId,
+            pageId: pageModel?.pageId ?? response.page?.pageId,
+            pageModel: pageModel,
+            parseStart: parseStart,
+            parseEnd: parseEnd
+        )
+    }
+
+    /**
+     Loads and displays the layout from a pre-parsed page model, skipping the decode step.
+
+     Use together with ``parseExperience(_:)`` so the experience response is parsed exactly once.
+     Page initial events are sent from here so event semantics match the
+     `loadLayout(experienceResponse:)` overloads.
+
+     - Parameters:
+       - startDate: The start date for the process. Default is current date.
+       - pageModel: A page model previously produced by ``parseExperience(_:)``.
+       - layoutPluginViewStates: Plugin view states ([RoktPluginViewState]) to be restored.
+       - defaultLayoutLoader: Default loader for the layout.
+       - layoutLoaders: A dictionary mapping layout element selectors to their loaders.
+       - config: Configuration for the RoktUX.
+       - onLoad: Closure to handle the loading process.
+       - onUnload: Closure to handle the unloading process.
+       - onEmbeddedSizeChange: Closure to handle changes in embedded layout size.
+       - onRoktUXEvent: Closure to handle RoktUX events.
+       - onRoktPlatformEvent: Closure to handle platform events. Platform events are an essential part of integration and it has to be sent to Rokt via your backend.
+            For ease of use, platformEvent is defined as [String: Any]
+       - onPluginViewStateChange: Closure to handle changes to the RoktPluginViewState.
+     */
+    public func loadLayout(
+        startDate: Date = Date(),
+        pageModel: RoktUXPageModel,
+        layoutPluginViewStates: [RoktPluginViewState]? = nil,
+        defaultLayoutLoader: LayoutLoader? = nil,
+        layoutLoaders: [String: LayoutLoader?]? = nil,
+        config: RoktUXConfig? = nil,
+        onLoad: @escaping (() -> Void),
+        onUnload: @escaping (() -> Void),
+        onEmbeddedSizeChange: @escaping (String, CGFloat) -> Void,
+        onRoktUXEvent: @escaping (RoktUXEvent) -> Void,
+        onRoktPlatformEvent: @escaping ([String: Any]) -> Void,
+        onPluginViewStateChange: @escaping (RoktPluginViewState) -> Void
+    ) {
+        if let configLogLevel = config?.logLevel, configLogLevel != .none {
+            RoktUXLogger.shared.logLevel = configLogLevel
+        }
+        RoktUXLogger.shared.verbose("loadLayout called with pre-parsed page model")
+        let processor = EventProcessor(integrationType: .sdk,
+                                       onRoktPlatformEvent: onRoktPlatformEvent)
+
+        sendPageIntialEvents(
+            pageModel: pageModel,
+            startDate: startDate,
+            responseReceivedDate: pageModel.responseReceivedDate,
+            processor: processor
+        )
+
+        displayLayoutPlugins(
+            page: pageModel,
+            startDate: startDate,
+            layoutPluginViewStates: layoutPluginViewStates,
+            defaultLayoutLoader: defaultLayoutLoader,
+            layoutLoaders: layoutLoaders,
+            config: config,
+            onLoad: onLoad,
+            onUnload: onUnload,
+            onEmbeddedSizeChange: onEmbeddedSizeChange,
+            onRoktUXEvent: onRoktUXEvent,
+            onPluginViewStateChange: onPluginViewStateChange,
+            processor: processor
+        )
     }
 
     /**
@@ -286,6 +364,56 @@ public class RoktUX: UXEventsDelegate {
             processor: processor
         )
         return layoutPage
+    }
+
+    /// Displays every layout plugin on the given page (SDK integration shape).
+    /// Shared by `loadLayout(experienceResponse:)` and `loadLayout(pageModel:)` so the
+    /// pre-parsed path renders identically without re-decoding.
+    private func displayLayoutPlugins(
+        page: RoktUXPageModel,
+        startDate: Date,
+        layoutPluginViewStates: [RoktPluginViewState]?,
+        defaultLayoutLoader: LayoutLoader?,
+        layoutLoaders: [String: LayoutLoader?]?,
+        config: RoktUXConfig?,
+        onLoad: @escaping (() -> Void),
+        onUnload: @escaping (() -> Void),
+        onEmbeddedSizeChange: @escaping (String, CGFloat) -> Void,
+        onRoktUXEvent: @escaping (RoktUXEvent) -> Void,
+        onPluginViewStateChange: @escaping (RoktPluginViewState) -> Void,
+        processor: EventProcessing
+    ) {
+        if let layoutPlugins = page.layoutPlugins {
+            RoktUXLogger.shared.info("Processing \(layoutPlugins.count) layout plugin(s)")
+            for layoutPlugin in layoutPlugins {
+                let layoutLoader = defaultLayoutLoader ?? layoutLoaders?
+                    .first { $0.key == layoutPlugin.targetElementSelector }?
+                    .value
+                let layoutPluginViewState = layoutPluginViewStates?
+                    .first { viewState in viewState.pluginId == layoutPlugin.pluginId }
+                displayLayout(
+                    page: page,
+                    layoutPlugin: layoutPlugin,
+                    layoutPluginViewState: layoutPluginViewState,
+                    startDate: startDate,
+                    responseReceivedDate: page.responseReceivedDate,
+                    layoutLoader: layoutLoader,
+                    config: config,
+                    onLoad: onLoad,
+                    onUnload: onUnload,
+                    onEmbeddedSizeChange: onEmbeddedSizeChange,
+                    onRoktUXEvent: onRoktUXEvent,
+                    onPluginViewStateChange: onPluginViewStateChange,
+                    processor: processor
+                )
+            }
+        } else {
+            sendDiagnostics(code: kAPIExecuteErrorCode,
+                            callStack: kEmptyResponse,
+                            processor: processor)
+            RoktUXLogger.shared.warning("No layouts found in experience response")
+            onRoktUXEvent(RoktUXEvent.LayoutFailure(layoutId: nil))
+        }
     }
 
     private func displayLayout(

--- a/Sources/RoktUXHelper/RoktUX.swift
+++ b/Sources/RoktUXHelper/RoktUX.swift
@@ -159,8 +159,12 @@ public class RoktUX: UXEventsDelegate {
     /**
      Parses (and times) an SDK experience response exactly once.
 
-     Use together with ``loadLayout(startDate:pageModel:layoutPluginViewStates:defaultLayoutLoader:layoutLoaders:config:onLoad:onUnload:onEmbeddedSizeChange:onRoktUXEvent:onRoktPlatformEvent:onPluginViewStateChange:)``
+     Use together with ``loadLayout(startDate:pageModel:layoutPluginViewStates:defaultLayoutLoader:layoutLoaders:config:onEmbeddedSizeChange:onRoktUXEvent:onRoktPlatformEvent:onPluginViewStateChange:)``
      to avoid decoding the experience response a second time when rendering.
+
+     > Important: Intended for use by the Rokt mobile SDK. It is `public` only so the SDK
+     > can call it across the module boundary; it is not a supported public integration
+     > entry point and may change without notice.
 
      - Parameter experienceResponse: The raw experience response JSON string.
      - Returns: A ``RoktUXParseResult`` containing the session/page identifiers, the decoded
@@ -192,6 +196,12 @@ public class RoktUX: UXEventsDelegate {
      Page initial events are sent from here so event semantics match the
      `loadLayout(experienceResponse:)` overloads.
 
+     > Important: Intended for use by the Rokt mobile SDK. It is `public` only so the SDK
+     > can call it across the module boundary; it is not a supported public integration
+     > entry point and may change without notice. Placement load/unload is observed via the
+     > `RoktUXEvent` stream (`LayoutInteractive` / `LayoutClosed` / `LayoutCompleted` /
+     > `LayoutFailure`), which is why this overload takes no `onLoad`/`onUnload` closures.
+
      - Parameters:
        - startDate: The start date for the process. Default is current date.
        - pageModel: A page model previously produced by ``parseExperience(_:)``.
@@ -199,8 +209,6 @@ public class RoktUX: UXEventsDelegate {
        - defaultLayoutLoader: Default loader for the layout.
        - layoutLoaders: A dictionary mapping layout element selectors to their loaders.
        - config: Configuration for the RoktUX.
-       - onLoad: Closure to handle the loading process.
-       - onUnload: Closure to handle the unloading process.
        - onEmbeddedSizeChange: Closure to handle changes in embedded layout size.
        - onRoktUXEvent: Closure to handle RoktUX events.
        - onRoktPlatformEvent: Closure to handle platform events. Platform events are an essential part of integration and it has to be sent to Rokt via your backend.
@@ -214,8 +222,6 @@ public class RoktUX: UXEventsDelegate {
         defaultLayoutLoader: LayoutLoader? = nil,
         layoutLoaders: [String: LayoutLoader?]? = nil,
         config: RoktUXConfig? = nil,
-        onLoad: @escaping (() -> Void),
-        onUnload: @escaping (() -> Void),
         onEmbeddedSizeChange: @escaping (String, CGFloat) -> Void,
         onRoktUXEvent: @escaping (RoktUXEvent) -> Void,
         onRoktPlatformEvent: @escaping ([String: Any]) -> Void,
@@ -227,14 +233,21 @@ public class RoktUX: UXEventsDelegate {
         RoktUXLogger.shared.verbose("loadLayout called with pre-parsed page model")
         let processor = EventProcessor(integrationType: .sdk,
                                        onRoktPlatformEvent: onRoktPlatformEvent)
+        let responseReceivedDate = Self.preParsedResponseReceivedDate(pageModel: pageModel,
+                                                                      startDate: startDate)
 
         sendPageIntialEvents(
             pageModel: pageModel,
             startDate: startDate,
-            responseReceivedDate: pageModel.responseReceivedDate,
+            responseReceivedDate: responseReceivedDate,
             processor: processor
         )
 
+        // This pre-parsed (SDK-only) overload takes no onLoad/onUnload closures.
+        // Placement load/unload is observed by the consumer through the RoktUXEvent
+        // stream (LayoutInteractive / LayoutClosed / LayoutCompleted / LayoutFailure),
+        // which fire independently of these view-lifecycle hooks. No-ops are passed so
+        // the shared rendering path (still used by the string-based overloads) is unchanged.
         displayLayoutPlugins(
             page: pageModel,
             startDate: startDate,
@@ -242,13 +255,18 @@ public class RoktUX: UXEventsDelegate {
             defaultLayoutLoader: defaultLayoutLoader,
             layoutLoaders: layoutLoaders,
             config: config,
-            onLoad: onLoad,
-            onUnload: onUnload,
+            responseReceivedDate: responseReceivedDate,
+            onLoad: {},
+            onUnload: {},
             onEmbeddedSizeChange: onEmbeddedSizeChange,
             onRoktUXEvent: onRoktUXEvent,
             onPluginViewStateChange: onPluginViewStateChange,
             processor: processor
         )
+    }
+
+    static func preParsedResponseReceivedDate(pageModel: RoktUXPageModel, startDate: Date) -> Date {
+        max(pageModel.responseReceivedDate, startDate)
     }
 
     /**
@@ -376,6 +394,7 @@ public class RoktUX: UXEventsDelegate {
         defaultLayoutLoader: LayoutLoader?,
         layoutLoaders: [String: LayoutLoader?]?,
         config: RoktUXConfig?,
+        responseReceivedDate: Date? = nil,
         onLoad: @escaping (() -> Void),
         onUnload: @escaping (() -> Void),
         onEmbeddedSizeChange: @escaping (String, CGFloat) -> Void,
@@ -384,6 +403,7 @@ public class RoktUX: UXEventsDelegate {
         processor: EventProcessing
     ) {
         if let layoutPlugins = page.layoutPlugins {
+            let layoutResponseReceivedDate = responseReceivedDate ?? page.responseReceivedDate
             RoktUXLogger.shared.info("Processing \(layoutPlugins.count) layout plugin(s)")
             for layoutPlugin in layoutPlugins {
                 let layoutLoader = defaultLayoutLoader ?? layoutLoaders?
@@ -396,7 +416,7 @@ public class RoktUX: UXEventsDelegate {
                     layoutPlugin: layoutPlugin,
                     layoutPluginViewState: layoutPluginViewState,
                     startDate: startDate,
-                    responseReceivedDate: page.responseReceivedDate,
+                    responseReceivedDate: layoutResponseReceivedDate,
                     layoutLoader: layoutLoader,
                     config: config,
                     onLoad: onLoad,

--- a/Tests/RoktUXHelperTests/RoktUXParseExperienceTests.swift
+++ b/Tests/RoktUXHelperTests/RoktUXParseExperienceTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+import SwiftUI
+@testable import RoktUXHelper
+
+@available(iOS 15, *)
+final class RoktUXParseExperienceTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Builds an SDK-shaped experience response embedding the given plugins JSON.
+    private func makeExperienceResponse(
+        sessionId: String = "test-session-id",
+        pageId: String? = "test-page-id",
+        pluginsJSON: String = "[]"
+    ) -> String {
+        let page = pageId.map { #""page": {"pageId": "\#($0)"},"# } ?? ""
+        return """
+        {
+          "sessionId": "\(sessionId)",
+          \(page)
+          "placementContext": {
+            "roktTagId": "123",
+            "pageInstanceGuid": "test-page-instance-guid",
+            "token": "context-token"
+          },
+          "placements": [],
+          "token": "",
+          "plugins": \(pluginsJSON)
+        }
+        """
+    }
+
+    /// Extracts the plugins array (with a complete layout schema) from the
+    /// embedded one-by-one fixture so the SDK-shaped response renders.
+    private func pluginsFromEmbeddedFixture() throws -> String {
+        let data = ModelTestData.toData(jsonFilename: "embedded_onebyone")
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let plugins = try XCTUnwrap(json["plugins"])
+        let pluginsData = try JSONSerialization.data(withJSONObject: plugins)
+        return try XCTUnwrap(String(data: pluginsData, encoding: .utf8))
+    }
+
+    // MARK: - parseExperience
+
+    func test_parseExperience_validResponse_returnsPageModelAndParseWindow() throws {
+        let response = makeExperienceResponse(pluginsJSON: try pluginsFromEmbeddedFixture())
+
+        let result = try XCTUnwrap(RoktUX.parseExperience(response))
+
+        XCTAssertEqual(result.sessionId, "test-session-id")
+        XCTAssertEqual(result.pageId, "test-page-id")
+        let pageModel = try XCTUnwrap(result.pageModel)
+        XCTAssertEqual(pageModel.sessionId, "test-session-id")
+        XCTAssertEqual(pageModel.pageInstanceGuid, "test-page-instance-guid")
+        XCTAssertEqual(pageModel.layoutPlugins?.count, 1)
+        XCTAssertGreaterThanOrEqual(result.parseEnd, result.parseStart)
+    }
+
+    func test_parseExperience_noPlugins_returnsSessionIdWithoutPageModel() throws {
+        let response = makeExperienceResponse(pluginsJSON: "[]")
+
+        let result = try XCTUnwrap(RoktUX.parseExperience(response))
+
+        XCTAssertEqual(result.sessionId, "test-session-id")
+        XCTAssertEqual(result.pageId, "test-page-id")
+        XCTAssertNil(result.pageModel)
+        XCTAssertGreaterThanOrEqual(result.parseEnd, result.parseStart)
+    }
+
+    func test_parseExperience_missingPage_returnsNilPageId() throws {
+        let response = makeExperienceResponse(pageId: nil, pluginsJSON: "[]")
+
+        let result = try XCTUnwrap(RoktUX.parseExperience(response))
+
+        XCTAssertNil(result.pageId)
+        XCTAssertNil(result.pageModel)
+    }
+
+    func test_parseExperience_invalidJSON_returnsNil() {
+        XCTAssertNil(RoktUX.parseExperience(#"{"sessionId":}"#))
+    }
+
+    func test_parseExperience_unexpectedShape_returnsNil() {
+        XCTAssertNil(RoktUX.parseExperience(#"{"unrelated": true}"#))
+    }
+
+    // MARK: - loadLayout(pageModel:)
+
+    func test_loadLayout_withPreParsedPageModel_rendersWithoutReDecoding() throws {
+        let response = makeExperienceResponse(pluginsJSON: try pluginsFromEmbeddedFixture())
+        let pageModel = try XCTUnwrap(RoktUX.parseExperience(response)?.pageModel)
+        let sut = RoktUX()
+        let layoutLoader = MockLayoutLoader()
+
+        // The pre-parsed overload renders straight from the page model — the embedded
+        // layout reaching the loader proves the whole pipeline ran without re-decoding.
+        let loaderInvoked = expectation(description: "layout loader invoked")
+        layoutLoader.onLoad = { loaderInvoked.fulfill() }
+
+        sut.loadLayout(
+            pageModel: pageModel,
+            defaultLayoutLoader: layoutLoader,
+            onLoad: {},
+            onUnload: {},
+            onEmbeddedSizeChange: { _, _ in },
+            onRoktUXEvent: { _ in },
+            onRoktPlatformEvent: { _ in },
+            onPluginViewStateChange: { _ in }
+        )
+
+        // Generous timeout: the first layout render on a cold simulator can be slow.
+        wait(for: [loaderInvoked], timeout: 30)
+    }
+}
+
+private final class MockLayoutLoader: LayoutLoader {
+    var onLoad: (() -> Void)?
+
+    func load<Content: View>(
+        onSizeChanged: @escaping ((CGFloat) -> Void),
+        @ViewBuilder injectedView: @escaping () -> Content
+    ) {
+        onLoad?()
+    }
+
+    func updateEmbeddedSize(_ size: CGFloat) {}
+
+    func closeEmbedded() {}
+}

--- a/Tests/RoktUXHelperTests/RoktUXParseExperienceTests.swift
+++ b/Tests/RoktUXHelperTests/RoktUXParseExperienceTests.swift
@@ -109,34 +109,6 @@ final class RoktUXParseExperienceTests: XCTestCase {
         // Generous timeout: the first layout render on a cold simulator can be slow.
         wait(for: [loaderInvoked], timeout: 30)
     }
-
-    func test_preParsedResponseReceivedDate_whenParseTimeIsOlder_usesStartDate() throws {
-        let response = makeExperienceResponse(pluginsJSON: try pluginsFromEmbeddedFixture())
-        let parseResult = try XCTUnwrap(RoktUX.parseExperience(response))
-        let pageModel = try XCTUnwrap(parseResult.pageModel)
-        let renderStart = parseResult.parseEnd.addingTimeInterval(60)
-
-        let responseReceivedDate = RoktUX.preParsedResponseReceivedDate(
-            pageModel: pageModel,
-            startDate: renderStart
-        )
-
-        XCTAssertEqual(responseReceivedDate, renderStart)
-    }
-
-    func test_preParsedResponseReceivedDate_whenResponseTimeIsNewer_preservesResponseDate() throws {
-        let response = makeExperienceResponse(pluginsJSON: try pluginsFromEmbeddedFixture())
-        let parseResult = try XCTUnwrap(RoktUX.parseExperience(response))
-        let pageModel = try XCTUnwrap(parseResult.pageModel)
-        let renderStart = parseResult.parseStart.addingTimeInterval(-60)
-
-        let responseReceivedDate = RoktUX.preParsedResponseReceivedDate(
-            pageModel: pageModel,
-            startDate: renderStart
-        )
-
-        XCTAssertEqual(responseReceivedDate, pageModel.responseReceivedDate)
-    }
 }
 
 private final class MockLayoutLoader: LayoutLoader {

--- a/Tests/RoktUXHelperTests/RoktUXParseExperienceTests.swift
+++ b/Tests/RoktUXHelperTests/RoktUXParseExperienceTests.swift
@@ -100,8 +100,6 @@ final class RoktUXParseExperienceTests: XCTestCase {
         sut.loadLayout(
             pageModel: pageModel,
             defaultLayoutLoader: layoutLoader,
-            onLoad: {},
-            onUnload: {},
             onEmbeddedSizeChange: { _, _ in },
             onRoktUXEvent: { _ in },
             onRoktPlatformEvent: { _ in },
@@ -110,6 +108,34 @@ final class RoktUXParseExperienceTests: XCTestCase {
 
         // Generous timeout: the first layout render on a cold simulator can be slow.
         wait(for: [loaderInvoked], timeout: 30)
+    }
+
+    func test_preParsedResponseReceivedDate_whenParseTimeIsOlder_usesStartDate() throws {
+        let response = makeExperienceResponse(pluginsJSON: try pluginsFromEmbeddedFixture())
+        let parseResult = try XCTUnwrap(RoktUX.parseExperience(response))
+        let pageModel = try XCTUnwrap(parseResult.pageModel)
+        let renderStart = parseResult.parseEnd.addingTimeInterval(60)
+
+        let responseReceivedDate = RoktUX.preParsedResponseReceivedDate(
+            pageModel: pageModel,
+            startDate: renderStart
+        )
+
+        XCTAssertEqual(responseReceivedDate, renderStart)
+    }
+
+    func test_preParsedResponseReceivedDate_whenResponseTimeIsNewer_preservesResponseDate() throws {
+        let response = makeExperienceResponse(pluginsJSON: try pluginsFromEmbeddedFixture())
+        let parseResult = try XCTUnwrap(RoktUX.parseExperience(response))
+        let pageModel = try XCTUnwrap(parseResult.pageModel)
+        let renderStart = parseResult.parseStart.addingTimeInterval(-60)
+
+        let responseReceivedDate = RoktUX.preParsedResponseReceivedDate(
+            pageModel: pageModel,
+            startDate: renderStart
+        )
+
+        XCTAssertEqual(responseReceivedDate, pageModel.responseReceivedDate)
     }
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- Hosts that need to inspect or time an SDK experience response before rendering currently have to decode it separately from `loadLayout`, which causes duplicate parsing work. This change exposes a parsed result that can be reused for rendering while preserving the existing layout loading behavior.

## What Has Changed

- Added `RoktUX.parseExperience(_:)` to decode an SDK experience response and return session, page, parsed page model, and parse timing details.
- Added a `loadLayout(pageModel:)` overload so callers can render a previously parsed experience without decoding the response again.
- Shared the SDK layout plugin rendering path between the existing response-based load method and the new pre-parsed page model method.
- Added unit coverage for valid parse results, empty plugin responses, invalid responses, and rendering from a pre-parsed page model.
- Updated Swift package resolved pins to match the declared `dcui-swift-schema` dependency version.

## Screenshots/Video

- N/A - no visual changes.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Local tests were run on the available `iPhone 16` simulator with iOS 18.6 because the documented `OS:latest` destination did not resolve on this machine.
