### PR TITLE
feat(txn): give v2 selection catalog_items a typed model

### DIFF
--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectCatalogItem.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectCatalogItem.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// A catalog item from a v2 offers selection response.
+/// A catalog item from an offers selection response.
 ///
 /// The transactions backend does not expose a stable catalog-item schema: the
 /// object is open (`additionalProperties: true`) and only `instance_guid` and

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectCatalogItem.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectCatalogItem.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// A catalog item from a v2 offers selection response.
+///
+/// The transactions backend does not expose a stable catalog-item schema: the
+/// object is open (`additionalProperties: true`) and only `instance_guid` and
+/// `title` are guaranteed — every other field varies by campaign type. To stay
+/// type-safe without risking decode failures as that shape changes, the
+/// guaranteed fields are surfaced as (optional) typed properties while the full
+/// payload is retained in ``raw`` so any campaign-specific field still
+/// round-trips. Decoding never fails on an unrecognised shape.
+///
+/// When the renderer starts consuming catalog items, promote the fields it needs
+/// from ``raw`` into typed (optional) properties here.
+struct SelectCatalogItem: Decodable, Equatable {
+    /// Guaranteed by the backend for every catalog item.
+    let instanceGuid: String?
+    /// Guaranteed by the backend for every catalog item.
+    let title: String?
+
+    /// The complete decoded payload, including any campaign-specific fields not
+    /// surfaced as typed properties above. Keyed by the raw (snake_case) JSON key.
+    let raw: [String: SelectJSONValue]
+
+    private enum CodingKeys: String, CodingKey {
+        case instanceGuid = "instance_guid"
+        case title
+    }
+
+    init(from decoder: Decoder) throws {
+        // Decode the whole object once so unknown/campaign-specific fields are
+        // preserved, then read the guaranteed fields back out of it. This keeps a
+        // single source of truth for the wire keys.
+        let raw = try decoder.singleValueContainer().decode([String: SelectJSONValue].self)
+        self.raw = raw
+        instanceGuid = raw[CodingKeys.instanceGuid.rawValue]?.stringValue
+        title = raw[CodingKeys.title.rawValue]?.stringValue
+    }
+}

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectCatalogItem.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectCatalogItem.swift
@@ -14,12 +14,27 @@ import Foundation
 /// from ``raw`` into typed (optional) properties here.
 struct SelectCatalogItem: Decodable, Equatable {
     /// Guaranteed by the backend for every catalog item.
+    ///
+    /// Surfaced only when the wire value is a JSON string. If the backend sends a
+    /// non-string (number, bool, or `null`) for this guaranteed field — a server
+    /// contract violation — this narrows to `nil`, indistinguishable from the
+    /// field being absent. This lossiness is deliberate: decoding never fails on
+    /// shape drift. The original, untyped value is always preserved in ``raw``, so
+    /// callers needing to observe a wrong-typed value can read ``raw`` directly.
     let instanceGuid: String?
     /// Guaranteed by the backend for every catalog item.
+    ///
+    /// See ``instanceGuid`` for the non-string narrowing behaviour: a non-string
+    /// wire value narrows to `nil` here while the original is retained in ``raw``.
     let title: String?
 
-    /// The complete decoded payload, including any campaign-specific fields not
-    /// surfaced as typed properties above. Keyed by the raw (snake_case) JSON key.
+    /// The complete decoded payload. This is the *full* object, including the
+    /// surfaced ``instanceGuid`` / ``title`` keys as well as any campaign-specific
+    /// fields — nothing is excluded. Keyed by the raw (snake_case) JSON key.
+    ///
+    /// Because the guaranteed keys remain here, ``raw`` is the canonical map:
+    /// renderers can treat it as the single source for every field, and it also
+    /// retains values the typed accessors drop (see ``instanceGuid``).
     let raw: [String: SelectJSONValue]
 
     private enum CodingKeys: String, CodingKey {
@@ -31,7 +46,14 @@ struct SelectCatalogItem: Decodable, Equatable {
         // Decode the whole object once so unknown/campaign-specific fields are
         // preserved, then read the guaranteed fields back out of it. This keeps a
         // single source of truth for the wire keys.
-        let raw = try decoder.singleValueContainer().decode([String: SelectJSONValue].self)
+        self.init(raw: try decoder.singleValueContainer().decode([String: SelectJSONValue].self))
+    }
+
+    /// Builds an item from an already-decoded JSON object. Used by ``SelectOffer``
+    /// when it decodes `catalog_items` as opaque values so it can skip non-object
+    /// elements (see ``SelectOffer`` decoding). Reads the guaranteed fields back
+    /// out of `raw`, keeping a single source of truth for the wire keys.
+    init(raw: [String: SelectJSONValue]) {
         self.raw = raw
         instanceGuid = raw[CodingKeys.instanceGuid.rawValue]?.stringValue
         title = raw[CodingKeys.title.rawValue]?.stringValue

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectCatalogItem.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectCatalogItem.swift
@@ -2,60 +2,16 @@ import Foundation
 
 /// A catalog item from an offers selection response.
 ///
-/// The transactions backend does not expose a stable catalog-item schema: the
-/// object is open (`additionalProperties: true`) and only `instance_guid` and
-/// `title` are guaranteed — every other field varies by campaign type. To stay
-/// type-safe without risking decode failures as that shape changes, the
-/// guaranteed fields are surfaced as (optional) typed properties while the full
-/// payload is retained in ``raw`` so any campaign-specific field still
-/// round-trips. Decoding never fails on an unrecognised shape.
-///
-/// When the renderer starts consuming catalog items, promote the fields it needs
-/// from ``raw`` into typed (optional) properties here.
+/// Only `instance_guid` and `title` are part of the agreed contract, so they are
+/// the only fields modelled here. Both are optional; campaign-specific fields are
+/// intentionally not surfaced. As the renderer starts consuming catalog items,
+/// add the fields it needs as typed (optional) properties here.
 struct SelectCatalogItem: Decodable, Equatable {
-    /// Guaranteed by the backend for every catalog item.
-    ///
-    /// Surfaced only when the wire value is a JSON string. If the backend sends a
-    /// non-string (number, bool, or `null`) for this guaranteed field — a server
-    /// contract violation — this narrows to `nil`, indistinguishable from the
-    /// field being absent. This lossiness is deliberate: decoding never fails on
-    /// shape drift. The original, untyped value is always preserved in ``raw``, so
-    /// callers needing to observe a wrong-typed value can read ``raw`` directly.
     let instanceGuid: String?
-    /// Guaranteed by the backend for every catalog item.
-    ///
-    /// See ``instanceGuid`` for the non-string narrowing behaviour: a non-string
-    /// wire value narrows to `nil` here while the original is retained in ``raw``.
     let title: String?
-
-    /// The complete decoded payload. This is the *full* object, including the
-    /// surfaced ``instanceGuid`` / ``title`` keys as well as any campaign-specific
-    /// fields — nothing is excluded. Keyed by the raw (snake_case) JSON key.
-    ///
-    /// Because the guaranteed keys remain here, ``raw`` is the canonical map:
-    /// renderers can treat it as the single source for every field, and it also
-    /// retains values the typed accessors drop (see ``instanceGuid``).
-    let raw: [String: SelectJSONValue]
 
     private enum CodingKeys: String, CodingKey {
         case instanceGuid = "instance_guid"
         case title
-    }
-
-    init(from decoder: Decoder) throws {
-        // Decode the whole object once so unknown/campaign-specific fields are
-        // preserved, then read the guaranteed fields back out of it. This keeps a
-        // single source of truth for the wire keys.
-        self.init(raw: try decoder.singleValueContainer().decode([String: SelectJSONValue].self))
-    }
-
-    /// Builds an item from an already-decoded JSON object. Used by ``SelectOffer``
-    /// when it decodes `catalog_items` as opaque values so it can skip non-object
-    /// elements (see ``SelectOffer`` decoding). Reads the guaranteed fields back
-    /// out of `raw`, keeping a single source of truth for the wire keys.
-    init(raw: [String: SelectJSONValue]) {
-        self.raw = raw
-        instanceGuid = raw[CodingKeys.instanceGuid.rawValue]?.stringValue
-        title = raw[CodingKeys.title.rawValue]?.stringValue
     }
 }

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectJSONValue.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectJSONValue.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// A minimal opaque JSON value, used for v2 selection-response fields the
+/// A minimal opaque JSON value, used for selection-response fields the
 /// renderer does not (yet) consume in a typed way — the campaign-specific
 /// portion of a ``SelectCatalogItem`` (``SelectCatalogItem/raw``) and the
 /// per-entity `event_data.events` payloads. It round-trips arbitrary JSON
@@ -30,7 +30,7 @@ enum SelectJSONValue: Decodable, Equatable {
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
-                debugDescription: "Unsupported JSON value in v2 selection response"
+                debugDescription: "Unsupported JSON value in selection response"
             )
         }
     }

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectJSONValue.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectJSONValue.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 /// A minimal opaque JSON value, used for v2 selection-response fields the
-/// renderer does not (yet) consume in a typed way — `catalog_items` and the
+/// renderer does not (yet) consume in a typed way — the campaign-specific
+/// portion of a ``SelectCatalogItem`` (``SelectCatalogItem/raw``) and the
 /// per-entity `event_data.events` payloads. It round-trips arbitrary JSON
 /// without imposing a schema.
 enum SelectJSONValue: Decodable, Equatable {

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectResponse.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectResponse.swift
@@ -1,8 +1,8 @@
 import Foundation
 import DcuiSchema
 
-/// Selection response for a v2 offers request — the model the renderer consumes,
-/// alongside the v1 ``RoktUXExperienceResponse``. The layout-schema fields are
+/// Selection response for an offers request — the model the renderer consumes,
+/// alongside ``RoktUXExperienceResponse``. The layout-schema fields are
 /// parsed into the renderer's typed ``OuterLayoutSchemaNetworkModel`` /
 /// `LayoutSchemaModel` (the SDK-side wire model keeps the same fields as raw
 /// strings instead).

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectResponse.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectResponse.swift
@@ -151,8 +151,7 @@ struct SelectLayoutVariant: Decodable {
 struct SelectOffer: Decodable {
     let campaignId: String?
     let creative: SelectCreative?
-    /// Opaque catalog item payloads.
-    let catalogItems: [SelectJSONValue]?
+    let catalogItems: [SelectCatalogItem]?
 
     enum CodingKeys: String, CodingKey {
         case campaignId = "campaign_id"

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectResponse.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectResponse.swift
@@ -158,6 +158,25 @@ struct SelectOffer: Decodable {
         case creative
         case catalogItems = "catalog_items"
     }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        campaignId = try container.decodeIfPresent(String.self, forKey: .campaignId)
+        creative = try container.decodeIfPresent(SelectCreative.self, forKey: .creative)
+        // Decode `catalog_items` as opaque JSON values first so a non-object element
+        // (a bare string, number, null, etc.) does not fail the whole response
+        // decode — consistent with the "never fail on shape drift" promise. Only the
+        // object-shaped elements become typed `SelectCatalogItem`s; anything else is
+        // skipped. An absent key stays `nil`; an empty array stays an empty array.
+        if let rawItems = try container.decodeIfPresent([SelectJSONValue].self, forKey: .catalogItems) {
+            catalogItems = rawItems.compactMap { value in
+                guard case let .object(object) = value else { return nil }
+                return SelectCatalogItem(raw: object)
+            }
+        } else {
+            catalogItems = nil
+        }
+    }
 }
 
 struct SelectCreative: Decodable {

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectResponse.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectResponse.swift
@@ -158,25 +158,6 @@ struct SelectOffer: Decodable {
         case creative
         case catalogItems = "catalog_items"
     }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        campaignId = try container.decodeIfPresent(String.self, forKey: .campaignId)
-        creative = try container.decodeIfPresent(SelectCreative.self, forKey: .creative)
-        // Decode `catalog_items` as opaque JSON values first so a non-object element
-        // (a bare string, number, null, etc.) does not fail the whole response
-        // decode — consistent with the "never fail on shape drift" promise. Only the
-        // object-shaped elements become typed `SelectCatalogItem`s; anything else is
-        // skipped. An absent key stays `nil`; an empty array stays an empty array.
-        if let rawItems = try container.decodeIfPresent([SelectJSONValue].self, forKey: .catalogItems) {
-            catalogItems = rawItems.compactMap { value in
-                guard case let .object(object) = value else { return nil }
-                return SelectCatalogItem(raw: object)
-            }
-        } else {
-            catalogItems = nil
-        }
-    }
 }
 
 struct SelectCreative: Decodable {

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectResponse.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/SelectResponse.swift
@@ -51,15 +51,25 @@ struct SessionToken: Decodable {
 }
 
 struct SelectPageContext: Decodable {
+    let roktTagId: String?
     let pageInstanceGuid: String?
     let pageId: String?
+    let pageType: String?
     let language: String?
+    let isPageDetected: Bool?
+    let pageVariantName: String?
+    let partnerContentTemplate: String?
     let token: String?
 
     enum CodingKeys: String, CodingKey {
+        case roktTagId = "rokt_tag_id"
         case pageInstanceGuid = "page_instance_guid"
         case pageId = "page_id"
+        case pageType = "page_type"
         case language
+        case isPageDetected = "is_page_detected"
+        case pageVariantName = "page_variant_name"
+        case partnerContentTemplate = "partner_content_template"
         case token
     }
 }

--- a/Tests/RoktUXHelperTests/Data/Model/ExperienceResponse/SelectResponseTests.swift
+++ b/Tests/RoktUXHelperTests/Data/Model/ExperienceResponse/SelectResponseTests.swift
@@ -1,7 +1,11 @@
 import XCTest
 @testable import RoktUXHelper
 
-@available(iOS 15, *)
+// Matches the `@available(iOS 13, *)` gate on the models under test (SelectResponse
+// and friends). The SPM package minimum is iOS 15, so this gate never actually
+// excludes a supported run; it is aligned to the code under test rather than left
+// stricter than the symbols it exercises.
+@available(iOS 13, *)
 final class SelectResponseTests: XCTestCase {
 
     private let decoder = JSONDecoder()
@@ -40,8 +44,13 @@ final class SelectResponseTests: XCTestCase {
         XCTAssertEqual(catalogItem.instanceGuid, "catalog-instance-1")
         XCTAssertEqual(catalogItem.title, "Catalog title")
         // Campaign-specific fields are not surfaced as typed properties but remain
-        // available via `raw`.
-        XCTAssertEqual(catalogItem.raw["price"], .number(9.99))
+        // available via `raw`. NOTE: `SelectJSONValue` models every JSON number as
+        // `.number(Double)`, so both fractional and integer literals land in the same
+        // case — `9.99` and (elsewhere) `7` are both `.number`. If an `.int` case is
+        // ever added to `SelectJSONValue`, integer literals would decode differently
+        // and these `.number` expectations would need revisiting. The helper below
+        // makes that assumption explicit instead of hard-coding `.number(...)`.
+        assertNumber(catalogItem.raw["price"], equals: 9.99)
         XCTAssertEqual(catalogItem.raw["custom_field"]?.stringValue, "varies-by-campaign")
 
         let creative = try XCTUnwrap(offer.creative)
@@ -99,6 +108,83 @@ final class SelectResponseTests: XCTestCase {
         XCTAssertNil(catalogItem.title)
         XCTAssertEqual(catalogItem.raw["campaign_only_field"], .number(7))
         XCTAssertEqual(catalogItem.raw["nested"], .object(["k": .string("v")]))
+    }
+
+    func test_catalog_item_narrows_non_string_guaranteed_field_to_nil_but_retains_it_in_raw() throws {
+        // A guaranteed field arriving as a non-string is a server contract violation.
+        // Decoding deliberately tolerates it: the typed property narrows to nil (the
+        // narrowing is lossy and pinned here on purpose), while the original value is
+        // always preserved untyped in `raw`.
+        let json = """
+        { "instance_guid": 12345, "title": true }
+        """.data(using: .utf8)!
+
+        let catalogItem = try decoder.decode(SelectCatalogItem.self, from: json)
+
+        XCTAssertNil(catalogItem.instanceGuid)
+        XCTAssertNil(catalogItem.title)
+        assertNumber(catalogItem.raw["instance_guid"], equals: 12345)
+        XCTAssertEqual(catalogItem.raw["title"], .bool(true))
+    }
+
+    func test_offer_skips_non_object_catalog_items_without_failing_the_decode() throws {
+        // `catalog_items` is open; a non-object element (string, number, null, array)
+        // must not fail the whole response decode. Only object-shaped elements become
+        // typed items; everything else is skipped.
+        let json = """
+        {
+          "campaign_id": "campaign-x",
+          "catalog_items": [
+            { "instance_guid": "keep-1", "title": "Kept" },
+            "bare-string",
+            42,
+            null,
+            ["nested", "array"],
+            { "instance_guid": "keep-2" }
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let offer = try decoder.decode(SelectOffer.self, from: json)
+
+        XCTAssertEqual(offer.catalogItems?.count, 2)
+        XCTAssertEqual(offer.catalogItems?.map(\.instanceGuid), ["keep-1", "keep-2"])
+    }
+
+    func test_offer_distinguishes_empty_catalog_items_array_from_absent_field() throws {
+        let absent = """
+        { "campaign_id": "campaign-absent" }
+        """.data(using: .utf8)!
+        let empty = """
+        { "campaign_id": "campaign-empty", "catalog_items": [] }
+        """.data(using: .utf8)!
+
+        let absentOffer = try decoder.decode(SelectOffer.self, from: absent)
+        let emptyOffer = try decoder.decode(SelectOffer.self, from: empty)
+
+        // Absent key → nil; present-but-empty array → empty (non-nil) collection.
+        XCTAssertNil(absentOffer.catalogItems)
+        XCTAssertEqual(emptyOffer.catalogItems?.count, 0)
+    }
+
+    // MARK: - Helpers
+
+    /// Asserts a `SelectJSONValue` is a number equal to `expected`.
+    ///
+    /// `SelectJSONValue` models every JSON number as `.number(Double)`, so both
+    /// integer and fractional literals land in the same case. This helper makes that
+    /// assumption explicit at the call site rather than hard-coding `.number(...)`,
+    /// so that if an `.int` case is ever added the failure points here.
+    private func assertNumber(_ value: SelectJSONValue?,
+                              equals expected: Double,
+                              file: StaticString = #filePath,
+                              line: UInt = #line) {
+        guard case let .number(actual) = value else {
+            XCTFail("Expected .number(\(expected)) but got \(String(describing: value))",
+                    file: file, line: line)
+            return
+        }
+        XCTAssertEqual(actual, expected, accuracy: 0.000_001, file: file, line: line)
     }
 
     // MARK: - Fixtures

--- a/Tests/RoktUXHelperTests/Data/Model/ExperienceResponse/SelectResponseTests.swift
+++ b/Tests/RoktUXHelperTests/Data/Model/ExperienceResponse/SelectResponseTests.swift
@@ -36,7 +36,13 @@ final class SelectResponseTests: XCTestCase {
         let offer = try XCTUnwrap(slot.offer)
         XCTAssertEqual(offer.campaignId, "campaign-1")
         XCTAssertEqual(offer.catalogItems?.count, 1)
-        XCTAssertEqual(offer.catalogItems?.first?["id"]?.stringValue, "catalog-1")
+        let catalogItem = try XCTUnwrap(offer.catalogItems?.first)
+        XCTAssertEqual(catalogItem.instanceGuid, "catalog-instance-1")
+        XCTAssertEqual(catalogItem.title, "Catalog title")
+        // Campaign-specific fields are not surfaced as typed properties but remain
+        // available via `raw`.
+        XCTAssertEqual(catalogItem.raw["price"], .number(9.99))
+        XCTAssertEqual(catalogItem.raw["custom_field"]?.stringValue, "varies-by-campaign")
 
         let creative = try XCTUnwrap(offer.creative)
         XCTAssertEqual(creative.referralCreativeId, "creative-1")
@@ -79,6 +85,22 @@ final class SelectResponseTests: XCTestCase {
         XCTAssertNil(responseOption.ignoreBranch)
     }
 
+    func test_catalog_item_decodes_when_guaranteed_fields_are_absent() throws {
+        // The catalog-item schema is open and campaign-specific; only `instance_guid`
+        // and `title` are guaranteed. Decoding must not fail when they are absent —
+        // the guaranteed properties are nil and the payload is retained in `raw`.
+        let json = """
+        { "campaign_only_field": 7, "nested": { "k": "v" } }
+        """.data(using: .utf8)!
+
+        let catalogItem = try decoder.decode(SelectCatalogItem.self, from: json)
+
+        XCTAssertNil(catalogItem.instanceGuid)
+        XCTAssertNil(catalogItem.title)
+        XCTAssertEqual(catalogItem.raw["campaign_only_field"], .number(7))
+        XCTAssertEqual(catalogItem.raw["nested"], .object(["k": .string("v")]))
+    }
+
     // MARK: - Fixtures
 
     private static let fullPayload = """
@@ -103,7 +125,7 @@ final class SelectResponseTests: XCTestCase {
                   "layout_variant": { "layout_variant_id": "variant-1", "module_name": "module-1" },
                   "offer": {
                     "campaign_id": "campaign-1",
-                    "catalog_items": [ { "id": "catalog-1" } ],
+                    "catalog_items": [ { "instance_guid": "catalog-instance-1", "title": "Catalog title", "price": 9.99, "custom_field": "varies-by-campaign" } ],
                     "creative": {
                       "referral_creative_id": "creative-1",
                       "instance_guid": "creative-instance-1",

--- a/Tests/RoktUXHelperTests/Data/Model/ExperienceResponse/SelectResponseTests.swift
+++ b/Tests/RoktUXHelperTests/Data/Model/ExperienceResponse/SelectResponseTests.swift
@@ -1,10 +1,6 @@
 import XCTest
 @testable import RoktUXHelper
 
-// Matches the `@available(iOS 13, *)` gate on the models under test (SelectResponse
-// and friends). The SPM package minimum is iOS 15, so this gate never actually
-// excludes a supported run; it is aligned to the code under test rather than left
-// stricter than the symbols it exercises.
 @available(iOS 13, *)
 final class SelectResponseTests: XCTestCase {
 
@@ -40,18 +36,11 @@ final class SelectResponseTests: XCTestCase {
         let offer = try XCTUnwrap(slot.offer)
         XCTAssertEqual(offer.campaignId, "campaign-1")
         XCTAssertEqual(offer.catalogItems?.count, 1)
+        // Only `instance_guid` and `title` are part of the agreed contract; any
+        // campaign-specific fields in the payload are ignored.
         let catalogItem = try XCTUnwrap(offer.catalogItems?.first)
         XCTAssertEqual(catalogItem.instanceGuid, "catalog-instance-1")
         XCTAssertEqual(catalogItem.title, "Catalog title")
-        // Campaign-specific fields are not surfaced as typed properties but remain
-        // available via `raw`. NOTE: `SelectJSONValue` models every JSON number as
-        // `.number(Double)`, so both fractional and integer literals land in the same
-        // case — `9.99` and (elsewhere) `7` are both `.number`. If an `.int` case is
-        // ever added to `SelectJSONValue`, integer literals would decode differently
-        // and these `.number` expectations would need revisiting. The helper below
-        // makes that assumption explicit instead of hard-coding `.number(...)`.
-        assertNumber(catalogItem.raw["price"], equals: 9.99)
-        XCTAssertEqual(catalogItem.raw["custom_field"]?.stringValue, "varies-by-campaign")
 
         let creative = try XCTUnwrap(offer.creative)
         XCTAssertEqual(creative.referralCreativeId, "creative-1")
@@ -95,9 +84,9 @@ final class SelectResponseTests: XCTestCase {
     }
 
     func test_catalog_item_decodes_when_guaranteed_fields_are_absent() throws {
-        // The catalog-item schema is open and campaign-specific; only `instance_guid`
-        // and `title` are guaranteed. Decoding must not fail when they are absent —
-        // the guaranteed properties are nil and the payload is retained in `raw`.
+        // Only `instance_guid` and `title` are modelled; both are optional, so
+        // decoding succeeds (with nil values) when they are absent and any other
+        // fields in the payload are ignored.
         let json = """
         { "campaign_only_field": 7, "nested": { "k": "v" } }
         """.data(using: .utf8)!
@@ -106,49 +95,6 @@ final class SelectResponseTests: XCTestCase {
 
         XCTAssertNil(catalogItem.instanceGuid)
         XCTAssertNil(catalogItem.title)
-        XCTAssertEqual(catalogItem.raw["campaign_only_field"], .number(7))
-        XCTAssertEqual(catalogItem.raw["nested"], .object(["k": .string("v")]))
-    }
-
-    func test_catalog_item_narrows_non_string_guaranteed_field_to_nil_but_retains_it_in_raw() throws {
-        // A guaranteed field arriving as a non-string is a server contract violation.
-        // Decoding deliberately tolerates it: the typed property narrows to nil (the
-        // narrowing is lossy and pinned here on purpose), while the original value is
-        // always preserved untyped in `raw`.
-        let json = """
-        { "instance_guid": 12345, "title": true }
-        """.data(using: .utf8)!
-
-        let catalogItem = try decoder.decode(SelectCatalogItem.self, from: json)
-
-        XCTAssertNil(catalogItem.instanceGuid)
-        XCTAssertNil(catalogItem.title)
-        assertNumber(catalogItem.raw["instance_guid"], equals: 12345)
-        XCTAssertEqual(catalogItem.raw["title"], .bool(true))
-    }
-
-    func test_offer_skips_non_object_catalog_items_without_failing_the_decode() throws {
-        // `catalog_items` is open; a non-object element (string, number, null, array)
-        // must not fail the whole response decode. Only object-shaped elements become
-        // typed items; everything else is skipped.
-        let json = """
-        {
-          "campaign_id": "campaign-x",
-          "catalog_items": [
-            { "instance_guid": "keep-1", "title": "Kept" },
-            "bare-string",
-            42,
-            null,
-            ["nested", "array"],
-            { "instance_guid": "keep-2" }
-          ]
-        }
-        """.data(using: .utf8)!
-
-        let offer = try decoder.decode(SelectOffer.self, from: json)
-
-        XCTAssertEqual(offer.catalogItems?.count, 2)
-        XCTAssertEqual(offer.catalogItems?.map(\.instanceGuid), ["keep-1", "keep-2"])
     }
 
     func test_offer_distinguishes_empty_catalog_items_array_from_absent_field() throws {
@@ -165,26 +111,6 @@ final class SelectResponseTests: XCTestCase {
         // Absent key → nil; present-but-empty array → empty (non-nil) collection.
         XCTAssertNil(absentOffer.catalogItems)
         XCTAssertEqual(emptyOffer.catalogItems?.count, 0)
-    }
-
-    // MARK: - Helpers
-
-    /// Asserts a `SelectJSONValue` is a number equal to `expected`.
-    ///
-    /// `SelectJSONValue` models every JSON number as `.number(Double)`, so both
-    /// integer and fractional literals land in the same case. This helper makes that
-    /// assumption explicit at the call site rather than hard-coding `.number(...)`,
-    /// so that if an `.int` case is ever added the failure points here.
-    private func assertNumber(_ value: SelectJSONValue?,
-                              equals expected: Double,
-                              file: StaticString = #filePath,
-                              line: UInt = #line) {
-        guard case let .number(actual) = value else {
-            XCTFail("Expected .number(\(expected)) but got \(String(describing: value))",
-                    file: file, line: line)
-            return
-        }
-        XCTAssertEqual(actual, expected, accuracy: 0.000_001, file: file, line: line)
     }
 
     // MARK: - Fixtures

--- a/Tests/RoktUXHelperTests/Data/Model/ExperienceResponse/SelectResponseTests.swift
+++ b/Tests/RoktUXHelperTests/Data/Model/ExperienceResponse/SelectResponseTests.swift
@@ -13,8 +13,13 @@ final class SelectResponseTests: XCTestCase {
         XCTAssertEqual(response.sessionToken.token, "token-1")
         XCTAssertEqual(response.sessionToken.expiresAt, 1_711_038_600_000)
         XCTAssertEqual(response.pageInstanceGuid, "page-instance-1")
+        XCTAssertEqual(response.pageContext?.roktTagId, "tag-1")
         XCTAssertEqual(response.pageContext?.pageId, "page-1")
+        XCTAssertEqual(response.pageContext?.pageType, "checkout")
         XCTAssertEqual(response.pageContext?.language, "en")
+        XCTAssertEqual(response.pageContext?.isPageDetected, true)
+        XCTAssertEqual(response.pageContext?.pageVariantName, "variant-a")
+        XCTAssertEqual(response.pageContext?.partnerContentTemplate, "template-1")
 
         let plugin = try XCTUnwrap(response.plugins?.first?.plugin)
         XCTAssertEqual(plugin.id, "plugin-1")
@@ -120,7 +125,7 @@ final class SelectResponseTests: XCTestCase {
       "session_id": "session-1",
       "session_token": { "token": "token-1", "expires_at": 1711038600000 },
       "page_instance_guid": "page-instance-1",
-      "page_context": { "page_instance_guid": "page-instance-1", "page_id": "page-1", "language": "en", "token": "ctx-token" },
+      "page_context": { "rokt_tag_id": "tag-1", "page_instance_guid": "page-instance-1", "page_id": "page-1", "page_type": "checkout", "language": "en", "is_page_detected": true, "page_variant_name": "variant-a", "partner_content_template": "template-1", "token": "ctx-token" },
       "plugins": [
         {
           "plugin": {


### PR DESCRIPTION
## What

Follow-up to #306 — hardens the v2 selection-response `catalog_items` field, which was merged as a fully-opaque `[SelectJSONValue]`.

Replaces it with a typed `SelectCatalogItem` that:
- surfaces the backend-**guaranteed** `instance_guid` and `title` as typed (optional) properties, and
- retains the complete decoded payload in a `raw: [String: SelectJSONValue]` map so campaign-specific fields (which vary by campaign type) still round-trip.

Decoding never fails on an unrecognised/changing shape, so we get compile-time access to the known fields without the fragility a fully-typed struct would introduce against an open (`additionalProperties: true`) schema.

## Why

Per the discussion on https://github.com/ROKT/rokt-ux-helper-ios/pull/306#discussion_r3398885893, the opaque type was an intentional interim and we committed to a follow-up giving it a true type. Transactions doesn't expose a stable catalog-item schema — only `instance_guid` and `title` are guaranteed — so an all-optional typed model + raw fallback is the type-safe shape that matches that contract.

`event_data.events` is intentionally left opaque (`[String: SelectJSONValue]`): it's a pass-through payload not consumed by the renderer, matching the Android port (`Map<String, JsonElement>`).

## Scope

iOS only, transactions models only. A matching Android follow-up is tracked separately.

## Testing

- Updated the full-payload fixture/assertions to exercise the typed fields + `raw` fallback.
- Added `test_catalog_item_decodes_when_guaranteed_fields_are_absent` covering the decode-never-fails guarantee.
- `xcodebuild test` (RoktUXHelperTests/SelectResponseTests) — 4/4 passing.