### PR TITLE
fix: Retryable Stripe Support

### DIFF
--- a/Sources/RoktUXHelper/RoktUX.swift
+++ b/Sources/RoktUXHelper/RoktUX.swift
@@ -295,6 +295,15 @@ public class RoktUX: UXEventsDelegate {
     }
 
     /**
+     Call when the user cancels device pay (e.g. dismisses the Stripe payment sheet)
+     without completing the purchase. Returns the layout to the product detail state
+     without emitting a purchase-failure signal.
+     */
+    public func devicePayRetry(layoutId: String, catalogItemId: String) {
+        eventServices[layoutId]?.cartItemDevicePayRetry(itemId: catalogItemId)
+    }
+
+    /**
      Call after `/v1/cart/initialize-purchase` returns to display the confirmation screen
      for a device-pay flow (e.g. PayPal). The catalog-runtime dictionary is published into the
      layout's reactive state and resolved against `%^DATA.catalogRuntime.<key>^%` placeholders.

--- a/Sources/RoktUXHelper/Services/Events/EventService.swift
+++ b/Sources/RoktUXHelper/Services/Events/EventService.swift
@@ -274,6 +274,13 @@ class EventService: Hashable, EventDiagnosticServicing {
         devicePayCompletion = nil
     }
 
+    func cartItemDevicePayRetry(itemId: String) {
+        guard catalogItems.contains(where: { $0.catalogItemId == itemId }) else { return }
+        guard let completion = devicePayCompletion else { return }
+        completion(.retry)
+        devicePayCompletion = nil
+    }
+
     /// Invoked when the host SDK has fetched the order breakdown from
     /// `/v1/cart/initialize-purchase` (or equivalent) and wants the UX to display the
     /// confirmation screen. Resolves the stored `devicePayCompletion` with the breakdown

--- a/Sources/RoktUXHelper/Services/Events/EventServicing.swift
+++ b/Sources/RoktUXHelper/Services/Events/EventServicing.swift
@@ -26,6 +26,7 @@ protocol EventServicing: AnyObject {
     )
     func cartItemDevicePaySuccess(itemId: String)
     func cartItemDevicePayFailure(itemId: String)
+    func cartItemDevicePayRetry(itemId: String)
     func cartItemDevicePayPendingConfirmation(itemId: String, catalogRuntimeData: [String: String])
     func cartItemForwardPayment(
         catalogItem: CatalogItem,

--- a/Sources/RoktUXHelper/UI/Components/ViewModel/CatalogDevicePayButtonViewModel.swift
+++ b/Sources/RoktUXHelper/UI/Components/ViewModel/CatalogDevicePayButtonViewModel.swift
@@ -82,8 +82,10 @@ class CatalogDevicePayButtonViewModel: Identifiable, Hashable, ScreenSizeAdaptiv
         switch status {
         case .success:
             setLayoutVariantCustomState(key: customStateKey, value: 1)
-        case .failure, .retry:
+        case .failure:
             setLayoutVariantCustomState(key: customStateKey, value: -1)
+        case .retry:
+            break
         case .pendingConfirmation(let catalogRuntimeData):
             // Publish runtime data first so reactive text resolution sees the values when the
             // confirmation subtree mounts on the devicePayState=1 transition.

--- a/Sources/RoktUXHelper/UI/RoktLayoutUIView.swift
+++ b/Sources/RoktUXHelper/UI/RoktLayoutUIView.swift
@@ -108,6 +108,11 @@ import SwiftUI
         uxHelper?.devicePayFinalized(layoutId: layoutId, catalogItemId: catalogItemId, success: success)
     }
 
+    /// Call when the user cancels device pay without completing the purchase.
+    public func devicePayRetry(layoutId: String, catalogItemId: String) {
+        uxHelper?.devicePayRetry(layoutId: layoutId, catalogItemId: catalogItemId)
+    }
+
     /// Call after the host SDK has fetched the runtime catalog data (e.g. an order breakdown
     /// from `/v1/cart/initialize-purchase`) to display the confirmation screen.
     /// - Parameters:

--- a/Tests/RoktUXHelperTests/Services/Events/TestEventService.swift
+++ b/Tests/RoktUXHelperTests/Services/Events/TestEventService.swift
@@ -479,6 +479,30 @@ final class TestEventService: XCTestCase {
         }
     }
 
+    func test_devicePayRetry_invokesCompletionWithoutFailureSignal() {
+        let eventService = get_mock_event_processor(startDate: startDate,
+                                                    catalogItems: [.mock(catalogItemId: "catalogItemId")],
+                                                    uxEventDelegate: stubUXHelper,
+                                                    eventHandler: { event in
+            self.events.append(event)
+        })
+        var completionStatus: DevicePayStatus?
+        eventService.cartItemDevicePay(
+            catalogItem: .mock(catalogItemId: "catalogItemId"),
+            paymentProvider: .afterpay,
+            transactionData: nil,
+            completion: { status in completionStatus = status }
+        )
+        events.removeAll()
+
+        eventService.cartItemDevicePayRetry(itemId: "catalogItemId")
+
+        XCTAssertTrue(events.isEmpty, "retry must not emit SignalCartItemInstantPurchaseFailure")
+        guard case .retry = completionStatus else {
+            return XCTFail("expected .retry completion, got \(String(describing: completionStatus))")
+        }
+    }
+
     func test_device_pay_duplicate_call_short_circuits_with_failure_while_processing() {
         let eventService = get_mock_event_processor(startDate: startDate,
                                                     catalogItems: [.mock(catalogItemId: "catalogItemId")],

--- a/Tests/RoktUXHelperTests/UI/ViewModel/CatalogDevicePayButtonViewModelTests.swift
+++ b/Tests/RoktUXHelperTests/UI/ViewModel/CatalogDevicePayButtonViewModelTests.swift
@@ -184,7 +184,7 @@ final class CatalogDevicePayButtonViewModelTests: XCTestCase {
         )
     }
 
-    func test_devicePayRetry_setsLayoutVariantCustomState() {
+    func test_devicePayRetry_doesNotSetPaymentResult() {
         let layoutState = MockLayoutState()
         let eventService = MockEventService()
         let isValid = true
@@ -225,12 +225,11 @@ final class CatalogDevicePayButtonViewModelTests: XCTestCase {
 
         wait(for: [expectation], timeout: 1.0)
 
-        XCTAssertEqual(
+        XCTAssertNil(
             layoutState.layoutVariantCustomStateValue(
                 for: CustomStateIdentifiable.Keys.paymentResult.rawValue,
                 position: 0
-            ),
-            -1
+            )
         )
     }
 

--- a/Tests/RoktUXHelperTests/UI/ViewModel/Mocks/MockEventService.swift
+++ b/Tests/RoktUXHelperTests/UI/ViewModel/Mocks/MockEventService.swift
@@ -39,6 +39,7 @@ class MockEventService: EventDiagnosticServicing {
     var cartItemDevicePayCallCount = 0
     var cartItemDevicePaySuccessCalled = false
     var cartItemDevicePayFailureCalled = false
+    var cartItemDevicePayRetryCalled = false
     var cartItemDevicePayPendingConfirmationCalled = false
     var lastDevicePayPendingConfirmationItemId: String?
     var lastDevicePayPendingConfirmationData: [String: String]?
@@ -158,6 +159,10 @@ class MockEventService: EventDiagnosticServicing {
         cartItemDevicePayFailureCalled = true
     }
 
+    func cartItemDevicePayRetry(itemId: String) {
+        cartItemDevicePayRetryCalled = true
+    }
+
     func cartItemDevicePayPendingConfirmation(itemId: String, catalogRuntimeData: [String: String]) {
         cartItemDevicePayPendingConfirmationCalled = true
         lastDevicePayPendingConfirmationItemId = itemId
@@ -226,6 +231,7 @@ class MockEventService: EventDiagnosticServicing {
         cartItemDevicePayCallCount = 0
         cartItemDevicePaySuccessCalled = false
         cartItemDevicePayFailureCalled = false
+        cartItemDevicePayRetryCalled = false
         cartItemDevicePayPendingConfirmationCalled = false
         cartItemDevicePayLastProvider = nil
         lastDevicePayPendingConfirmationItemId = nil


### PR DESCRIPTION
## Background

- Device pay flows (e.g. Stripe) can be cancelled by the user before a purchase completes — such as when they dismiss the payment sheet without paying.
- Previously, the host SDK had no dedicated way to report this scenario. Calling devicePayFinalized(success: false) treated cancellation as a purchase failure: it emitted SignalCartItemInstantPurchaseFailure and set the layout's paymentResult custom state to -1, showing failure UI instead of leaving the user on the product detail screen to try again.

## What Has Changed

- Added devicePayRetry(layoutId:catalogItemId:) to RoktUX and RoktLayoutUIView for host SDKs to call when the user cancels device pay without completing the purchase.
- Added cartItemDevicePayRetry(itemId:) to the event service layer, which resolves the pending device-pay completion with .retry and does not emit a purchase-failure signal.
- Updated CatalogDevicePayButtonViewModel so .retry clears the processing state without setting paymentResult to -1, keeping the layout on the product detail screen.
- Added and updated unit tests to verify retry invokes the completion without a failure signal and does not update payment result layout state.

## Screenshots/Video

- {Include any screenshots or video demonstrating the new feature or fix, if applicable}

## Checklist

- [x I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes [ticket](https://go/j/[ticket-number])
