### PR TITLE
ci(release): support maintenance patch releases

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - main
+      - maintenance/*
   pull_request:
 
 jobs:

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -24,10 +24,31 @@ jobs:
   publish-draft-release:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate release branch
+        env:
+          BUMP_TYPE: ${{ github.event.inputs.bump-type }}
+        run: |
+          release_branch="${GITHUB_REF_NAME}"
+          bump_type="${BUMP_TYPE}"
+
+          case "$release_branch" in
+            main|maintenance/*)
+              ;;
+            *)
+              echo "Release drafts can only run from main or maintenance/* branches."
+              exit 1
+              ;;
+          esac
+
+          if [[ "$release_branch" == maintenance/* && "$bump_type" != "patch" ]]; then
+            echo "Maintenance branch releases must use a patch bump."
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: main
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
 
       - name: Get current version
@@ -64,7 +85,7 @@ jobs:
           commit-message: Create ${{ steps.bump-version.outputs.new_version }}
           branch: release/${{ steps.bump-version.outputs.new_version }}
           title: Prepare release ${{ steps.bump-version.outputs.new_version }}
-          base: main
+          base: ${{ github.ref_name }}
           body: |
             Preparing for release ${{ steps.bump-version.outputs.new_version }}
             - Bumped version

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - maintenance/*
     paths:
       - VERSION
 
@@ -12,6 +13,7 @@ permissions:
 
 jobs:
   build-and-release:
+    if: ${{ !github.event.created && !github.event.deleted }}
     runs-on: macos-latest
     steps:
       - name: Checkout code
@@ -24,6 +26,17 @@ jobs:
         run: |
           version_from_file=$(head -n 1 VERSION)
           echo "release-version=$version_from_file" >> $GITHUB_OUTPUT
+
+      - name: Check release stability
+        id: release-stability
+        env:
+          RELEASE_VERSION: ${{ steps.version-file.outputs.release-version }}
+        run: |
+          if [[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "is-stable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is-stable=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Resolve Packages
         run: swift package resolve --verbose
@@ -49,7 +62,7 @@ jobs:
       - name: Create Github release
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
-          makeLatest: true
+          makeLatest: ${{ steps.release-stability.outputs.is-stable == 'true' && github.ref_name == 'main' }}
           tag: ${{ steps.version-file.outputs.release-version }}
           body: |
             ## Release notes:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,11 +1,74 @@
 # Releasing
 
-To create a new release you will first create a pull request using the Github Actions workflow [Release – Draft](https://github.com/ROKT/rokt-ux-helper-ios/actions/workflows/release-draft.yml). You need to manually select the version bump from patch, minor or major depending on the changes that are being deployed.
+Releases are prepared by the [Release – Draft](https://github.com/ROKT/rokt-ux-helper-ios/actions/workflows/release-draft.yml)
+workflow and published by the [Release – Publish](https://github.com/ROKT/rokt-ux-helper-ios/actions/workflows/release-publish.yml)
+workflow.
 
-This will oepn a pull request where you need to validate that the correct files have been updated. These should be documented in the body of the pull request, your job is to validate these have updated correctly and that the release notes look correct for client consumption.
+The draft workflow updates `VERSION`, `RoktUXHelper.podspec`, and
+`CHANGELOG.md`, then opens a release PR. After that PR is reviewed, tested, and
+merged, the publish workflow creates the GitHub release and tag used by Swift
+Package Manager, then publishes the podspec to CocoaPods.
 
-If everything checks out, and tests pass you can merge this pull request which will automatically trigger the [Release – Publish](https://github.com/ROKT/rokt-ux-helper-ios/actions/workflows/release-publish.yml) workflow.
+## Standard releases from main
+
+Use this flow for normal patch, minor, or major releases on the main release
+line:
+
+1. Open the "Actions" tab in GitHub.
+2. Select the "Release – Draft" workflow.
+3. Set "Use workflow from" to `main`.
+4. Choose the required version bump: `patch`, `minor`, or `major`.
+5. Run the workflow and review the generated `release/<version>` PR.
+6. Merge the release PR after checks pass.
+
+When the release PR is merged to `main`, "Release – Publish" creates the GitHub
+release, tags the commit, and publishes `RoktUXHelper.podspec` to CocoaPods.
+Stable releases from `main` are marked as GitHub "Latest".
+
+## Maintenance patch releases
+
+Use maintenance branches for patch releases after a stable major or minor
+release has landed on `main`.
+
+Create the maintenance branch from the stable release tag or release commit:
+
+```bash
+git fetch origin --tags
+git checkout -b maintenance/1.0.x 1.0.0
+git push --set-upstream origin maintenance/1.0.x
+```
+
+To release a patch from that maintenance line:
+
+1. Cherry-pick or merge the required patch changes into `maintenance/X.Y.x`.
+2. Open the "Release – Draft" workflow.
+3. Set "Use workflow from" to the maintenance branch, for example
+   `maintenance/1.0.x`.
+4. Choose `patch` as the version bump.
+5. Run the workflow and review the generated `release/<version>` PR.
+6. Merge the release PR back into the maintenance branch.
+
+When the release PR is merged to `maintenance/*`, "Release – Publish" creates
+the GitHub release, tags the commit, and publishes the patch podspec to
+CocoaPods. Maintenance releases are not marked as GitHub "Latest"; only stable
+releases from `main` update the latest release badge.
+
+## Workflow behavior
+
+`Release – Draft` can run from `main` or `maintenance/*` branches. Maintenance
+branch drafts must use a patch bump.
+
+`Release – Publish` runs only when `VERSION` changes on `main` or
+`maintenance/*`, and it ignores branch create/delete push events.
+
+Snapshot builds are not part of this repository's release flow. Publishing is
+tied to versioned releases.
 
 ## CHANGELOG.md
 
-`CHANGELOG.md` is generated automatically by the `Release – Draft` workflow from the git history (conventional commit PR titles). **Do not edit `CHANGELOG.md` in feature branches** — any manual entries will be overwritten when the release PR is drafted. Write clear, conventional commit-style PR titles (e.g. `feat(richtext): support <p> tag`) and the changelog entry will be produced for you at release time.
+`CHANGELOG.md` is generated automatically by the `Release – Draft` workflow from
+the git history and conventional commit PR titles. Do not edit `CHANGELOG.md` in
+feature branches; manual entries will be overwritten when the release PR is
+drafted. Write clear, conventional commit-style PR titles, for example
+`feat(richtext): support <p> tag`, and the changelog entry will be produced at
+release time.


### PR DESCRIPTION
## Background

- Patch releases need to be publishable from maintenance branches after a stable major or minor release lands on `main`.
- The iOS release process also publishes CocoaPods artifacts, so the maintenance flow needs to preserve both Swift Package Manager tags and podspec publishing while keeping GitHub Latest tied to the main release line.

## What Has Changed

- Added `maintenance/*` support to the release publish workflow.
- Made release publishing skip branch create/delete push events.
- Limited GitHub Latest updates to stable releases from `main`.
- Made the release draft workflow branch-aware and restricted maintenance drafts to patch bumps.
- Added pull request workflow coverage for pushes to `maintenance/*` branches.
- Updated the release guide with the main and maintenance patch release flows, including CocoaPods publishing behavior.

## Screenshots/Video

- N/A - workflow and documentation changes only.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes

- Local verification passed:
  - `trunk check --ci`
  - `xcodebuild -skipPackagePluginValidation -scheme RoktUXHelper -destination 'platform=iOS Simulator,id=DD9D624A-B138-45EB-8F87-0D53288F97C6' -derivedDataPath DerivedData test`
  - `pod lib lint RoktUXHelper.podspec --allow-warnings --verbose`