### PR TITLE
feat(ci): guard release-publish on existing tag + roll back VERSION on failure

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -12,8 +12,44 @@ permissions:
   contents: write
 
 jobs:
-  build-and-release:
+  # Guard: if the version in VERSION already has a GitHub release, stop before doing
+  # anything. This makes any VERSION change to an already-released version a no-op, so a
+  # rollback (or a re-run) can never re-publish an existing version.
+  preflight:
+    name: Preflight – skip if already released
     if: ${{ !github.event.created && !github.event.deleted }}
+    runs-on: ubuntu-latest
+    outputs:
+      release-version: ${{ steps.version-file.outputs.release-version }}
+      should-release: ${{ steps.guard.outputs.should-release }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Get current version
+        id: version-file
+        run: |
+          version_from_file=$(head -n 1 VERSION | tr -d '\r\n ')
+          echo "release-version=$version_from_file" >> "$GITHUB_OUTPUT"
+
+      - name: Skip if version already released
+        id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.version-file.outputs.release-version }}
+        run: |
+          if gh release view "$RELEASE_VERSION" >/dev/null 2>&1; then
+            echo "::notice::Version $RELEASE_VERSION already has a GitHub release — skipping publish."
+            echo "should-release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should-release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-and-release:
+    needs: preflight
+    if: ${{ needs.preflight.outputs.should-release == 'true' }}
     runs-on: ${{ vars.CI_MACOS_RUNNER || 'macos-latest' }}
     steps:
       - name: Checkout code
@@ -72,7 +108,8 @@ jobs:
             ${{ steps.extract-release-notes.outputs.release_notes }}
 
   publish-cocoapods:
-    needs: build-and-release
+    needs: [preflight, build-and-release]
+    if: ${{ needs.preflight.outputs.should-release == 'true' }}
     runs-on: ${{ vars.CI_MACOS_RUNNER || 'macos-latest' }}
     steps:
       - name: Checkout code
@@ -84,3 +121,55 @@ jobs:
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: pod trunk push RoktUXHelper.podspec --allow-warnings
+
+  # If the release build/tag creation fails, open a PR that reverts VERSION to the
+  # previously-released value so the release line is not left stuck on a version that
+  # never shipped. Merging that PR is safe because the preflight guard stops a re-release
+  # of an already-tagged version.
+  rollback-on-failure:
+    name: Roll back VERSION on failed release
+    needs: [preflight, build-and-release]
+    if: ${{ always() && needs.preflight.outputs.should-release == 'true' && needs.build-and-release.result == 'failure' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Determine previous version
+        id: prev
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          prev=$(git show "$BEFORE:VERSION" 2>/dev/null | head -n1 | tr -d '\r\n ' || true)
+          if [ -z "$prev" ]; then
+            prev=$(git show HEAD~1:VERSION | head -n1 | tr -d '\r\n ')
+          fi
+          echo "previous-version=$prev" >> "$GITHUB_OUTPUT"
+
+      - name: Roll back VERSION file
+        env:
+          PREV: ${{ steps.prev.outputs.previous-version }}
+        run: printf '%s\n' "$PREV" > VERSION
+
+      - name: Open rollback pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          branch: rollback/version-${{ needs.preflight.outputs.release-version }}
+          base: ${{ github.ref_name }}
+          commit-message: "Roll back VERSION to ${{ steps.prev.outputs.previous-version }} after failed release of ${{ needs.preflight.outputs.release-version }}"
+          title: "Roll back VERSION to ${{ steps.prev.outputs.previous-version }} after failed release ${{ needs.preflight.outputs.release-version }}"
+          body: |
+            The `Release – Publish` run for `${{ needs.preflight.outputs.release-version }}` failed before completing:
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            This PR reverts `VERSION` back to `${{ steps.prev.outputs.previous-version }}` so the release line reflects the last successfully-published version.
+
+            **Merging is safe:** the `preflight` guard stops `Release – Publish` when the version in `VERSION` already has a GitHub release, so restoring `${{ steps.prev.outputs.previous-version }}` will not start another release.
+
+            To retry `${{ needs.preflight.outputs.release-version }}`, re-run the failed workflow run, or re-run `Release – Draft` after this merges.

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -32,6 +32,14 @@ jobs:
         id: version-file
         run: |
           version_from_file=$(head -n 1 VERSION | tr -d '\r\n ')
+          # Validate before propagating: this value flows into branch names, commit
+          # messages and PR titles/bodies downstream, so reject anything that isn't a
+          # plain semver (optionally with a pre-release suffix). This also prevents
+          # GITHUB_OUTPUT injection via crafted VERSION content.
+          if [[ ! "$version_from_file" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::VERSION file contains an invalid version string: '$version_from_file'"
+            exit 1
+          fi
           echo "release-version=$version_from_file" >> "$GITHUB_OUTPUT"
 
       - name: Skip if version already released


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

Releases are triggered by a change to `VERSION` on `main`/`maintenance/*`. When a `Release – Publish` run fails, `main`'s `VERSION` is already at the new version, so there's no clean way to retrigger without hand-editing `VERSION` — and any such edit risks kicking off *another* release. `main` is protected (PR + approval, no bypass actors), so a workflow can't push a `VERSION` change directly.

## What Has Changed

`.github/workflows/release-publish.yml`:

1. **`preflight` tag-existence guard (new first job).** Reads `VERSION` and checks `gh release view`. If that version already has a GitHub release, it sets `should-release=false` and every downstream job is skipped. This makes any `VERSION` change to an already-released version a safe no-op — a rollback (or a re-run) can never re-publish an existing version.
2. **`build-and-release` and `publish-cocoapods` are gated** on `needs.preflight.outputs.should-release == 'true'`.
3. **`rollback-on-failure` (new job).** If `build-and-release` fails, it opens a PR reverting `VERSION` to the previously-released value (derived from `github.event.before:VERSION`). A human merges it (branch protection); the guard guarantees merging it won't start a new release. Uses the same `peter-evans/create-pull-request` action already used by `Release – Draft`.

Pattern mirrors `ROKT/rokt-sdk-ios`'s gating `detect` job, gating on "not already released."

## Screenshots/Video

- N/A — CI/release-automation change.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation. <!-- Behavior documented in this PR; RELEASING.md follow-up optional. -->
- [ ] I have added tests that prove my fix is effective or that my feature works. <!-- Workflow logic; validated by actionlint + reasoning. Safe end-to-end test requires a throwaway maintenance branch, not main. -->
- [x] I have tested this locally. <!-- actionlint + yamllint pass (trunk check). -->

## Behavior / edge cases

- **Retrigger a flaky failure:** just "Re-run failed jobs" — the guard sees no tag (pre-tag failure) and proceeds; no `VERSION` change needed.
- **Merging the rollback PR:** pushes the previous (already-tagged) version → guard stops → no re-release.
- **Failure after the release/tag was created (e.g. only CocoaPods failed):** `build-and-release` succeeded, so rollback does *not* fire; re-running is gated off by the guard. Retry CocoaPods separately.
- **Test failures** are inside `build-and-release`, so they also open a rollback PR — close it and fix-forward if you'd rather.

## Additional Notes

- Stacked on #322 (base = `claude/magical-matsumoto-1a73ce`, which already contains the merged #323). Rebase to `main` once #322 merges.
- Recommend an end-to-end dry-run on a throwaway `maintenance/*` branch before relying on it (see the PR's plan): confirm the guard skips an already-released version and that a forced failure opens the rollback PR. Do not test on `main`.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- N/A
