### PR TITLE
fix(overlay): Walk modal chain for detached key-window root

### DIFF
--- a/Sources/RoktUXHelper/UI/Components/Common/RoktUXPresentationResolver.swift
+++ b/Sources/RoktUXHelper/UI/Components/Common/RoktUXPresentationResolver.swift
@@ -14,19 +14,32 @@ enum RoktUXPresentationResolver {
         startingAt controller: UIViewController?,
         isPresenterUsable: (UIViewController) -> Bool = defaultIsPresenterUsable
     ) -> UIViewController? {
-        guard let controller, isPresenterUsable(controller) else {
+        guard let controller else {
+            RoktUXLogger.shared.warning(
+                "Overlay presenter resolution failed: starting view controller was nil (no key-window rootViewController)."
+            )
             return nil
         }
 
-        var topController = controller
-        while let presentedViewController = topController.presentedViewController {
-            guard isPresenterUsable(presentedViewController) else {
-                break
-            }
-            topController = presentedViewController
+        // The starting controller (key window's `rootViewController`) is routinely detached
+        // from the window when a `.fullScreen` modal is presented on top. That must not abort
+        // resolution — walk the chain and return the deepest usable controller (staleness checks
+        // still apply to each step along the chain).
+        var bestUsable: UIViewController? = isPresenterUsable(controller) ? controller : nil
+        var cursor = controller
+        while let presented = cursor.presentedViewController {
+            guard isPresenterUsable(presented) else { break }
+            bestUsable = presented
+            cursor = presented
         }
-
-        return topController
+        if bestUsable == nil {
+            RoktUXLogger.shared.warning(
+                "Overlay presenter resolution failed: no usable view controller in the "
+                    + "presentation chain (e.g. detached or dismissing). "
+                    + "Overlay UI will not be presented."
+            )
+        }
+        return bestUsable
     }
 
     private static func defaultIsPresenterUsable(_ controller: UIViewController) -> Bool {

--- a/Tests/RoktUXHelperTests/UI/Components/Common/TestRoktUXPresentationResolver.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/Common/TestRoktUXPresentationResolver.swift
@@ -41,6 +41,36 @@ final class TestRoktUXPresentationResolver: XCTestCase {
 
         XCTAssertNil(presenter)
     }
+
+    /// When the key window's root is detached (e.g. covered by a `.fullScreen` modal), overlay
+    /// presentation must still resolve the on-screen presented controller.
+    func testStableTopViewControllerWalksModalChainWhenStartingControllerUnusable() {
+        let root = StubPresentedViewController()
+        let fullScreenModal = StubPresentedViewController()
+        let modalContent = StubPresentedViewController()
+        root.stubPresentedViewController = fullScreenModal
+        fullScreenModal.stubPresentedViewController = modalContent
+
+        let presenter = RoktUXPresentationResolver.stableTopViewController(
+            startingAt: root,
+            isPresenterUsable: { $0 !== root }
+        )
+
+        XCTAssertTrue(presenter === modalContent)
+    }
+
+    func testStableTopViewControllerReturnsNilWhenRootUnusableAndFirstPresentedUnusable() {
+        let root = StubPresentedViewController()
+        let stalePresented = StubPresentedViewController()
+        root.stubPresentedViewController = stalePresented
+
+        let presenter = RoktUXPresentationResolver.stableTopViewController(
+            startingAt: root,
+            isPresenterUsable: { $0 !== root && $0 !== stalePresented }
+        )
+
+        XCTAssertNil(presenter)
+    }
 }
 
 private final class StubPresentedViewController: UIViewController {


### PR DESCRIPTION
## Background

- Overlay-style placements (for example dynamic bottom sheets) load successfully (PlacementReady, layout load signals), but no UI is presented and no impression fires when selectPlacements runs while the visible screen sits under a .fullScreen modal.
- In that situation UIKit often detaches the key window’s rootViewController’s view from the window (the covered root is no longer in the window hierarchy). The overlay presenter resolver treated an “unusable” starting controller as a hard failure and returned nil before walking the modal presentation chain, so present was never called even though a presented view controller was on-screen and valid.
- A prior “stale presenter” guard is still important, but it must apply per step along the chain, not as a blanket requirement on the starting VC alone.
- 
## What Has Changed

- RoktUXPresentationResolver.stableTopViewController now keeps the deepest usable controller found while walking presentedViewController, even when the starting VC fails the usability check (e.g. detached root under .fullScreen). The loop still stops at the first unusable presented VC so stale/dismissing presenters are not used.
- RoktUXLogger.shared.warning calls when resolution fails: nil starting VC, or no usable VC anywhere in the chain (opt-in via log level; default remains quiet).
- Unit tests in TestRoktUXPresentationResolver for: walking the chain when the start VC is “unusable”, and returning nil when the first presented is also unusable; existing stale-chain behavior is unchanged.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes [ticket](https://go/j/[ticket-number])
