### PR TITLE
fix(ci): make CocoaPods publish idempotent to avoid false failures

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -87,10 +87,6 @@ jobs:
           set -o pipefail
           version=$(head -n 1 VERSION)
 
-          # `pod trunk push` is not idempotent: a re-run, or a transient trunk
-          # error that occurs *after* the spec was already accepted, leaves the
-          # version published yet reports the job as failed. Skip the push when
-          # the version is already on trunk so those cases stay green.
           if pod trunk info RoktUXHelper 2>/dev/null | grep -qE "^[[:space:]]*-[[:space:]]*${version//./\\.}([[:space:]].*)?$"; then
             echo "RoktUXHelper ${version} is already published to CocoaPods trunk; skipping push."
             exit 0

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -83,4 +83,17 @@ jobs:
       - name: Publish to CocoaPods
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-        run: pod trunk push RoktUXHelper.podspec --allow-warnings
+        run: |
+          set -o pipefail
+          version=$(head -n 1 VERSION)
+
+          # `pod trunk push` is not idempotent: a re-run, or a transient trunk
+          # error that occurs *after* the spec was already accepted, leaves the
+          # version published yet reports the job as failed. Skip the push when
+          # the version is already on trunk so those cases stay green.
+          if pod trunk info RoktUXHelper 2>/dev/null | grep -qE "^[[:space:]]*-[[:space:]]*${version//./\\.}([[:space:]].*)?$"; then
+            echo "RoktUXHelper ${version} is already published to CocoaPods trunk; skipping push."
+            exit 0
+          fi
+
+          pod trunk push RoktUXHelper.podspec --allow-warnings


### PR DESCRIPTION
## Background

The `Release – Publish` → `publish-cocoapods` job intermittently reports **failure even when the release succeeded**, which is confusing when triaging releases.

Concrete example — `RoktUXHelper 0.13.0` ([run 28818821716](https://github.com/ROKT/rokt-ux-helper-ios/actions/runs/28818821716)):

| Time (UTC) | What happened |
|---|---|
| 20:01:30 | Attempt 1 `pod trunk push` starts validating |
| **20:03:10** | Spec **accepted & registered on trunk** → 0.13.0 goes live |
| 20:03:16 | Trunk returns `An internal server error occurred` → CLI exits 1, job goes red |
| 20:04:26 | Re-run (attempt 2) fails with `Unable to accept duplicate entry for: RoktUXHelper (0.13.0)` |

So the pod was published, but both attempts showed red: attempt 1 hit a transient trunk 500 *after* the push was accepted, and the re-run hit the duplicate.

## What changed

`pod trunk push` is not idempotent. This guards the push with `pod trunk info`: if the current `VERSION` is already on trunk, the step logs and exits 0 instead of erroring. This covers both re-runs and transient trunk errors that occur after the spec was already accepted.

No change to the happy path — a genuinely-new version still pushes exactly as before.

## Testing

- Validated the workflow YAML (yaml-lint ✔).
- Verified the version-match grep against real `pod trunk info` output: matches when the version is present (skips) and does not match when absent (pushes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)