### PR TITLE
feat(instant-purchase): emit DropDownItemSelected on catalog dropdown selection

### DIFF
--- a/Sources/RoktUXHelper/Data/Model/Event/RoktUXEventType.swift
+++ b/Sources/RoktUXHelper/Data/Model/Event/RoktUXEventType.swift
@@ -39,6 +39,7 @@ public enum RoktUXEventType: String, Codable, CaseIterable {
 
 enum UserInteraction: String, Codable, CaseIterable {
     case ValidationTriggerFailed
+    case OfferProgression
     case DropDownItemSelected
     case ThumbnailClick
     case MainImageScrollIconLeftClick

--- a/Sources/RoktUXHelper/UI/Components/ViewModel/CatalogDevicePayButtonViewModel.swift
+++ b/Sources/RoktUXHelper/UI/Components/ViewModel/CatalogDevicePayButtonViewModel.swift
@@ -62,6 +62,12 @@ class CatalogDevicePayButtonViewModel: Identifiable, Hashable, ScreenSizeAdaptiv
             return
         }
 
+        eventService?.cartItemUserInteraction(
+            itemId: catalogItem.catalogItemId,
+            action: UserInteraction.OfferProgression,
+            context: UserInteractionContext.CustomStateValidationTriggerButton
+        )
+
         guard let eventService else { return }
         isProcessing = true
         eventService.cartItemDevicePay(

--- a/Sources/RoktUXHelper/UI/Components/ViewModel/CatalogDropdownViewModel.swift
+++ b/Sources/RoktUXHelper/UI/Components/ViewModel/CatalogDropdownViewModel.swift
@@ -178,6 +178,15 @@ class CatalogDropdownViewModel: Identifiable, Hashable, ScreenSizeAdaptive {
             layoutState?.items[LayoutState.activeCatalogItemKey] = resolvedItem
         }
 
+        // Signal the selection, scoped to the catalog item behind the chosen option.
+        if let selectedItem = resolveActiveCatalogItem() ?? catalogItem(for: options[index]) {
+            eventService?.cartItemUserInteraction(
+                itemId: selectedItem.catalogItemId,
+                action: .DropDownItemSelected,
+                context: .CatalogDropDown
+            )
+        }
+
         layoutState?.publishStateChange()
     }
 

--- a/Tests/RoktUXHelperTests/UI/Components/TestCatalogDevicePayButtonComponent.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/TestCatalogDevicePayButtonComponent.swift
@@ -115,6 +115,42 @@ final class TestCatalogDevicePayButtonComponent: XCTestCase {
 
         XCTAssertFalse(eventService.cartItemDevicePayCalled)
         XCTAssertTrue(eventService.cartItemUserInteractionCalled)
+        XCTAssertEqual(eventService.lastUserInteractionAction, .ValidationTriggerFailed)
+        XCTAssertEqual(eventService.lastUserInteractionContext, .CustomStateValidationTriggerButton)
+    }
+
+    func test_handleTap_validationPasses_sendsOfferProgression() {
+        let layoutState = MockLayoutState()
+        let eventService = MockEventService()
+        let catalogItem = CatalogItem.mock(catalogItemId: "item-1")
+
+        layoutState.validationCoordinator.registerField(
+            key: "dropdown",
+            owner: self,
+            validation: { .valid },
+            onStatusChange: { _ in }
+        )
+
+        let sut = CatalogDevicePayButtonViewModel(
+            catalogItem: catalogItem,
+            children: nil,
+            provider: .applePay,
+            layoutState: layoutState,
+            eventService: eventService,
+            defaultStyle: nil,
+            pressedStyle: nil,
+            hoveredStyle: nil,
+            disabledStyle: nil,
+            validatorTriggerConfig: ValidationTriggerConfig(validatorFieldKeys: ["dropdown"])
+        )
+
+        sut.handleTap()
+
+        XCTAssertTrue(eventService.cartItemUserInteractionCalled)
+        XCTAssertEqual(eventService.lastUserInteractionItemId, "item-1")
+        XCTAssertEqual(eventService.lastUserInteractionAction, .OfferProgression)
+        XCTAssertEqual(eventService.lastUserInteractionContext, .CustomStateValidationTriggerButton)
+        XCTAssertTrue(eventService.cartItemDevicePayCalled)
     }
 
     func test_devicePayCompletion_success_setsCustomState() {

--- a/Tests/RoktUXHelperTests/UI/ViewModel/CatalogDropdownViewModelTests.swift
+++ b/Tests/RoktUXHelperTests/UI/ViewModel/CatalogDropdownViewModelTests.swift
@@ -43,6 +43,30 @@ final class CatalogDropdownViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.persistedSelectedIndex)
     }
 
+    func test_selectItem_emitsDropDownItemSelected() {
+        let (layoutState, _) = makeLayoutStateWithGroup()
+        let eventService = MockEventService()
+        let viewModel = makeViewModel(layoutState: layoutState, eventService: eventService)
+
+        viewModel.selectItem(at: 0)
+
+        XCTAssertTrue(eventService.cartItemUserInteractionCalled)
+        XCTAssertEqual(eventService.lastUserInteractionItemId, "item1")
+        XCTAssertEqual(eventService.lastUserInteractionAction, .DropDownItemSelected)
+        XCTAssertEqual(eventService.lastUserInteractionContext, .CatalogDropDown)
+    }
+
+    func test_selectItem_disabledOption_doesNotEmit() {
+        let (layoutState, _) = makeLayoutStateWithGroup()
+        let eventService = MockEventService()
+        let viewModel = makeViewModel(layoutState: layoutState, eventService: eventService)
+
+        // Option 1 is out of stock — ignored, so no signal.
+        viewModel.selectItem(at: 1)
+
+        XCTAssertFalse(eventService.cartItemUserInteractionCalled)
+    }
+
     func test_displayText_showsPlaceholderWhenNothingSelected() {
         let (layoutState, _) = makeLayoutStateWithGroup()
         let viewModel = makeViewModel(layoutState: layoutState, placeholderValue: "Please select")


### PR DESCRIPTION
## Background

The catalog variation dropdown (`CatalogDropDown`) updated its selection state but emitted no `SignalUserInteraction`, leaving dropdown engagement invisible to event consumers. This adds the missing signal to match the cross-platform event contract (the web renderer already emits it).

> Stacked on #318 — review/merge that first. This PR's diff is scoped to the dropdown change.

## What Has Changed

- `CatalogDropdownViewModel.selectItem(at:)` now emits `SignalUserInteraction` (`DropDownItemSelected` / `CatalogDropDown`), scoped to the catalog item behind the chosen option, when a valid option is selected.
- Disabled / out-of-stock options remain ignored and emit nothing.
- Added unit tests for the emit and the no-emit-on-disabled cases.

## Screenshots/Video

Not applicable — event behaviour change, no UI change.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation. Not applicable.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Local validation: `CatalogDropdownViewModelTests` suite passes on iPhone 16 Pro (iOS 18.5) simulator.
- Second in a stack of instant-purchase signal PRs.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- N/A

## Testing

- Unit: `CatalogDropdownViewModelTests.test_selectItem_emitsDropDownItemSelected`.
- Live app: rendered the layout in the Example app via `tools/merge_layout.py`, opened the dropdown and selected an option → confirmed `SignalUserInteraction` (`DropDownItemSelected` / `CatalogDropDown`) delivered to `onPlatformEvent`.
