### PR TITLE
fix(toggle-button): send user interaction signal

### DIFF
--- a/Sources/RoktUXHelper/Data/Model/Event/RoktUXEventType.swift
+++ b/Sources/RoktUXHelper/Data/Model/Event/RoktUXEventType.swift
@@ -45,10 +45,12 @@ enum UserInteraction: String, Codable, CaseIterable {
     case MainImageScrollIconRightClick
     case MainImageSwipeLeft
     case MainImageSwipeRight
+    case ToggleButtonStateTriggerClick
 }
 
 enum UserInteractionContext: String, Codable, CaseIterable {
     case CustomStateValidationTriggerButton
     case CatalogDropDown
     case CatalogImageGallery
+    case ToggleButtonStateTrigger
 }

--- a/Sources/RoktUXHelper/Services/Events/EventService.swift
+++ b/Sources/RoktUXHelper/Services/Events/EventService.swift
@@ -200,6 +200,19 @@ class EventService: Hashable, EventDiagnosticServicing {
         sendCartItemEvent(eventType: .SignalCartItemInstantPurchaseFailure, catalogItem: catalogItem)
     }
 
+    func sendUserInteraction(action: UserInteraction, context: UserInteractionContext) {
+        let objectData = [
+            kAction: action.rawValue,
+            kContext: context.rawValue
+        ]
+        sendEvent(
+            .SignalUserInteraction,
+            parentGuid: pluginInstanceGuid,
+            objectData: objectData,
+            jwtToken: pluginConfigJWTToken
+        )
+    }
+
     func cartItemUserInteraction(itemId: String, action: UserInteraction, context: UserInteractionContext) {
         guard let catalogItem = catalogItems.first(where: { $0.catalogItemId == itemId }) else { return }
         let objectData = [

--- a/Sources/RoktUXHelper/Services/Events/EventServicing.swift
+++ b/Sources/RoktUXHelper/Services/Events/EventServicing.swift
@@ -15,6 +15,7 @@ protocol EventServicing: AnyObject {
     func openURL(url: URL, type: RoktUXOpenURLType, completionHandler: @escaping () -> Void)
     func cartItemInstantPurchase(catalogItem: CatalogItem)
     func cartItemInstantPurchaseSuccess(itemId: String)
+    func sendUserInteraction(action: UserInteraction, context: UserInteractionContext)
     func cartItemUserInteraction(itemId: String, action: UserInteraction, context: UserInteractionContext)
     func cartItemInstantPurchaseFailure(itemId: String)
     func cartItemDevicePay(

--- a/Sources/RoktUXHelper/Services/LayoutTransformer/LayoutTransformer.swift
+++ b/Sources/RoktUXHelper/Services/LayoutTransformer/LayoutTransformer.swift
@@ -951,7 +951,8 @@ where CreativeSyntaxMapper.Context == CreativeContext,
     func getToggleButton(customStateKey: String,
                          styles: LayoutStyle<ToggleButtonStateTriggerElements,
                                              ConditionalStyleTransition<ToggleButtonStateTriggerTransitions, WhenPredicate>>?,
-                         children: [LayoutSchemaViewModel]?) throws -> ToggleButtonViewModel {
+                         children: [LayoutSchemaViewModel]?,
+                         eventService: EventDiagnosticServicing? = nil) throws -> ToggleButtonViewModel {
         let updateStyles = try StyleTransformer.updatedStyles(styles?.elements?.own)
         return ToggleButtonViewModel(children: children,
                                      customStateKey: customStateKey,
@@ -959,6 +960,7 @@ where CreativeSyntaxMapper.Context == CreativeContext,
                                      pressedStyle: updateStyles.compactMap {$0.pressed},
                                      hoveredStyle: updateStyles.compactMap {$0.hovered},
                                      disabledStyle: updateStyles.compactMap {$0.disabled},
+                                     eventService: eventService ?? self.eventService,
                                      layoutState: layoutState)
     }
 

--- a/Sources/RoktUXHelper/UI/Components/ToggleButtonComponent.swift
+++ b/Sources/RoktUXHelper/UI/Components/ToggleButtonComponent.swift
@@ -209,6 +209,10 @@ struct ToggleButtonComponent: View {
                 key: model.customStateKey
             )
         )
+        model.eventService?.sendUserInteraction(
+            action: .ToggleButtonStateTriggerClick,
+            context: .ToggleButtonStateTrigger
+        )
     }
 
     private func updateStyleState() {

--- a/Sources/RoktUXHelper/UI/Components/ViewModel/ToggleButtonViewModel.swift
+++ b/Sources/RoktUXHelper/UI/Components/ViewModel/ToggleButtonViewModel.swift
@@ -10,6 +10,7 @@ class ToggleButtonViewModel: Identifiable, Hashable, ScreenSizeAdaptive {
     let pressedStyle: [ToggleButtonStateTriggerStyle]?
     let hoveredStyle: [ToggleButtonStateTriggerStyle]?
     let disabledStyle: [ToggleButtonStateTriggerStyle]?
+    weak var eventService: EventDiagnosticServicing?
     weak var layoutState: (any LayoutStateRepresenting)?
     var imageLoader: RoktUXImageLoader? {
         layoutState?.imageLoader
@@ -21,6 +22,7 @@ class ToggleButtonViewModel: Identifiable, Hashable, ScreenSizeAdaptive {
          pressedStyle: [ToggleButtonStateTriggerStyle]?,
          hoveredStyle: [ToggleButtonStateTriggerStyle]?,
          disabledStyle: [ToggleButtonStateTriggerStyle]?,
+         eventService: EventDiagnosticServicing? = nil,
          layoutState: (any LayoutStateRepresenting)?) {
         self.children = children
         self.customStateKey = customStateKey
@@ -28,6 +30,7 @@ class ToggleButtonViewModel: Identifiable, Hashable, ScreenSizeAdaptive {
         self.pressedStyle = pressedStyle
         self.hoveredStyle = hoveredStyle
         self.disabledStyle = disabledStyle
+        self.eventService = eventService
         self.layoutState = layoutState
     }
 }

--- a/Tests/RoktUXHelperTests/Services/Events/TestEventService.swift
+++ b/Tests/RoktUXHelperTests/Services/Events/TestEventService.swift
@@ -107,6 +107,30 @@ final class TestEventService: XCTestCase {
         XCTAssertEqual(events.first?.eventType, .SignalActivation)
         XCTAssertEqual(events.first?.pageInstanceGuid, mockPageInstanceGuid)
     }
+
+    func test_sendUserInteraction_shouldSendLayoutScopedSignal() throws {
+        // Arrange
+        let eventService = get_mock_event_processor(startDate: startDate,
+                                                    uxEventDelegate: stubUXHelper,
+                                                    eventHandler: { event in
+            self.events.append(event)
+        })
+
+        // Act
+        eventService.sendUserInteraction(
+            action: .ToggleButtonStateTriggerClick,
+            context: .ToggleButtonStateTrigger
+        )
+
+        // Assert
+        let event = events.first
+        XCTAssertEqual(event?.eventType, .SignalUserInteraction)
+        XCTAssertEqual(event?.pageInstanceGuid, mockPageInstanceGuid)
+        XCTAssertEqual(event?.parentGuid, mockPluginInstanceGuid)
+        XCTAssertEqual(event?.jwtToken, mockPluginConfigJWTToken)
+        XCTAssertEqual(event?.objectData?[kAction], UserInteraction.ToggleButtonStateTriggerClick.rawValue)
+        XCTAssertEqual(event?.objectData?[kContext], UserInteractionContext.ToggleButtonStateTrigger.rawValue)
+    }
     
     func test_sendSignalResponse_onPositive_engagementEventsAndSignals_shouldSend() throws {
         // Arrange

--- a/Tests/RoktUXHelperTests/Services/LayoutTransformer/TestLayoutTransformer.swift
+++ b/Tests/RoktUXHelperTests/Services/LayoutTransformer/TestLayoutTransformer.swift
@@ -415,6 +415,26 @@ final class TestLayoutTransformer: XCTestCase {
         XCTAssertEqual(transformedToggleButton.defaultStyle?[1].background?.backgroundColor?.light, "#F2A7AB")
     }
 
+    func test_toggleButton_transformedWithEventService() throws {
+        // Arrange
+        let model = ModelTestData.ToggleButtonData.basicToggleButton()
+        let eventService = MockEventService()
+        let layoutTransformer = LayoutTransformer(
+            layoutPlugin: get_layout_plugin(layout: nil, slots: []),
+            eventService: eventService
+        )
+
+        // Act
+        let transformedToggleButton = try layoutTransformer.getToggleButton(
+            customStateKey: model.customStateKey,
+            styles: model.styles,
+            children: nil
+        )
+
+        // Assert
+        XCTAssertTrue(transformedToggleButton.eventService === eventService)
+    }
+
     func test_expand_withValidBNF_updatesNestedValues() throws {
         let bnfPageModel = ModelTestData.PageModelData.withBNF()
 

--- a/Tests/RoktUXHelperTests/UI/Components/TestToggleButtonComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestToggleButtonComponent.swift
@@ -38,6 +38,26 @@ final class TestToggleButtonComponent: XCTestCase {
         XCTAssertEqual(backgroundStyle?.backgroundColor, ThemeColor(light: "#FFFFFF", dark: "#000000"))
     }
 
+    func test_tapGesture_sendsUserInteraction() throws {
+        let eventService = MockEventService()
+        let view = TestPlaceHolder(layout: LayoutSchemaViewModel.toggleButton(try get_model(eventService: eventService)))
+
+        let sut = try view.inspect().view(TestPlaceHolder.self)
+            .view(EmbeddedComponent.self)
+            .vStack()[0]
+            .view(LayoutSchemaComponent.self)
+            .view(ToggleButtonComponent.self)
+            .actualView()
+
+        XCTAssertFalse(eventService.userInteractionCalled)
+
+        try sut.inspect().find(ViewType.HStack.self).callOnTapGesture()
+
+        XCTAssertTrue(eventService.userInteractionCalled)
+        XCTAssertEqual(eventService.lastLayoutUserInteractionAction, .ToggleButtonStateTriggerClick)
+        XCTAssertEqual(eventService.lastLayoutUserInteractionContext, .ToggleButtonStateTrigger)
+    }
+
     // MARK: - Snapshots
 
     func testSnapshot() throws {
@@ -50,12 +70,13 @@ final class TestToggleButtonComponent: XCTestCase {
 
     // MARK: - Helpers
 
-    func get_model() throws -> ToggleButtonViewModel {
+    func get_model(eventService: EventDiagnosticServicing? = nil) throws -> ToggleButtonViewModel {
         let transformer = LayoutTransformer(layoutPlugin: get_mock_layout_plugin())
         let model = ModelTestData.ToggleButtonData.basicToggleButton()
         return try transformer.getToggleButton(customStateKey: model.customStateKey,
                                                styles: model.styles,
-                                               children: transformer.transformChildren(model.children, context: .outer([])))
+                                               children: transformer.transformChildren(model.children, context: .outer([])),
+                                               eventService: eventService)
     }
 
     func get_snapshot_model() throws -> ToggleButtonViewModel {

--- a/Tests/RoktUXHelperTests/UI/ViewModel/Mocks/MockEventService.swift
+++ b/Tests/RoktUXHelperTests/UI/ViewModel/Mocks/MockEventService.swift
@@ -33,6 +33,7 @@ class MockEventService: EventDiagnosticServicing {
     var cartItemInstantPurchaseCalled = false
     var cartItemInstantPurchaseSuccessCalled = false
     var cartItemInstantPurchaseFailureCalled = false
+    var userInteractionCalled = false
     var cartItemUserInteractionCalled = false
     var cartItemDevicePayCalled = false
     var cartItemDevicePayCallCount = 0
@@ -110,6 +111,15 @@ class MockEventService: EventDiagnosticServicing {
 
     func cartItemInstantPurchaseFailure(itemId: String) {
         cartItemInstantPurchaseFailureCalled = true
+    }
+
+    var lastLayoutUserInteractionAction: UserInteraction?
+    var lastLayoutUserInteractionContext: UserInteractionContext?
+
+    func sendUserInteraction(action: UserInteraction, context: UserInteractionContext) {
+        userInteractionCalled = true
+        lastLayoutUserInteractionAction = action
+        lastLayoutUserInteractionContext = context
     }
 
     var lastUserInteractionItemId: String?
@@ -208,6 +218,9 @@ class MockEventService: EventDiagnosticServicing {
         cartItemInstantPurchaseCalled = false
         cartItemInstantPurchaseSuccessCalled = false
         cartItemInstantPurchaseFailureCalled = false
+        userInteractionCalled = false
+        lastLayoutUserInteractionAction = nil
+        lastLayoutUserInteractionContext = nil
         cartItemUserInteractionCalled = false
         cartItemDevicePayCalled = false
         cartItemDevicePayCallCount = 0


### PR DESCRIPTION
## Background

- `ToggleButtonStateTrigger` currently toggles custom state without emitting a user-interaction signal.
- That makes taps on layout-scoped toggles invisible to event consumers even though the interaction is meaningful.

## What Has Changed

- Added layout-scoped `SignalUserInteraction` support to `EventService`.
- Added `ToggleButtonStateTriggerClick` and `ToggleButtonStateTrigger` action/context values.
- Passed `eventService` into `ToggleButtonViewModel` from `LayoutTransformer`.
- Updated `ToggleButtonComponent` to emit the interaction signal when the toggle is tapped, alongside the existing custom-state toggle.
- Added service, transformer, and component tests for the new behavior.

## Screenshots/Video

- Not applicable. This is an event behavior change with no intended UI change.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation. Not applicable; no public documentation change needed.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Local validation:
  - `trunk check`
  - `xcodebuild -skipPackagePluginValidation -scheme RoktUXHelper -destination 'platform=macOS,variant=Mac Catalyst' -derivedDataPath DerivedData test -only-testing:RoktUXHelperTests/TestEventService/test_sendUserInteraction_shouldSendLayoutScopedSignal -only-testing:RoktUXHelperTests/TestToggleButtonComponent/test_tapGesture_sendsUserInteraction -only-testing:RoktUXHelperTests/TestLayoutTransformer/test_toggleButton_transformedWithEventService`
- The repository-recommended iOS simulator test command could not run locally because this machine does not have an iOS simulator runtime installed. CI should run the normal iOS test matrix.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- N/A
