### PR TITLE
feat(instant-purchase): emit OfferProgression on buy-now success

### DIFF
--- a/Sources/RoktUXHelper/Data/Model/Event/RoktUXEventType.swift
+++ b/Sources/RoktUXHelper/Data/Model/Event/RoktUXEventType.swift
@@ -39,6 +39,7 @@ public enum RoktUXEventType: String, Codable, CaseIterable {
 
 enum UserInteraction: String, Codable, CaseIterable {
     case ValidationTriggerFailed
+    case OfferProgression
     case DropDownItemSelected
     case ThumbnailClick
     case MainImageScrollIconLeftClick

--- a/Sources/RoktUXHelper/UI/Components/ViewModel/CatalogDevicePayButtonViewModel.swift
+++ b/Sources/RoktUXHelper/UI/Components/ViewModel/CatalogDevicePayButtonViewModel.swift
@@ -62,6 +62,12 @@ class CatalogDevicePayButtonViewModel: Identifiable, Hashable, ScreenSizeAdaptiv
             return
         }
 
+        eventService?.cartItemUserInteraction(
+            itemId: catalogItem.catalogItemId,
+            action: UserInteraction.OfferProgression,
+            context: UserInteractionContext.CustomStateValidationTriggerButton
+        )
+
         guard let eventService else { return }
         isProcessing = true
         eventService.cartItemDevicePay(

--- a/Tests/RoktUXHelperTests/UI/Components/TestCatalogDevicePayButtonComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestCatalogDevicePayButtonComponent.swift
@@ -115,6 +115,42 @@ final class TestCatalogDevicePayButtonComponent: XCTestCase {
 
         XCTAssertFalse(eventService.cartItemDevicePayCalled)
         XCTAssertTrue(eventService.cartItemUserInteractionCalled)
+        XCTAssertEqual(eventService.lastUserInteractionAction, .ValidationTriggerFailed)
+        XCTAssertEqual(eventService.lastUserInteractionContext, .CustomStateValidationTriggerButton)
+    }
+
+    func test_handleTap_validationPasses_sendsOfferProgression() {
+        let layoutState = MockLayoutState()
+        let eventService = MockEventService()
+        let catalogItem = CatalogItem.mock(catalogItemId: "item-1")
+
+        layoutState.validationCoordinator.registerField(
+            key: "dropdown",
+            owner: self,
+            validation: { .valid },
+            onStatusChange: { _ in }
+        )
+
+        let sut = CatalogDevicePayButtonViewModel(
+            catalogItem: catalogItem,
+            children: nil,
+            provider: .applePay,
+            layoutState: layoutState,
+            eventService: eventService,
+            defaultStyle: nil,
+            pressedStyle: nil,
+            hoveredStyle: nil,
+            disabledStyle: nil,
+            validatorTriggerConfig: ValidationTriggerConfig(validatorFieldKeys: ["dropdown"])
+        )
+
+        sut.handleTap()
+
+        XCTAssertTrue(eventService.cartItemUserInteractionCalled)
+        XCTAssertEqual(eventService.lastUserInteractionItemId, "item-1")
+        XCTAssertEqual(eventService.lastUserInteractionAction, .OfferProgression)
+        XCTAssertEqual(eventService.lastUserInteractionContext, .CustomStateValidationTriggerButton)
+        XCTAssertTrue(eventService.cartItemDevicePayCalled)
     }
 
     func test_devicePayCompletion_success_setsCustomState() {


### PR DESCRIPTION
## Background

The "Buy Now" button (`CatalogDevicePayButton`, `CustomStateValidationTriggerButton` context) only emitted a `SignalUserInteraction` on the validation-failure path (`ValidationTriggerFailed`). The success path — the user actually progressing the offer — produced no interaction signal, so event consumers couldn't see that step of the funnel. This adds the missing signal to match the cross-platform event contract (the web renderer already emits it).

## What Has Changed

- Added the `OfferProgression` `UserInteraction` action.
- `CatalogDevicePayButtonViewModel.handleTap()` now emits `SignalUserInteraction` (`OfferProgression` / `CustomStateValidationTriggerButton`), item-scoped, once validation passes and before the device-pay flow starts.
- Added a unit test for the success-path emit and tightened the existing validation-fail test to assert action/context.

## Screenshots/Video

Not applicable — event behaviour change, no UI change.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation. Not applicable.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Local validation: `TestCatalogDevicePayButtonComponent` suite passes on iPhone 16 Pro (iOS 18.5) simulator.
- First in a stack of instant-purchase signal PRs.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- N/A

## Testing

- Unit: `TestCatalogDevicePayButtonComponent.test_handleTap_validationPasses_sendsOfferProgression`.
- Live app: rendered the instant-purchase layout in the Example app via `tools/merge_layout.py`, selected a variant, and tapped Buy → confirmed `SignalUserInteraction` (`OfferProgression` / `CustomStateValidationTriggerButton`) delivered to `onPlatformEvent`.
