### PR TITLE
ci: use CI runner/Xcode repo variables across all macOS workflow jobs

### DIFF
--- a/.github/workflows/ci-size-report.yml
+++ b/.github/workflows/ci-size-report.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   measure-size:
-    runs-on: macos-15
+    runs-on: ${{ vars.CI_MACOS_RUNNER || 'macos-latest' }}
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -35,7 +35,7 @@ jobs:
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
-          xcode-version: "26.2"
+          xcode-version: ${{ vars.CI_XCODE_VERSION || '26.2' }}
 
       # The base branch may not have the size tooling yet (e.g. before this
       # merges, or if the script is relocated); both steps fall back to an empty

--- a/.github/workflows/maintenance-trunk-upgrade.yml
+++ b/.github/workflows/maintenance-trunk-upgrade.yml
@@ -35,7 +35,7 @@ jobs:
 
   trunk-check:
     name: Trunk code check
-    runs-on: macos-latest
+    runs-on: ${{ vars.CI_MACOS_RUNNER || 'macos-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   trunk-check:
-    runs-on: macos-latest
+    runs-on: ${{ vars.CI_MACOS_RUNNER || 'macos-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -29,7 +29,7 @@ jobs:
           check-mode: all
 
   podspec-lint:
-    runs-on: macos-15
+    runs-on: ${{ vars.CI_MACOS_RUNNER || 'macos-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -73,7 +73,7 @@ jobs:
 
   publish-cocoapods:
     needs: build-and-release
-    runs-on: macos-15
+    runs-on: ${{ vars.CI_MACOS_RUNNER || 'macos-latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- Stacked on top of #322, which introduced the `CI_MACOS_RUNNER`, `CI_XCODE_VERSION`, `CI_SIMULATOR_MODEL`, and `CI_SIMULATOR_OS` repository variables and wired them into the two jobs that run the iOS test suite.
- Several other macOS jobs still hard-coded their runner label (and one hard-coded Xcode), so a future GitHub runner-image change would still require a code PR to fix them.

## What Has Changed

- Apply `CI_MACOS_RUNNER` (default `macos-latest`) to the remaining macOS jobs:
  - `pull-request.yml` — `trunk-check`, `podspec-lint`
  - `release-publish.yml` — `publish-cocoapods`
  - `ci-size-report.yml` — `measure-size`
  - `maintenance-trunk-upgrade.yml` — `trunk-check`
- Apply `CI_XCODE_VERSION` (default `26.2`) to the size-report's `Select Xcode` step.
- Defaults match today's values, so behavior is unchanged until a variable is set. Ubuntu-only jobs are intentionally left as-is (unrelated to these variables).

## Screenshots/Video

- N/A — CI configuration only.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation. <!-- Variables documented in TESTING.md via #322. -->
- [ ] I have added tests that prove my fix is effective or that my feature works. <!-- CI-config only. -->
- [x] I have tested this locally. <!-- Format identical to the already-green parameterized lines from #322. -->

## Additional Notes

- Depends on #322 — review/merge that first (this PR targets its branch).
- After merge, the four repo variables (Settings → Secrets and variables → Actions → Variables) control every macOS job's runner + Xcode with no further PRs.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- N/A
