### PR TITLE
refactor(api): trim public surface before 1.0.0

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -2,6 +2,54 @@
 
 This document provides guidance on migrating to newer versions of `rokt-ux-helper-ios`.
 
+## Migrating to 1.0.0
+
+Version **1.0.0** trims the public API surface ahead of the first stable release. The changes below are the only ones that can affect callers.
+
+> Note: log **configuration** is unchanged — `RoktUXLogLevel`, `RoktUX.setLogLevel(_:)`, and `RoktUXConfig.Builder.logLevel(_:)` all remain public. Only the deprecated `enableLogging(_:)` and the internal `RoktUXLogger` implementation are affected.
+
+### Removed: `RoktUXConfig.Builder.enableLogging(_:)`
+
+The deprecated `enableLogging(_:)` builder method has been removed. Use `logLevel(_:)` instead.
+
+```swift
+// Before
+let config = RoktUXConfig.Builder()
+    .enableLogging(true)
+    .build()
+
+// After
+let config = RoktUXConfig.Builder()
+    .logLevel(.debug)   // use .none to disable logging
+    .build()
+```
+
+### `RoktUXLogger` is now internal
+
+The `RoktUXLogger` implementation class is no longer part of the public API. Configure logging through the public log-level API instead of touching the logger directly.
+
+```swift
+// Before
+RoktUXLogger.shared.logLevel = .debug
+
+// After
+RoktUX.setLogLevel(.debug)
+// or per-configuration:
+let config = RoktUXConfig.Builder().logLevel(.debug).build()
+```
+
+### Removed: `RoktUXPaymentProvider`
+
+The unused `RoktUXPaymentProvider` type alias has been removed. Reference `PaymentProvider` directly (for example, via `CartItemDevicePay.paymentProvider`).
+
+```swift
+// Before
+let provider: RoktUXPaymentProvider = cartItem.paymentProvider
+
+// After
+let provider: PaymentProvider = cartItem.paymentProvider
+```
+
 ## Migrating from versions < 0.3.0
 
 From version **0.3.0 onwards**, the `ImageLoader` class has been **renamed** to `RoktUXImageLoader` to maintain consistency with the library's naming conventions.

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/OuterLayoutSchemaNetworkModel.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/OuterLayoutSchemaNetworkModel.swift
@@ -3,9 +3,9 @@ import DcuiSchema
 
 @available(iOS 13, *)
 struct OuterLayoutSchemaNetworkModel: Decodable {
-    public let breakpoints: BreakPoint?
-    public let layout: LayoutSchemaModel?
-    public let settings: LayoutSettings?
+    let breakpoints: BreakPoint?
+    let layout: LayoutSchemaModel?
+    let settings: LayoutSettings?
 }
 
 @available(iOS 13, *)

--- a/Sources/RoktUXHelper/Data/Model/ExperienceResponse/RoktUXPaymentProvider.swift
+++ b/Sources/RoktUXHelper/Data/Model/ExperienceResponse/RoktUXPaymentProvider.swift
@@ -1,4 +1,0 @@
-import Foundation
-import DcuiSchema
-
-public typealias RoktUXPaymentProvider = PaymentProvider

--- a/Sources/RoktUXHelper/Services/Events/ViewModel/FontDiagnosticsViewModel.swift
+++ b/Sources/RoktUXHelper/Services/Events/ViewModel/FontDiagnosticsViewModel.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 class FontDiagnosticsViewModel {
-    public init(processedFontDiagnostics: Set<FontDiagnostics> = Set<FontDiagnostics>()) {
+    init(processedFontDiagnostics: Set<FontDiagnostics> = Set<FontDiagnostics>()) {
         self.processedFontDiagnostics = processedFontDiagnostics
     }
 
-    public var processedFontDiagnostics = Set<FontDiagnostics>()
+    var processedFontDiagnostics = Set<FontDiagnostics>()
 
-    public func insertProcessedFontDiagnostics(_ fontFamily: String) -> Bool {
+    func insertProcessedFontDiagnostics(_ fontFamily: String) -> Bool {
         let pendingFontDiagnostics = FontDiagnostics(fontFamily: fontFamily)
         return processedFontDiagnostics.insert(pendingFontDiagnostics).inserted
     }

--- a/Sources/RoktUXHelper/Services/LayoutState.swift
+++ b/Sources/RoktUXHelper/Services/LayoutState.swift
@@ -56,7 +56,7 @@ class LayoutState: LayoutStateRepresenting {
         config?.imageLoader
     }
 
-    public let initialPluginViewState: RoktPluginViewState?
+    let initialPluginViewState: RoktPluginViewState?
     private let pluginId: String?
     private let onPluginViewStateChange: ((RoktPluginViewState) -> Void)?
 

--- a/Sources/RoktUXHelper/Services/Logging/RoktUXLogger.swift
+++ b/Sources/RoktUXHelper/Services/Logging/RoktUXLogger.swift
@@ -10,9 +10,9 @@ import Foundation
 /// RoktUXLogger.shared.logLevel = .debug
 /// RoktUXLogger.shared.debug("Layout loaded")
 /// ```
-public final class RoktUXLogger: @unchecked Sendable {
+final class RoktUXLogger: @unchecked Sendable {
     /// Shared singleton instance
-    public private(set) static var shared = RoktUXLogger()
+    private(set) static var shared = RoktUXLogger()
 
     /// Replaces the shared instance. Primarily for testing.
     /// - Parameter logger: The logger instance to use as shared
@@ -29,7 +29,7 @@ public final class RoktUXLogger: @unchecked Sendable {
 
     /// The current log level. Messages below this level will not be logged.
     /// Default is `.none` (no logging).
-    public var logLevel: RoktUXLogLevel {
+    var logLevel: RoktUXLogLevel {
         get { lock.withLock { _logLevel } }
         set { lock.withLock { _logLevel = newValue } }
     }
@@ -42,7 +42,7 @@ public final class RoktUXLogger: @unchecked Sendable {
     ///   - file: Source file (automatically captured)
     ///   - function: Source function (automatically captured)
     ///   - line: Source line (automatically captured)
-    public func verbose(
+    func verbose(
         _ message: String,
         error: Error? = nil,
         file: String = #file,
@@ -60,7 +60,7 @@ public final class RoktUXLogger: @unchecked Sendable {
     ///   - file: Source file (automatically captured)
     ///   - function: Source function (automatically captured)
     ///   - line: Source line (automatically captured)
-    public func debug(
+    func debug(
         _ message: String,
         error: Error? = nil,
         file: String = #file,
@@ -77,7 +77,7 @@ public final class RoktUXLogger: @unchecked Sendable {
     ///   - file: Source file (automatically captured)
     ///   - function: Source function (automatically captured)
     ///   - line: Source line (automatically captured)
-    public func info(
+    func info(
         _ message: String,
         error: Error? = nil,
         file: String = #file,
@@ -94,7 +94,7 @@ public final class RoktUXLogger: @unchecked Sendable {
     ///   - file: Source file (automatically captured)
     ///   - function: Source function (automatically captured)
     ///   - line: Source line (automatically captured)
-    public func warning(
+    func warning(
         _ message: String,
         error: Error? = nil,
         file: String = #file,
@@ -111,7 +111,7 @@ public final class RoktUXLogger: @unchecked Sendable {
     ///   - file: Source file (automatically captured)
     ///   - function: Source function (automatically captured)
     ///   - line: Source line (automatically captured)
-    public func error(
+    func error(
         _ message: String,
         error: Error? = nil,
         file: String = #file,

--- a/Sources/RoktUXHelper/UI/Components/Config/RoktUXConfig.swift
+++ b/Sources/RoktUXHelper/UI/Components/Config/RoktUXConfig.swift
@@ -51,15 +51,6 @@ public struct RoktUXConfig {
             return self
         }
 
-        /// Enables or disables debug logging for the RoktUXConfig.
-        /// - Parameter enable: A Boolean value indicating whether debug logging should be enabled.
-        /// - Returns: The Builder instance with the updated logging configuration.
-        @available(*, deprecated, message: "Use logLevel(_:) instead")
-        public func enableLogging(_ enable: Bool) -> Builder {
-            self.logLevel = enable ? .debug : RoktUXLogLevel.none
-            return self
-        }
-
         /// Sets the log level for the RoktUXConfig.
         /// - Parameter logLevel: The log level to be set.
         /// - Returns: The Builder instance with the updated log level configuration.

--- a/Sources/RoktUXHelper/UI/RoktLayoutView/RoktLayoutViewModel.swift
+++ b/Sources/RoktUXHelper/UI/RoktLayoutView/RoktLayoutViewModel.swift
@@ -46,20 +46,20 @@ extension RoktLayoutViewModel {
     /// - Parameters:
     ///   - onSizeChanged: Closure to handle size changes.
     ///   - injectedView: A closure returning the SwiftUI view to embed.
-    public func load<Content: View>(onSizeChanged: @escaping ((CGFloat) -> Void),
-                                    @ViewBuilder injectedView: @escaping () -> Content) {
+    func load<Content: View>(onSizeChanged: @escaping ((CGFloat) -> Void),
+                             @ViewBuilder injectedView: @escaping () -> Content) {
         RoktUXLogger.shared.debug("Embedded view attached to the screen")
         state = .ready(AnyView(injectedView()))
     }
 
     /// Closes the embedded view.
-    public func closeEmbedded() {
+    func closeEmbedded() {
         updateEmbeddedSize(0)
         state = .empty
         RoktUXLogger.shared.debug("User journey ended on Embedded view")
     }
 
-    public func updateEmbeddedSize(_ size: CGFloat) {
+    func updateEmbeddedSize(_ size: CGFloat) {
         height = size
         RoktUXLogger.shared.debug("Embedded height resized to \(size)")
     }

--- a/Tests/RoktUXHelperTests/UI/Components/Config/TestRoktUXConfig.swift
+++ b/Tests/RoktUXHelperTests/UI/Components/Config/TestRoktUXConfig.swift
@@ -39,20 +39,6 @@ class RoktUXConfigTests: XCTestCase {
             .build()
         XCTAssertEqual(config.logLevel, .verbose)
     }
-
-    func testDeprecatedEnableLogging() {
-        let config = RoktUXConfig.Builder()
-            .enableLogging(true)
-            .build()
-        XCTAssertEqual(config.logLevel, .debug)
-    }
-
-    func testDeprecatedEnableLoggingFalse() {
-        let config = RoktUXConfig.Builder()
-            .enableLogging(false)
-            .build()
-        XCTAssertEqual(config.logLevel, .none)
-    }
 }
 
 class MockImageLoader: RoktUXImageLoader {


### PR DESCRIPTION
## What

Pre-1.0.0 trim of the `RoktUXHelper` public API surface. Since 1.0.0 freezes the SemVer contract, this removes/demotes public symbols that no consumer needs, so we don't commit to maintaining them.

Scope is deliberately limited to **low-risk, verified-safe** changes. None of these touch anything the consumer SDK (`rokt-sdk-ios`) references — verified against the SDK's `workstation/transactions` branch (usage count 0 for each removed/demoted external symbol).

## Changes

| # | Change | Symbol | Rationale |
|---|--------|--------|-----------|
| 1 | **Remove** | `RoktUXPaymentProvider` (typealias) | Dead — zero references in module, Example, Tests, or the SDK. The underlying `PaymentProvider` stays exposed via `CartItemDevicePay.paymentProvider`. |
| 2 | **Remove** | `RoktUXConfig.Builder.enableLogging(_:)` | The only `@available(*, deprecated)` symbol in the module; superseded by `logLevel(_:)`. Not used by the SDK. Its two dedicated tests are removed (the `logLevel` path is already covered). |
| 3 | **Internalize** | `RoktUXLogger` (class + `shared`, `logLevel`, `verbose`/`debug`/`info`/`warning`/`error`) | No external consumer — logging is configured via `RoktUX.setLogLevel(_:)` / `RoktUXConfig`. Used only inside the module. |
| 4 | **Strip redundant `public`** | Members of internal types: `OuterLayoutSchemaNetworkModel` fields, `FontDiagnosticsViewModel` init/members, `LayoutState.initialPluginViewState`, `RoktLayoutViewModel.load`/`closeEmbedded`/`updateEmbeddedSize` | Compiler no-op (enclosing types are `internal`) — pure hygiene, zero behavior change. |

## Note on logging — `logLevel` is fully retained

To avoid confusion: only the **`RoktUXLogger` implementation class** is internalized. The **log-level public API is unchanged and stays public**:

- `RoktUXLogLevel` (enum) — public, untouched
- `RoktUX.setLogLevel(_:)` — public, untouched
- `RoktUXConfig.Builder.logLevel(_:)` — public, untouched (only the deprecated `enableLogging(_:)` was removed)

Consumers set the log level exactly as before (`RoktUX.setLogLevel(.debug)` / `RoktUXConfig.Builder().logLevel(.debug)`). `RoktUX.setLogLevel` still writes to `RoktUXLogger.shared.logLevel` internally — valid because both are in the same module; the public signature only exposes the public `RoktUXLogLevel`. The consumer SDK's log-level flow (`Rokt.setLogLevel` → `RoktUX.setLogLevel` → `RoktUXConfig.logLevel`, via `toUXLogLevel()`) uses only this public API and **never references `RoktUXLogger`** (0 references, verified).

## Verification

- `xcodebuild -scheme RoktUXHelper build` → **BUILD SUCCEEDED** (0 errors)
- `xcodebuild -scheme RoktUXHelper build-for-testing` → **TEST BUILD SUCCEEDED**
- Cross-checked every removed/demoted external symbol against the consumer SDK (`rokt-sdk-ios` `workstation/transactions`): 0 references each.
- **SDK cross-compile:** resolved `rokt-sdk-ios` `workstation/transactions` against this PR branch (`c45d7f0`) and built `rokt-Example` → **BUILD SUCCEEDED, 0 errors** (compiled the trimmed `RoktUXLogger.swift` / `OuterLayoutSchemaNetworkModel.swift` etc.). Confirms no consumer breakage by real compilation, not just static analysis.

## Findings — flags that were NOT removed (and why)

Two items from the initial audit turned out to be **false positives** from grep (Swift type-inference hides usage). Reporting for the record:

- **Response-model cluster** (`RoktUXPlacementResponse`, `RoktUXS2SExperienceResponse`, `RoktUXPlacement`, `RoktUXSlot`, `RoktUXOffer`, `RoktUXCreative`, `RoktUXResponseOption`, `RoktUXPlacementContext`, `RoktUXPage`, `RoktUXPlacementLayoutCode`): **must stay public.** `RoktUXExperienceResponse` (a `public class` the SDK consumes via `RoktUX.parseExperience`) *inherits from* `RoktUXPlacementResponse`, and the rest form its property/inheritance graph. Swift requires a public class's superclass and exposed member types to be public. Grep showed "0 SDK references" only because the SDK traverses this graph via type inference (`parseResult.pageModel` etc.) without naming the types.
- **`RoktUXCaseIterableDefaultLast`** (protocol): **left public.** It is the default-last `Decodable` mechanism for the public enums `RoktUXSignalType`, `Action`, `RoktUXPlacementLayoutCode` in the response graph above; internalizing it risks those public enums' decoding for no real benefit.
