### PR TITLE
fix: Guard Against 0 Height Preventing Dynamic Bottom Sheet From Appe…

### DIFF
--- a/Sources/RoktUXHelper/UI/Components/Common/UIViewController+Extension.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/UIViewController+Extension.swift
@@ -35,18 +35,18 @@ extension UIViewController {
            let bottomSheetUIModel = bottomSheetUIModel {
             // Only for iOS 16+ dynamic bottomsheet
             var isOnLoadCalled = false
-            let onSizeChange = { [weak modal] size in
+            let onSizeChange = { [weak modal] (size: CGFloat) in
                 DispatchQueue.main.async {
-                    if let sheet = modal?.sheetPresentationController {
-                        sheet.animateChanges {
-                            sheet.detents = [.custom { _ in
-                                return size
-                            }]
-                        }
-                        if !isOnLoadCalled {
-                            isOnLoadCalled = true
-                            onLoad()
-                        }
+                    let detentHeight = max(size, 1)
+                    guard let sheet = modal?.sheetPresentationController else {
+                        return
+                    }
+                    sheet.animateChanges {
+                        sheet.detents = [.custom { _ in detentHeight }]
+                    }
+                    if !isOnLoadCalled {
+                        isOnLoadCalled = true
+                        onLoad()
                     }
                 }
             }
@@ -57,7 +57,10 @@ extension UIViewController {
 
             applyBottomSheetStyles(modal: modal, bottomSheetUIModel: bottomSheetUIModel)
             applyInitialDynamicBottomSheetHeight(modal: modal)
-            self.present(modal, animated: true)
+            self.present(modal, animated: true, completion: {
+                modal.view.setNeedsLayout()
+                modal.view.layoutIfNeeded()
+            })
 
         } else {
             modal.rootView = AnyView(
@@ -175,10 +178,14 @@ extension UIViewController {
 
     @available(iOS 16.0, *)
     private func applyInitialDynamicBottomSheetHeight(modal: UIHostingController<AnyView>) {
-        let zeroDetents: [UISheetPresentationController.Detent] = [.custom { _ in
-            return CGFloat(0)
-        }]
-        modal.sheetPresentationController?.detents = zeroDetents
+        // A pure zero-height custom detent can prevent the hosted SwiftUI tree from receiving
+        // a non-zero layout proposal on some OS versions. Geometry/readSize then never reaches
+        // wrap-content height, onSizeChange never runs, and impression events never fire.
+        // Start from the system medium detent so content can measure; onSizeChange then replaces
+        // detents with an exact-height custom detent.
+        guard let sheet = modal.sheetPresentationController else { return }
+        sheet.detents = [.medium()]
+        sheet.selectedDetentIdentifier = .medium
     }
 
     fileprivate static let expandedStateKey = "BottomSheetExpandedState"


### PR DESCRIPTION
## Background

- A client ran into an issue where they called `selectPlacements` and got a `PlacementReady` signal but the placement never rendered or gave a `PlacementInteractive` signal. Since it was a bottom sheet the most likely cause seemed to be starting the sheet with a zero-height custom detent which by the logic can leave the hosted SwiftUI view without a usable layout on some iOS versions, so size measurement never progresses, onSizeChange does not run, and downstream behavior (like onLoad / impressions) can fail. We were not able to reproduce but even if its just a possibility in the code we should guard against it.

## What Has Changed

- We no longer bootstrap dynamic wrap-content sheets at 0 height. We start at .medium(), let the layout measure, then snap to the exact custom detent from onSizeChange, with a post-present layout nudge and a minimum detent height of 1 to avoid reintroducing a zero-height custom detent. That breaks the failure mode where measurement and impressions never start.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes [ticket](https://go/j/[ticket-number])
