### PR TITLE
feat(txn): add v2 offers selection-response models

### DIFF
--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectJSONValue.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectJSONValue.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// A minimal opaque JSON value, used for v2 selection-response fields the
+/// renderer does not (yet) consume in a typed way — `catalog_items` and the
+/// per-entity `event_data.events` payloads. This is the iOS analog of Android's
+/// `JsonObject` / `JsonElement`: it round-trips arbitrary JSON without imposing
+/// a schema.
+enum SelectJSONValue: Decodable, Equatable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case object([String: SelectJSONValue])
+    case array([SelectJSONValue])
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([SelectJSONValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode([String: SelectJSONValue].self) {
+            self = .object(value)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unsupported JSON value in v2 selection response"
+            )
+        }
+    }
+}
+
+extension SelectJSONValue {
+    /// Convenience accessor for the value at a key when this is a JSON object.
+    subscript(key: String) -> SelectJSONValue? {
+        guard case let .object(dictionary) = self else { return nil }
+        return dictionary[key]
+    }
+
+    /// The underlying string when this value is a `.string`, otherwise `nil`.
+    var stringValue: String? {
+        guard case let .string(value) = self else { return nil }
+        return value
+    }
+}

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectJSONValue.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectJSONValue.swift
@@ -2,9 +2,8 @@ import Foundation
 
 /// A minimal opaque JSON value, used for v2 selection-response fields the
 /// renderer does not (yet) consume in a typed way — `catalog_items` and the
-/// per-entity `event_data.events` payloads. This is the iOS analog of Android's
-/// `JsonObject` / `JsonElement`: it round-trips arbitrary JSON without imposing
-/// a schema.
+/// per-entity `event_data.events` payloads. It round-trips arbitrary JSON
+/// without imposing a schema.
 enum SelectJSONValue: Decodable, Equatable {
     case string(String)
     case number(Double)

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectResponse.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectResponse.swift
@@ -7,8 +7,7 @@ import DcuiSchema
 /// `LayoutSchemaModel` (the SDK-side wire model keeps the same fields as raw
 /// strings instead).
 ///
-/// This is the iOS port of the Android `SelectResponse` (rokt-ux-helper-android
-/// PR #275). It is response-side only and not yet wired into rendering.
+/// It is response-side only and not yet wired into rendering.
 @available(iOS 13, *)
 struct SelectResponse: Decodable {
     let sessionId: String
@@ -31,7 +30,7 @@ struct SelectResponse: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         sessionId = try container.decode(String.self, forKey: .sessionId)
         sessionToken = try container.decode(SessionToken.self, forKey: .sessionToken)
-        // Mirror Android's `= ""` default when the key is absent.
+        // Defaults to an empty string when the key is absent.
         pageInstanceGuid = try container.decodeIfPresent(String.self, forKey: .pageInstanceGuid) ?? ""
         pageContext = try container.decodeIfPresent(SelectPageContext.self, forKey: .pageContext)
         plugins = try container.decodeIfPresent([SelectPlugin].self, forKey: .plugins)
@@ -89,7 +88,7 @@ struct SelectPluginConfig: Decodable {
     let slots: [SelectSlot]
     let instanceGuid: String?
     /// Parsed from the `outer_layout_schema` JSON string into the renderer's typed
-    /// schema model. Nullable, mirroring Android.
+    /// schema model. Nullable.
     let outerLayoutSchema: OuterLayoutSchemaNetworkModel?
     let token: String?
 
@@ -102,7 +101,7 @@ struct SelectPluginConfig: Decodable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        // Android defaults `slots` to an empty list when the key is absent.
+        // Defaults `slots` to an empty list when the key is absent.
         slots = try container.decodeIfPresent([SelectSlot].self, forKey: .slots) ?? []
         instanceGuid = try container.decodeIfPresent(String.self, forKey: .instanceGuid)
         token = try container.decodeIfPresent(String.self, forKey: .token)
@@ -131,7 +130,7 @@ struct SelectLayoutVariant: Decodable {
     let layoutVariantId: String?
     let moduleName: String?
     /// Parsed from the `layout_variant_schema` JSON string into the renderer's
-    /// typed `LayoutSchemaModel`. Nullable, mirroring Android.
+    /// typed `LayoutSchemaModel`. Nullable.
     let layoutVariantSchema: LayoutSchemaModel?
 
     enum CodingKeys: String, CodingKey {
@@ -152,7 +151,7 @@ struct SelectLayoutVariant: Decodable {
 struct SelectOffer: Decodable {
     let campaignId: String?
     let creative: SelectCreative?
-    /// Opaque catalog item payloads — mirrors Android's `List<JsonObject>`.
+    /// Opaque catalog item payloads.
     let catalogItems: [SelectJSONValue]?
 
     enum CodingKeys: String, CodingKey {
@@ -221,7 +220,7 @@ struct SelectResponseOption: Decodable {
         shortLabel = try container.decodeIfPresent(String.self, forKey: .shortLabel)
         longLabel = try container.decodeIfPresent(String.self, forKey: .longLabel)
         shortSuccessLabel = try container.decodeIfPresent(String.self, forKey: .shortSuccessLabel)
-        // Android defaults `is_positive` to false when absent.
+        // Defaults `is_positive` to false when absent.
         isPositive = try container.decodeIfPresent(Bool.self, forKey: .isPositive) ?? false
         url = try container.decodeIfPresent(String.self, forKey: .url)
         ignoreBranch = try container.decodeIfPresent(Bool.self, forKey: .ignoreBranch)
@@ -246,6 +245,6 @@ struct SelectIcon: Decodable {
 
 struct SelectEventDataEntry: Decodable {
     let token: String
-    /// Opaque per-event payloads — mirrors Android's `Map<String, JsonElement>`.
+    /// Opaque per-event payloads.
     let events: [String: SelectJSONValue]?
 }

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectResponse.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectResponse.swift
@@ -1,0 +1,251 @@
+import Foundation
+import DcuiSchema
+
+/// Selection response for a v2 offers request — the model the renderer consumes,
+/// alongside the v1 ``RoktUXExperienceResponse``. The layout-schema fields are
+/// parsed into the renderer's typed ``OuterLayoutSchemaNetworkModel`` /
+/// `LayoutSchemaModel` (the SDK-side wire model keeps the same fields as raw
+/// strings instead).
+///
+/// This is the iOS port of the Android `SelectResponse` (rokt-ux-helper-android
+/// PR #275). It is response-side only and not yet wired into rendering.
+@available(iOS 13, *)
+struct SelectResponse: Decodable {
+    let sessionId: String
+    let sessionToken: SessionToken
+    let pageInstanceGuid: String
+    let pageContext: SelectPageContext?
+    let plugins: [SelectPlugin]?
+    let eventData: [String: SelectEventDataEntry]?
+
+    enum CodingKeys: String, CodingKey {
+        case sessionId = "session_id"
+        case sessionToken = "session_token"
+        case pageInstanceGuid = "page_instance_guid"
+        case pageContext = "page_context"
+        case plugins
+        case eventData = "event_data"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        sessionId = try container.decode(String.self, forKey: .sessionId)
+        sessionToken = try container.decode(SessionToken.self, forKey: .sessionToken)
+        // Mirror Android's `= ""` default when the key is absent.
+        pageInstanceGuid = try container.decodeIfPresent(String.self, forKey: .pageInstanceGuid) ?? ""
+        pageContext = try container.decodeIfPresent(SelectPageContext.self, forKey: .pageContext)
+        plugins = try container.decodeIfPresent([SelectPlugin].self, forKey: .plugins)
+        eventData = try container.decodeIfPresent([String: SelectEventDataEntry].self, forKey: .eventData)
+    }
+}
+
+/// The session token is treated as **opaque** — only the raw token string and its
+/// expiry are modelled. The JWT is deliberately NOT decoded here.
+struct SessionToken: Decodable {
+    let token: String
+    let expiresAt: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case token
+        case expiresAt = "expires_at"
+    }
+}
+
+struct SelectPageContext: Decodable {
+    let pageInstanceGuid: String?
+    let pageId: String?
+    let language: String?
+    let token: String?
+
+    enum CodingKeys: String, CodingKey {
+        case pageInstanceGuid = "page_instance_guid"
+        case pageId = "page_id"
+        case language
+        case token
+    }
+}
+
+/// Each plugin object has a single key, `plugin`, whose value is the layout.
+struct SelectPlugin: Decodable {
+    let plugin: SelectPluginLayout?
+}
+
+struct SelectPluginLayout: Decodable {
+    let id: String?
+    let name: String?
+    let targetElementSelector: String?
+    let config: SelectPluginConfig?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case targetElementSelector = "target_element_selector"
+        case config
+    }
+}
+
+@available(iOS 13, *)
+struct SelectPluginConfig: Decodable {
+    let slots: [SelectSlot]
+    let instanceGuid: String?
+    /// Parsed from the `outer_layout_schema` JSON string into the renderer's typed
+    /// schema model. Nullable, mirroring Android.
+    let outerLayoutSchema: OuterLayoutSchemaNetworkModel?
+    let token: String?
+
+    enum CodingKeys: String, CodingKey {
+        case slots
+        case instanceGuid = "instance_guid"
+        case outerLayoutSchema = "outer_layout_schema"
+        case token
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // Android defaults `slots` to an empty list when the key is absent.
+        slots = try container.decodeIfPresent([SelectSlot].self, forKey: .slots) ?? []
+        instanceGuid = try container.decodeIfPresent(String.self, forKey: .instanceGuid)
+        token = try container.decodeIfPresent(String.self, forKey: .token)
+        outerLayoutSchema = try SelectSchemaParsing.decodeOuterLayoutSchema(from: container,
+                                                                            forKey: .outerLayoutSchema)
+    }
+}
+
+@available(iOS 13, *)
+struct SelectSlot: Decodable {
+    let instanceGuid: String?
+    let layoutVariant: SelectLayoutVariant?
+    let offer: SelectOffer?
+    let token: String?
+
+    enum CodingKeys: String, CodingKey {
+        case instanceGuid = "instance_guid"
+        case layoutVariant = "layout_variant"
+        case offer
+        case token
+    }
+}
+
+@available(iOS 13, *)
+struct SelectLayoutVariant: Decodable {
+    let layoutVariantId: String?
+    let moduleName: String?
+    /// Parsed from the `layout_variant_schema` JSON string into the renderer's
+    /// typed `LayoutSchemaModel`. Nullable, mirroring Android.
+    let layoutVariantSchema: LayoutSchemaModel?
+
+    enum CodingKeys: String, CodingKey {
+        case layoutVariantId = "layout_variant_id"
+        case moduleName = "module_name"
+        case layoutVariantSchema = "layout_variant_schema"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        layoutVariantId = try container.decodeIfPresent(String.self, forKey: .layoutVariantId)
+        moduleName = try container.decodeIfPresent(String.self, forKey: .moduleName)
+        layoutVariantSchema = try SelectSchemaParsing.decodeLayoutVariantSchema(from: container,
+                                                                                forKey: .layoutVariantSchema)
+    }
+}
+
+struct SelectOffer: Decodable {
+    let campaignId: String?
+    let creative: SelectCreative?
+    /// Opaque catalog item payloads — mirrors Android's `List<JsonObject>`.
+    let catalogItems: [SelectJSONValue]?
+
+    enum CodingKeys: String, CodingKey {
+        case campaignId = "campaign_id"
+        case creative
+        case catalogItems = "catalog_items"
+    }
+}
+
+struct SelectCreative: Decodable {
+    let referralCreativeId: String?
+    let instanceGuid: String?
+    let token: String?
+    let responseOptionsMap: [String: SelectResponseOption]?
+    let copy: [String: String]?
+    let images: [String: SelectImage]?
+    let links: [String: SelectLink]?
+    let icons: [String: SelectIcon]?
+
+    enum CodingKeys: String, CodingKey {
+        case referralCreativeId = "referral_creative_id"
+        case instanceGuid = "instance_guid"
+        case token
+        case responseOptionsMap = "response_options_map"
+        case copy
+        case images
+        case links
+        case icons
+    }
+}
+
+struct SelectResponseOption: Decodable {
+    let id: String?
+    let action: String?
+    let instanceGuid: String?
+    let token: String?
+    let signalType: String?
+    let shortLabel: String?
+    let longLabel: String?
+    let shortSuccessLabel: String?
+    let isPositive: Bool
+    let url: String?
+    let ignoreBranch: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case action
+        case instanceGuid = "instance_guid"
+        case token
+        case signalType = "signal_type"
+        case shortLabel = "short_label"
+        case longLabel = "long_label"
+        case shortSuccessLabel = "short_success_label"
+        case isPositive = "is_positive"
+        case url
+        case ignoreBranch = "ignore_branch"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(String.self, forKey: .id)
+        action = try container.decodeIfPresent(String.self, forKey: .action)
+        instanceGuid = try container.decodeIfPresent(String.self, forKey: .instanceGuid)
+        token = try container.decodeIfPresent(String.self, forKey: .token)
+        signalType = try container.decodeIfPresent(String.self, forKey: .signalType)
+        shortLabel = try container.decodeIfPresent(String.self, forKey: .shortLabel)
+        longLabel = try container.decodeIfPresent(String.self, forKey: .longLabel)
+        shortSuccessLabel = try container.decodeIfPresent(String.self, forKey: .shortSuccessLabel)
+        // Android defaults `is_positive` to false when absent.
+        isPositive = try container.decodeIfPresent(Bool.self, forKey: .isPositive) ?? false
+        url = try container.decodeIfPresent(String.self, forKey: .url)
+        ignoreBranch = try container.decodeIfPresent(Bool.self, forKey: .ignoreBranch)
+    }
+}
+
+struct SelectImage: Decodable {
+    let light: String?
+    let dark: String?
+    let alt: String?
+    let title: String?
+}
+
+struct SelectLink: Decodable {
+    let url: String?
+    let title: String?
+}
+
+struct SelectIcon: Decodable {
+    let name: String?
+}
+
+struct SelectEventDataEntry: Decodable {
+    let token: String
+    /// Opaque per-event payloads — mirrors Android's `Map<String, JsonElement>`.
+    let events: [String: SelectJSONValue]?
+}

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectSchemaParsing.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectSchemaParsing.swift
@@ -3,15 +3,14 @@ import DcuiSchema
 
 /// Helpers for decoding the v2 selection-response layout-schema fields, which
 /// arrive on the wire as JSON **strings** and are parsed into the renderer's
-/// typed schema models. This mirrors Android's `RootSchemaModelSerializer` /
-/// `NetworkLayoutSchemaSerializer`, and matches the existing v1 pattern in
+/// typed schema models. This matches the existing v1 pattern in
 /// ``LayoutVariantModel`` / `PluginConfig`.
 @available(iOS 13, *)
 enum SelectSchemaParsing {
 
     /// Decodes the `outer_layout_schema` field — a JSON string — into the typed
     /// ``OuterLayoutSchemaNetworkModel``. Returns `nil` when the field is absent
-    /// or an empty string, mirroring Android's nullable schema field.
+    /// or an empty string.
     static func decodeOuterLayoutSchema<Key: CodingKey>(
         from container: KeyedDecodingContainer<Key>,
         forKey key: Key
@@ -25,7 +24,7 @@ enum SelectSchemaParsing {
 
     /// Decodes the `layout_variant_schema` field — a JSON string — into the typed
     /// `LayoutSchemaModel`. Returns `nil` when the field is absent or an empty
-    /// string, mirroring Android's nullable schema field.
+    /// string.
     static func decodeLayoutVariantSchema<Key: CodingKey>(
         from container: KeyedDecodingContainer<Key>,
         forKey key: Key

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectSchemaParsing.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectSchemaParsing.swift
@@ -1,0 +1,39 @@
+import Foundation
+import DcuiSchema
+
+/// Helpers for decoding the v2 selection-response layout-schema fields, which
+/// arrive on the wire as JSON **strings** and are parsed into the renderer's
+/// typed schema models. This mirrors Android's `RootSchemaModelSerializer` /
+/// `NetworkLayoutSchemaSerializer`, and matches the existing v1 pattern in
+/// ``LayoutVariantModel`` / `PluginConfig`.
+@available(iOS 13, *)
+enum SelectSchemaParsing {
+
+    /// Decodes the `outer_layout_schema` field — a JSON string — into the typed
+    /// ``OuterLayoutSchemaNetworkModel``. Returns `nil` when the field is absent
+    /// or an empty string, mirroring Android's nullable schema field.
+    static func decodeOuterLayoutSchema<Key: CodingKey>(
+        from container: KeyedDecodingContainer<Key>,
+        forKey key: Key
+    ) throws -> OuterLayoutSchemaNetworkModel? {
+        guard let schemaString = try container.decodeIfPresent(String.self, forKey: key),
+              !schemaString.isEmpty,
+              let schemaData = schemaString.data(using: .utf8)
+        else { return nil }
+        return try JSONDecoder().decode(OuterLayoutSchemaNetworkModel.self, from: schemaData)
+    }
+
+    /// Decodes the `layout_variant_schema` field — a JSON string — into the typed
+    /// `LayoutSchemaModel`. Returns `nil` when the field is absent or an empty
+    /// string, mirroring Android's nullable schema field.
+    static func decodeLayoutVariantSchema<Key: CodingKey>(
+        from container: KeyedDecodingContainer<Key>,
+        forKey key: Key
+    ) throws -> LayoutSchemaModel? {
+        guard let schemaString = try container.decodeIfPresent(String.self, forKey: key),
+              !schemaString.isEmpty,
+              let schemaData = schemaString.data(using: .utf8)
+        else { return nil }
+        return try JSONDecoder().decode(LayoutSchemaModel.self, from: schemaData)
+    }
+}

--- a/Tests/RoktUXHelperTests/Data/Model/ExperienceResponse/SelectResponseTests.swift
+++ b/Tests/RoktUXHelperTests/Data/Model/ExperienceResponse/SelectResponseTests.swift
@@ -1,0 +1,145 @@
+import XCTest
+@testable import RoktUXHelper
+
+@available(iOS 15, *)
+final class SelectResponseTests: XCTestCase {
+
+    private let decoder = JSONDecoder()
+
+    func test_decodes_a_fully_populated_selection_response() throws {
+        let response = try decoder.decode(SelectResponse.self, from: Self.fullPayload)
+
+        XCTAssertEqual(response.sessionId, "session-1")
+        XCTAssertEqual(response.sessionToken.token, "token-1")
+        XCTAssertEqual(response.sessionToken.expiresAt, 1_711_038_600_000)
+        XCTAssertEqual(response.pageInstanceGuid, "page-instance-1")
+        XCTAssertEqual(response.pageContext?.pageId, "page-1")
+        XCTAssertEqual(response.pageContext?.language, "en")
+
+        let plugin = try XCTUnwrap(response.plugins?.first?.plugin)
+        XCTAssertEqual(plugin.id, "plugin-1")
+        XCTAssertEqual(plugin.name, "Layout")
+        XCTAssertEqual(plugin.targetElementSelector, "#target")
+
+        let config = try XCTUnwrap(plugin.config)
+        XCTAssertEqual(config.instanceGuid, "plugin-instance-1")
+        // Typed layout schemas are parsed by the renderer's schema models (covered by
+        // the render-model tests); this fixture omits them, so they decode as nil.
+        XCTAssertNil(config.outerLayoutSchema)
+
+        let slot = try XCTUnwrap(config.slots.first)
+        XCTAssertEqual(slot.instanceGuid, "slot-1")
+        XCTAssertEqual(slot.layoutVariant?.layoutVariantId, "variant-1")
+        XCTAssertEqual(slot.layoutVariant?.moduleName, "module-1")
+        XCTAssertNil(slot.layoutVariant?.layoutVariantSchema)
+
+        let offer = try XCTUnwrap(slot.offer)
+        XCTAssertEqual(offer.campaignId, "campaign-1")
+        XCTAssertEqual(offer.catalogItems?.count, 1)
+        XCTAssertEqual(offer.catalogItems?.first?["id"]?.stringValue, "catalog-1")
+
+        let creative = try XCTUnwrap(offer.creative)
+        XCTAssertEqual(creative.referralCreativeId, "creative-1")
+        XCTAssertEqual(creative.copy?["title"], "Hello")
+        XCTAssertEqual(creative.images?["hero"]?.light, "https://example.com/light.png")
+        XCTAssertEqual(creative.images?["hero"]?.dark, "https://example.com/dark.png")
+        XCTAssertEqual(creative.links?["privacy"]?.url, "https://example.com/privacy")
+        XCTAssertEqual(creative.icons?["close"]?.name, "close")
+
+        let responseOption = try XCTUnwrap(creative.responseOptionsMap?["positive"])
+        XCTAssertEqual(responseOption.action, "url")
+        XCTAssertEqual(responseOption.signalType, "signal-response")
+        XCTAssertEqual(responseOption.shortLabel, "Yes")
+        XCTAssertEqual(responseOption.longLabel, "Yes please")
+        XCTAssertEqual(responseOption.shortSuccessLabel, "Done")
+        XCTAssertTrue(responseOption.isPositive)
+        XCTAssertEqual(responseOption.ignoreBranch, false)
+
+        XCTAssertEqual(response.eventData?["entity-1"]?.token, "event-token")
+    }
+
+    func test_applies_defaults_and_nulls_when_optional_fields_are_omitted() throws {
+        let response = try decoder.decode(SelectResponse.self, from: Self.minimalPayload)
+
+        XCTAssertEqual(response.sessionId, "session-2")
+        XCTAssertEqual(response.pageInstanceGuid, "")
+        XCTAssertNil(response.pageContext)
+        XCTAssertNil(response.plugins)
+        XCTAssertNil(response.eventData)
+    }
+
+    func test_is_positive_defaults_to_false_when_omitted() throws {
+        let json = """
+        { "id": "ro-x", "action": "url" }
+        """.data(using: .utf8)!
+
+        let responseOption = try decoder.decode(SelectResponseOption.self, from: json)
+
+        XCTAssertFalse(responseOption.isPositive)
+        XCTAssertNil(responseOption.ignoreBranch)
+    }
+
+    // MARK: - Fixtures
+
+    private static let fullPayload = """
+    {
+      "session_id": "session-1",
+      "session_token": { "token": "token-1", "expires_at": 1711038600000 },
+      "page_instance_guid": "page-instance-1",
+      "page_context": { "page_instance_guid": "page-instance-1", "page_id": "page-1", "language": "en", "token": "ctx-token" },
+      "plugins": [
+        {
+          "plugin": {
+            "id": "plugin-1",
+            "name": "Layout",
+            "target_element_selector": "#target",
+            "config": {
+              "instance_guid": "plugin-instance-1",
+              "token": "config-token",
+              "slots": [
+                {
+                  "instance_guid": "slot-1",
+                  "token": "slot-token",
+                  "layout_variant": { "layout_variant_id": "variant-1", "module_name": "module-1" },
+                  "offer": {
+                    "campaign_id": "campaign-1",
+                    "catalog_items": [ { "id": "catalog-1" } ],
+                    "creative": {
+                      "referral_creative_id": "creative-1",
+                      "instance_guid": "creative-instance-1",
+                      "token": "creative-token",
+                      "copy": { "title": "Hello" },
+                      "images": { "hero": { "light": "https://example.com/light.png", "dark": "https://example.com/dark.png", "alt": "alt", "title": "title" } },
+                      "links": { "privacy": { "url": "https://example.com/privacy", "title": "Privacy" } },
+                      "icons": { "close": { "name": "close" } },
+                      "response_options_map": {
+                        "positive": {
+                          "id": "ro-1",
+                          "action": "url",
+                          "instance_guid": "ro-instance-1",
+                          "token": "ro-token",
+                          "signal_type": "signal-response",
+                          "short_label": "Yes",
+                          "long_label": "Yes please",
+                          "short_success_label": "Done",
+                          "is_positive": true,
+                          "url": "https://example.com/accept",
+                          "ignore_branch": false
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "event_data": { "entity-1": { "token": "event-token", "events": { "impression": {} } } }
+    }
+    """.data(using: .utf8)!
+
+    private static let minimalPayload = """
+    { "session_id": "session-2", "session_token": { "token": "token-2", "expires_at": 0 } }
+    """.data(using: .utf8)!
+}


### PR DESCRIPTION
## What

Ports the v2 offers **selection-response** Codable models from
[`rokt-ux-helper-android` PR #275](https://github.com/ROKT/rokt-ux-helper-android/pull/275)
(`SelectResponse.kt`) to the iOS UX helper. **Additive, response-side only** —
new model types + serialization tests, no renderer/consumption wiring.

## Changes

- **`SelectResponse.swift`** — `SelectResponse` and its nested types
  (`SessionToken`, `SelectPageContext`, `SelectPlugin`, `SelectPluginLayout`,
  `SelectPluginConfig`, `SelectSlot`, `SelectLayoutVariant`, `SelectOffer`,
  `SelectCreative`, `SelectResponseOption`, `SelectImage`, `SelectLink`,
  `SelectIcon`, `SelectEventDataEntry`). Snake_case `CodingKeys`; Android
  defaults preserved (`pageInstanceGuid = ""`, `slots = []`, `isPositive = false`).
- **`SelectSchemaParsing.swift`** — `outer_layout_schema` / `layout_variant_schema`
  arrive as JSON **strings** and are parsed into the renderer's typed
  `OuterLayoutSchemaNetworkModel` / `LayoutSchemaModel`, kept **nullable**
  (mirrors Android). Reuses the existing v1 string→typed decode pattern from
  `LayoutVariantModel` / `PluginConfig`.
- **`SelectJSONValue.swift`** — opaque JSON value for `catalog_items` /
  `event_data` payloads (iOS analog of Android's `JsonObject` / `JsonElement`).
- **`SelectResponseTests.swift`** — full-payload decode, omitted-field
  defaults/nulls, and `is_positive` default.

## Notes

- **`session_token` is treated as opaque** (`token` + `expiresAt` only); the JWT
  is deliberately **not** decoded.
- **Decodable-only**, matching the iOS renderer-model convention (the schema
  string fields don't cleanly re-encode), rather than Android's full round-trip.

## Testing

`SelectResponseTests` — all 3 cases pass on the iOS simulator; package compiles clean.